### PR TITLE
fix(plugin): skip non-V4 plugins in broadcast_notification

### DIFF
--- a/crates/ocs_plugin_api/src/process.rs
+++ b/crates/ocs_plugin_api/src/process.rs
@@ -675,6 +675,11 @@ impl PluginProcess {
         }
     }
 
+    /// Whether this plugin process speaks the V4 protocol.
+    pub fn is_v4(&self) -> bool {
+        self.v4.is_some()
+    }
+
     /// Send a best-effort host-to-plugin notification. Requires V4; on V3
     /// processes this returns an error.
     pub fn notify_plugin(

--- a/crates/ocs_plugin_api/src/process/manager.rs
+++ b/crates/ocs_plugin_api/src/process/manager.rs
@@ -91,6 +91,15 @@ impl PluginManager {
             if !p.process.is_alive() {
                 continue;
             }
+            if !p.process.is_v4() {
+                if crate::process::verbose() {
+                    eprintln!(
+                        "[plugin] skipping notification for {} (not V4)",
+                        p.process.id()
+                    );
+                }
+                continue;
+            }
             if let Err(e) = p.process.notify_plugin(command_id, notification.clone()) {
                 eprintln!(
                     "[plugin] broadcast_notification failed for {}: {e}",


### PR DESCRIPTION
PluginManager::broadcast_notification was fanning out host notifications to every loaded plugin. Only V4 plugin processes can receive host->plugin notifications; V2/V3 plugins correctly rejected them with notify_plugin requires V4 protocol.

Add PluginProcess::is_v4() and skip non-V4 plugins in broadcast_notification so V4 document snapshot notifications only go to V4-capable plugins. Fixes repeated console errors for Example, Land Survey and V2 Compat.