### PR TITLE
fix(mtext): stop Up/Down walking command history under the editor

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1970,9 +1970,9 @@ pub enum Message {
     },
     /// A widget captured Up/Down; resolve it only if the command input owns
     /// keyboard focus.
-    CommandLineArrowProbe { direction: ArrowKey },
+    CommandLineArrowProbe { direction: ArrowKey, extend_selection: bool },
     /// Result of the command-input focus query for a captured Up/Down key.
-    CommandLineArrowResolved { direction: ArrowKey, focused: bool },
+    CommandLineArrowResolved { direction: ArrowKey, focused: bool, extend_selection: bool },
     /// Toggle the dropdown listing the full command-line history.
     CommandHistoryToggle,
     /// Grab/move/release the expanded history panel's top resize edge.

--- a/src/app/update/mod.rs
+++ b/src/app/update/mod.rs
@@ -1559,17 +1559,39 @@ impl OpenCADStudio {
                 ))
             }
 
-            Message::CommandLineArrowProbe { direction } => {
+            Message::CommandLineArrowProbe {
+                direction,
+                extend_selection,
+            } => {
                 iced::widget::operation::is_focused(iced::widget::Id::new(
                     crate::ui::command_line::CMD_INPUT_ID,
                 ))
                 .map(move |focused| Message::CommandLineArrowResolved {
                     direction,
                     focused,
+                    extend_selection,
                 })
             }
 
-            Message::CommandLineArrowResolved { direction, focused } => {
+            Message::CommandLineArrowResolved {
+                direction,
+                focused,
+                extend_selection,
+            } => {
+                // The MText editor paints its own caret and is not a focusable
+                // widget, so the command input keeps widget focus behind the
+                // dialog and captures Up / Down itself. Walking command history
+                // from under an open editor is never what the key meant: while the
+                // editor is up the arrow belongs to its caret, exactly as it does
+                // on the ArrowKeyPressed path.
+                if self.mtext_editor.is_some() {
+                    match direction {
+                        ArrowKey::Up => self.mtext_caret_move_vertical(1, extend_selection),
+                        ArrowKey::Down => self.mtext_caret_move_vertical(-1, extend_selection),
+                        ArrowKey::Left | ArrowKey::Right => {}
+                    }
+                    return Task::none();
+                }
                 if !focused {
                     return Task::none();
                 }

--- a/src/app/view/mod.rs
+++ b/src/app/view/mod.rs
@@ -2241,6 +2241,7 @@ impl OpenCADStudio {
                         {
                             return Some(Message::CommandLineArrowProbe {
                                 direction: arrow?,
+                                extend_selection: modifiers.shift(),
                             });
                         }
                         // A focused web text field needs the browser clipboard;


### PR DESCRIPTION
Fixes #655.

## Problem

Arrow keys reach the app on two paths, decided by whether a widget consumed the event:

- `Status::Ignored` → `ArrowKeyPressed`, which already checks `self.mtext_editor.is_some()` and moves the editor caret.
- `Status::Captured` → `CommandLineArrowProbe` → `CommandLineArrowResolved`, which only asked whether `CMD_INPUT_ID` was focused and then ran `CommandHistoryPrev` / `CommandHistoryNext`.

The MText editor paints its own caret and is not a focusable widget, so the command input keeps widget focus behind the dialog and captures Up / Down itself. That sends the key down the second path, where nothing knew an editor was open — so pressing Up or Down while typing MText stepped through command history in the main window instead of moving the caret.

## Change

`CommandLineArrowResolved` now applies the same rule `ArrowKeyPressed` already does: while the editor is open the arrow belongs to its caret, and history is not touched. `CommandLineArrowProbe` carries the shift state so a held Shift still extends the selection on this path rather than silently collapsing it.

Nothing changes when no editor is open: the focus check and the history bindings are untouched.

## Test plan

- Ran: `cargo test --lib` — 416 passed, 0 failed.
- Ran: `cargo build` — clean.
- Checked: `ArrowKeyPressed` (`src/app/update/mod.rs`) is the existing statement of this rule; the two paths now agree instead of only one of them knowing about the editor.