### PR TITLE
fix(plot): open properties for the selected printer on Windows

### DIFF
--- a/src/io/print_to_printer.rs
+++ b/src/io/print_to_printer.rs
@@ -91,39 +91,64 @@ pub fn list_printers() -> Vec<String> {
     }
 }
 
+/// The command that opens the OS printer configuration surface, for the named
+/// printer when one is selected and the printer list otherwise.
+///
+/// Split out from [`open_printer_properties`] so the argument construction can
+/// be asserted without spawning anything.
+#[cfg(not(target_arch = "wasm32"))]
+fn printer_properties_command(printer: Option<&str>) -> (&'static str, Vec<String>) {
+    let named = printer
+        .map(str::trim)
+        .filter(|name| !name.is_empty());
+
+    // printui.dll opens the driver's own Properties dialog for one printer,
+    // which is where print quality lives on Windows — `dispatch_to_printer_opts`
+    // prints through ShellExecute's "printto" verb, which carries no quality of
+    // its own. Without a selection there is nothing to open but the list.
+    #[cfg(target_os = "windows")]
+    let command = match named {
+        Some(name) => (
+            "rundll32.exe",
+            vec![
+                "printui.dll,PrintUIEntry".to_string(),
+                "/p".to_string(),
+                "/n".to_string(),
+                name.to_string(),
+            ],
+        ),
+        None => ("control.exe", vec!["printers".to_string()]),
+    };
+
+    #[cfg(target_os = "macos")]
+    let command = {
+        let _ = named;
+        (
+            "open",
+            vec!["x-apple.systempreferences:com.apple.Print-Scan-Settings.extension".to_string()],
+        )
+    };
+
+    #[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
+    let command = {
+        let target = named
+            .map(|name| format!("http://localhost:631/printers/{name}"))
+            .unwrap_or_else(|| "http://localhost:631/printers".to_string());
+        ("xdg-open", vec![target])
+    };
+
+    command
+}
+
 /// Open the operating system's printer configuration surface.
 #[cfg(not(target_arch = "wasm32"))]
 pub fn open_printer_properties(printer: Option<&str>) -> Result<(), String> {
-    #[cfg(target_os = "windows")]
-    {
-        let mut command = std::process::Command::new("control.exe");
-        command.arg("printers");
-        return command
-            .spawn()
-            .map(|_| ())
-            .map_err(|error| format!("Could not open printer properties: {error}"));
-    }
-    #[cfg(target_os = "macos")]
-    {
-        let mut command = std::process::Command::new("open");
-        command.arg("x-apple.systempreferences:com.apple.Print-Scan-Settings.extension");
-        return command
-            .spawn()
-            .map(|_| ())
-            .map_err(|error| format!("Could not open printer properties: {error}"));
-    }
-    #[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
-    {
-        let target = printer
-            .filter(|name| !name.is_empty())
-            .map(|name| format!("http://localhost:631/printers/{name}"))
-            .unwrap_or_else(|| "http://localhost:631/printers".to_string());
-        std::process::Command::new("xdg-open")
-            .arg(target)
-            .spawn()
-            .map(|_| ())
-            .map_err(|error| format!("Could not open printer properties: {error}"))
-    }
+    let (program, args) = printer_properties_command(printer);
+    std::process::Command::new(program)
+        .args(args)
+        .spawn()
+        .map(|_| ())
+        .map_err(|error| format!("Could not open printer properties: {error}"))
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -308,5 +333,37 @@ fn dispatch_to_printer_opts(
                 String::from_utf8_lossy(&out.stderr)
             ))
         }
+    }
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod printer_properties_tests {
+    use super::printer_properties_command;
+
+    #[test]
+    fn a_selected_printer_is_named_in_the_command() {
+        let (program, args) = printer_properties_command(Some("Office LaserJet"));
+        assert!(
+            args.iter().any(|arg| arg == "Office LaserJet"),
+            "{program} {args:?} must target the selected printer",
+        );
+    }
+
+    #[test]
+    fn no_selection_falls_back_to_the_printer_list() {
+        let (_, args) = printer_properties_command(None);
+        assert!(
+            !args.iter().any(|arg| arg.contains("Office LaserJet")),
+            "there is no printer to name",
+        );
+    }
+
+    #[test]
+    fn a_blank_selection_is_treated_as_no_selection() {
+        // The plot dialog stores Some("") before the user picks anything.
+        assert_eq!(
+            printer_properties_command(Some("   ")),
+            printer_properties_command(None),
+        );
     }
 }


### PR DESCRIPTION
## Summary
- open the selected printer's own Properties dialog on Windows instead of the generic printer list
- keep the list as the fallback when nothing is selected
- split the argument construction out so it can be asserted without spawning

The plot dialog passes the chosen printer to `open_printer_properties`, and the Windows arm ignored it and ran `control.exe printers`. Picking a printer and then pressing Properties gave you the list to find it in again. `rundll32 printui.dll,PrintUIEntry /p /n <name>` opens that printer's driver dialog directly. macOS and CUPS behaviour is unchanged — CUPS already used the name.

This matters a little more than a stray argument: on Windows that dialog is where print quality lives. `dispatch_to_printer_opts` prints through ShellExecute's `printto` verb, which carries no quality of its own, while the CUPS arm maps `PrintOptions.quality` to `lp -o print-quality`. So Properties is the only route to it there.

Also clears the `unused variable: printer` warning from #773. I left the other three in that issue alone — `quality` is read on the CUPS path so it is only unused per-platform, and whether `curve_snap` / `line_circle` are obsolete or planned is your call, not something I should guess at.

## Testing
- `cargo test printer_properties --lib` (3 new cases: a selected printer is named, no selection falls back to the list, a blank selection is treated as no selection)
- `cargo test --lib` (389 passed; `automation::tests::save_then_open_round_trips` also fails on a clean 32c3844)
- `cargo clippy --lib` — no warnings for this file

Only the Windows arm compiles here, so that is the branch the new cases actually exercise.
