### PR TITLE
Fix annotation scale sizing for non-paper drawing units

### DIFF
--- a/src/app/update/file.rs
+++ b/src/app/update/file.rs
@@ -1144,13 +1144,16 @@ pub(super) fn on_open_file(&mut self) -> Task<Message> {
                     crate::scene::text::ttf_glyph::clear_fallback_cache();
                 }
                 // Current model-space annotation scale comes from the drawing's
-                // CANNOSCALEVALUE (paper/drawing factor); the multiplier we use
-                // for text/dim sizing is its inverse (1:50 -> 0.02 -> 50.0).
+                // CANNOSCALEVALUE (paper/drawing factor). Convert its inverse into
+                // drawing units as well: metric annotation sizes are paper millimetres
+                // and imperial annotation sizes are paper inches.
                 let cannoscale_value = self.tabs[i].scene.document.header.annotation_scale_value;
+                let unit_factor = self.tabs[i].scene.annotation_scale_unit_factor();
+
                 self.tabs[i].scene.annotation_scale = if cannoscale_value > 1e-9 {
-                    (1.0 / cannoscale_value) as f32
+                    ((1.0 / cannoscale_value) / unit_factor) as f32
                 } else {
-                    1.0
+                    (1.0 / unit_factor) as f32
                 };
 
                 // Open-time breakdown so regressions are visible immediately.

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -872,10 +872,12 @@ pub fn prepare_open_geometry(
     scene.local_center = caches.local_center;
     scene.bg_color = model_bg;
     let cannoscale_value = scene.document.header.annotation_scale_value;
+    let unit_factor = scene.annotation_scale_unit_factor();
+
     scene.annotation_scale = if cannoscale_value > 1e-9 {
-        (1.0 / cannoscale_value) as f32
+        ((1.0 / cannoscale_value) / unit_factor) as f32
     } else {
-        1.0
+        (1.0 / unit_factor) as f32
     };
     scene.current_layout = "Model".to_string();
     let camera = scene.camera.borrow().clone();
@@ -3553,7 +3555,7 @@ impl Scene {
     /// The built-in scale factors are defined assuming model and paper use
     /// the same base unit. A drawing in metres therefore needs an extra
     /// factor of 1000 when its paper side is measured in millimetres.
-    fn annotation_scale_unit_factor(&self) -> f64 {
+    pub(crate) fn annotation_scale_unit_factor(&self) -> f64 {
         let paper_unit = if self.prefers_imperial_scales() == Some(true) {
             1 // Inches
         } else {
@@ -3836,14 +3838,25 @@ impl Scene {
 
     pub fn set_annotation_scale_named(&mut self, name: &str) -> Option<Handle> {
         let handle = self.scale_handle_ensuring(name)?;
-        let ObjectType::Scale(scale) = self.document.objects.get(&handle)? else {
-            return None;
+        let unit_factor = self.annotation_scale_unit_factor();
+
+        let (scale_name, scale_factor, multiplier) = {
+            let ObjectType::Scale(scale) = self.document.objects.get(&handle)? else {
+                return None;
+            };
+
+            (
+                scale.name.clone(),
+                scale.factor(),
+                scale.inverse_factor() / unit_factor,
+            )
         };
-        let multiplier = scale.inverse_factor();
+
         self.annotation_scale = multiplier as f32;
-        self.document.header.current_annotation_scale = scale.name.clone();
-        self.document.header.annotation_scale_value = scale.factor();
+        self.document.header.current_annotation_scale = scale_name;
+        self.document.header.annotation_scale_value = scale_factor;
         self.invalidate_annotation_dependencies();
+
         Some(handle)
     }
 

--- a/src/scene/view/render.rs
+++ b/src/scene/view/render.rs
@@ -3112,7 +3112,7 @@ impl Scene {
                 }
                 let context_scale = match self.document.objects.get(&scale) {
                     Some(acadrust::objects::ObjectType::Scale(value)) => {
-                        value.inverse_factor() as f32
+                        (value.inverse_factor() / self.annotation_scale_unit_factor()) as f32
                     }
                     _ => annotation_scale,
                 };


### PR DESCRIPTION
## Summary

Fix annotation scale sizing when drawing units differ from the paper units used by annotation scales.

Metric annotation scales use millimetres as their paper unit, while imperial scales use inches. Previously, model-space annotation multipliers used only the scale ratio and ignored the drawing unit conversion. This caused annotative dimensions in drawings using metres, for example, to render 1000x too large.

## Changes

- Apply the drawing-to-paper unit factor when restoring the model-space annotation scale.
- Apply the same conversion when changing the current annotation scale.
- Apply the unit conversion to additional annotation-context highlight representations.
- Preserve the corrected scale after saving and reopening the drawing.

## Tested

- Metric drawing with INSUNITS = metres.
- 1:1, 1:50 and 1:100 annotation scales.
- Multiple annotation scales assigned to the same dimension.
- Save, close and reopen without changing the annotation scale.