### PR TITLE
Fix annotative text scaling for drawing units

### DIFF
--- a/src/app/mtext_editor.rs
+++ b/src/app/mtext_editor.rs
@@ -705,7 +705,7 @@ impl super::OpenCADStudio {
         // it keeps the layout's shape, wrapping and alignment identical.
         mt.insertion_point = Vector3::new(0.0, 0.0, 0.0);
         let entity = EntityType::MText(mt.clone());
-        let anno = self.tabs[i].scene.annotation_scale;
+        let anno = 1.0;
         let bg = self.tabs[i].scene.bg_color;
         let wires: Vec<WireModel> = tessellate::tessellate(
             &self.tabs[i].scene.document,

--- a/src/app/update/file.rs
+++ b/src/app/update/file.rs
@@ -1147,6 +1147,10 @@ pub(super) fn on_open_file(&mut self) -> Task<Message> {
                 // CANNOSCALEVALUE (paper/drawing factor). Convert its inverse into
                 // drawing units as well: metric annotation sizes are paper millimetres
                 // and imperial annotation sizes are paper inches.
+                // Current model-space annotation scale comes from the drawing's
+                // CANNOSCALEVALUE (paper/drawing factor). Convert its paper unit into
+                // the drawing's INSUNITS as well, so e.g. a metre drawing uses
+                // 0.001 model units for 1 mm of paper at 1:1.
                 let cannoscale_value = self.tabs[i].scene.document.header.annotation_scale_value;
                 let unit_factor = self.tabs[i].scene.annotation_scale_unit_factor();
 

--- a/src/scene/annotative.rs
+++ b/src/scene/annotative.rs
@@ -670,7 +670,19 @@ pub fn effective_annotation_scale_for(
     if !context_annotative && (text_like || !style_annotative) {
         return 1.0;
     }
-
+    // Annotative TEXT/MTEXT store their paper text height as the base value.
+    // `fallback` is the absolute paper-to-model multiplier for the active
+    // annotation scale and already includes the drawing's INSUNITS conversion.
+    //
+    // Example for a metre drawing with 2 mm paper text:
+    //   1:1   -> 2 * 0.001 = 0.002 m
+    //   1:100 -> 2 * 0.100 = 0.200 m
+    //
+    // Using active/native here would only produce 1 / 100 and would lose the
+    // millimetre-to-metre conversion entirely.
+    if matches!(entity, EntityType::Text(_) | EntityType::MText(_)) {
+        return fallback;
+    }
     if matches!(
         entity,
         EntityType::Dimension(_)


### PR DESCRIPTION
## Summary

Fix annotative TEXT and MTEXT scaling in drawings whose model units differ from paper units.

- Respect INSUNITS when restoring the annotation scale on file open.
- Use the absolute annotation multiplier for annotative TEXT and MTEXT.
- Fix metric drawings in metres so paper text heights remain correct at scales such as 1:1, 1:50 and 1:100.
- Keep the MTEXT editor preview independent from drawing annotation scaling.

## Example

For a drawing in metres with a 2 mm annotative text height:

- 1:1 renders at 0.002 m in model space.
- 1:100 renders at 0.200 m in model space.
- Both display at the intended 2 mm paper height through the corresponding viewport.