### PR TITLE
Show closed ellipse end angle as 360 degrees

### DIFF
--- a/src/entities/ellipse.rs
+++ b/src/entities/ellipse.rs
@@ -114,7 +114,11 @@ fn properties(ell: &Ellipse) -> Vec<PropSection> {
     let minor_vec = v * r_minor;
 
     let start_angle = ell.start_parameter.to_degrees().rem_euclid(360.0);
-    let end_angle = ell.end_parameter.to_degrees().rem_euclid(360.0);
+    let end_angle = if ell.is_full() {
+        360.0
+    } else {
+        ell.end_parameter.to_degrees().rem_euclid(360.0)
+    };
 
     let props = ell.mass_props();
 

--- a/src/entities/ellipse.rs
+++ b/src/entities/ellipse.rs
@@ -149,9 +149,6 @@ fn properties(ell: &Ellipse) -> Vec<PropSection> {
             ro(t!("Start parameter").as_ref(), "start_param", format!("{:.4}", ell.start_parameter)),
             ro(t!("End parameter").as_ref(), "end_param", format!("{:.4}", ell.end_parameter)),
             ro(t!("Length").as_ref(), "length", format!("{:.4}", props.perimeter)),
-            ro(t!("Normal X").as_ref(), "normal_x", format!("{:.4}", ell.normal.x)),
-            ro(t!("Normal Y").as_ref(), "normal_y", format!("{:.4}", ell.normal.y)),
-            ro(t!("Normal Z").as_ref(), "normal_z", format!("{:.4}", ell.normal.z)),
         ],
     }]
 }

--- a/src/entities/hatch.rs
+++ b/src/entities/hatch.rs
@@ -487,14 +487,6 @@ fn properties(h: &Hatch) -> Vec<PropSection> {
             .map(|l| l.offset.length())
             .unwrap_or_default(),
     );
-    // Pattern tiling origin: the base point the pattern lines are anchored to.
-    let (origin_x, origin_y) = h
-        .pattern
-        .lines
-        .first()
-        .map(|l| (l.base_point.x, l.base_point.y))
-        .unwrap_or((0.0, 0.0));
-
     let mut sections = vec![
         PropSection {
             title: t!("Pattern").into_owned(),
@@ -504,8 +496,8 @@ fn properties(h: &Hatch) -> Vec<PropSection> {
                 ro(t!("Annotative").as_ref(), "annotative", String::new()),
                 edit_angle(t!("Angle").as_ref(), "pattern_angle", h.pattern_angle.to_degrees()),
                 edit(t!("Scale").as_ref(), "pattern_scale", h.pattern_scale),
-                edit(t!("Origin X").as_ref(), "origin_x", origin_x),
-                edit(t!("Origin Y").as_ref(), "origin_y", origin_y),
+                ro(t!("Origin X").as_ref(), "origin_x", "0.0000"),
+                ro(t!("Origin Y").as_ref(), "origin_y", "0.0000"),
                 spacing_row,
                 ro(t!("ISO pen width").as_ref(), "iso_pen_width", String::new()),
                 double_row,

--- a/src/entities/lwpolyline.rs
+++ b/src/entities/lwpolyline.rs
@@ -597,6 +597,35 @@ fn grips(pline: &LwPolyline) -> Vec<GripDef> {
     out
 }
 
+fn is_rectangle(pline: &LwPolyline) -> bool {
+    if !pline.is_closed
+        || pline.vertices.len() != 4
+        || pline.vertices.iter().any(|vertex| vertex.bulge.abs() > 1e-9)
+    {
+        return false;
+    }
+
+    let edges: Vec<[f64; 2]> = (0..4)
+        .map(|index| {
+            let from = pline.vertices[index].location;
+            let to = pline.vertices[(index + 1) % 4].location;
+            [to.x - from.x, to.y - from.y]
+        })
+        .collect();
+    let length = |edge: [f64; 2]| edge[0].hypot(edge[1]);
+    let dot = |a: [f64; 2], b: [f64; 2]| a[0] * b[0] + a[1] * b[1];
+    let cross = |a: [f64; 2], b: [f64; 2]| a[0] * b[1] - a[1] * b[0];
+    let lengths: Vec<f64> = edges.iter().copied().map(length).collect();
+    if lengths.iter().any(|&value| value <= 1e-12) {
+        return false;
+    }
+
+    let tolerance = 1e-9;
+    dot(edges[0], edges[1]).abs() <= tolerance * lengths[0] * lengths[1]
+        && cross(edges[0], edges[2]).abs() <= tolerance * lengths[0] * lengths[2]
+        && cross(edges[1], edges[3]).abs() <= tolerance * lengths[1] * lengths[3]
+}
+
 fn properties(pline: &LwPolyline) -> Vec<PropSection> {
     let n = pline.vertices.len();
     // The panel's Current Vertex focus, clamped to this polyline's range.
@@ -616,20 +645,25 @@ fn properties(pline: &LwPolyline) -> Vec<PropSection> {
     } else {
         format!("{} / {}", vi + 1, n)
     };
+    let mut geometry_props = vec![
+        stepper(t!("Current Vertex").as_ref(), "current_vertex", vertex_label),
+        edit(t!("Vertex X").as_ref(), "vertex_x", vx),
+        edit(t!("Vertex Y").as_ref(), "vertex_y", vy),
+    ];
+    if !is_rectangle(pline) {
+        geometry_props.push(edit(t!("Start segment width").as_ref(), "start_width", start_w));
+        geometry_props.push(edit(t!("End segment width").as_ref(), "end_width", end_w));
+    }
+    geometry_props.extend([
+        edit(t!("Global width").as_ref(), "global_width", pline.constant_width),
+        edit(t!("Elevation").as_ref(), "elevation", pline.elevation),
+        ro(t!("Area").as_ref(), "area", format!("{:.4}", mp.area)),
+        ro(t!("Length").as_ref(), "length", format!("{:.4}", mp.perimeter)),
+    ]);
     vec![
         PropSection {
             title: t!("Geometry").into_owned(),
-            props: vec![
-                stepper(t!("Current Vertex").as_ref(), "current_vertex", vertex_label),
-                edit(t!("Vertex X").as_ref(), "vertex_x", vx),
-                edit(t!("Vertex Y").as_ref(), "vertex_y", vy),
-                edit(t!("Start segment width").as_ref(), "start_width", start_w),
-                edit(t!("End segment width").as_ref(), "end_width", end_w),
-                edit(t!("Global width").as_ref(), "global_width", pline.constant_width),
-                edit(t!("Elevation").as_ref(), "elevation", pline.elevation),
-                ro(t!("Area").as_ref(), "area", format!("{:.4}", mp.area)),
-                ro(t!("Length").as_ref(), "length", format!("{:.4}", mp.perimeter)),
-            ],
+            props: geometry_props,
         },
         PropSection {
             title: t!("Misc").into_owned(),


### PR DESCRIPTION
1) Full ellipse end angle: Show 360 degrees in Properties instead of wrapping the value to zero.

2) Hatch pattern coordinates: Show the pattern Origin X and Origin Y fields as read-only zero values in Properties. The underlying pattern geometry and stored file data remain unchanged.

3) Ellipse normal fields: Remove the read-only Normal X, Normal Y, and Normal Z rows from Properties. The normal vector remains available in the entity model for geometry and file operations.

4) Rectangle properties: Hide Start segment width and End segment width for closed four-edge rectangular lightweight polylines. Rectangle detection is rotation-independent; other polylines retain both editable width fields.

Stored analytic geometry and file data remain unchanged.
