### PR TITLE
fix(point): keep DDPTYPE off dimension definition points

### DIFF
--- a/src/entities/point.rs
+++ b/src/entities/point.rs
@@ -82,7 +82,7 @@ pub fn relative_render(
         return None;
     };
     let pdsize = document.header.point_display_size;
-    let pdmode = document.header.point_display_mode;
+    let pdmode = effective_pdmode(pt, document.header.point_display_mode);
     if pdsize > 0.0 || pdmode == 0 {
         return None;
     }
@@ -173,8 +173,26 @@ fn point_glyph(cx: f64, cy: f64, z: f64, pdmode: i16, s_half: f64) -> Vec<[f64; 
     pts
 }
 
+/// Layer AutoCAD writes dimension definition points to.
+const DEFPOINTS_LAYER: &str = "DEFPOINTS";
+
+/// PDMODE as it applies to `pt`.
+///
+/// Definition points are ordinary POINT entities on the Defpoints layer, but
+/// they are a dimension's bookkeeping rather than draughting the user placed.
+/// Letting DDPTYPE stamp its glyph on them buries a drawing imported from other
+/// software under crosses and circles at every dimension end, so they stay the
+/// pixel-sized dot whatever the header says. (#378, #790)
+fn effective_pdmode(pt: &Point, pdmode: i16) -> i16 {
+    if pt.common.layer.eq_ignore_ascii_case(DEFPOINTS_LAYER) {
+        0
+    } else {
+        pdmode
+    }
+}
+
 fn to_render(pt: &Point, document: &acadrust::CadDocument) -> RenderEntity {
-    let pdmode = document.header.point_display_mode;
+    let pdmode = effective_pdmode(pt, document.header.point_display_mode);
     let s = pdsize_world(document.header.point_display_size) * 0.5;
     point_render(pt, pdmode, s)
 }
@@ -240,3 +258,60 @@ impl RenderConvertible for Point {
 }
 
 crate::impl_entity_basics!(Point);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn point_on(layer: &str) -> Point {
+        let mut pt = Point::default();
+        pt.common.layer = layer.to_string();
+        pt.location = acadrust::types::Vector3::new(1.0, 2.0, 0.0);
+        pt
+    }
+
+    /// #378 / #790: DDPTYPE must not reach a dimension's definition points.
+    #[test]
+    fn definition_points_ignore_the_point_style() {
+        let mut doc = acadrust::CadDocument::new();
+        // Circle-enclosed cross: the style that made imported drawings unreadable.
+        doc.header.point_display_mode = 34;
+        doc.header.point_display_size = 2.0;
+
+        let drawn = to_render(&point_on("0"), &doc);
+        assert!(
+            matches!(drawn.object, RenderObject::Lines(ref pts) if !pts.is_empty()),
+            "a point the user placed still follows PDMODE"
+        );
+
+        for layer in ["Defpoints", "DEFPOINTS", "defpoints"] {
+            let defpoint = to_render(&point_on(layer), &doc);
+            assert!(
+                matches!(defpoint.object, RenderObject::Dot(_)),
+                "a definition point on {layer} must stay a dot"
+            );
+        }
+    }
+
+    /// The relative-PDSIZE path hands the glyph a viewport size; it must make
+    /// the same call, or a definition point would come back as a sized cross.
+    #[test]
+    fn definition_points_ignore_the_point_style_at_relative_pdsize() {
+        let mut doc = acadrust::CadDocument::new();
+        doc.header.point_display_mode = 34;
+        doc.header.point_display_size = -5.0;
+
+        let drawn = relative_render(&EntityType::Point(point_on("0")), &doc, Some(0.01));
+        assert!(drawn.is_some(), "a user point still takes the viewport-aware path");
+
+        let defpoint = relative_render(
+            &EntityType::Point(point_on("Defpoints")),
+            &doc,
+            Some(0.01),
+        );
+        assert!(
+            defpoint.is_none(),
+            "a definition point falls through to the dot instead of a sized glyph"
+        );
+    }
+}


### PR DESCRIPTION
Fixes #790, the return of #378.

## Problem

A dimension's definition points arrive from a DWG as ordinary `POINT` entities on the `Defpoints` layer. `entities::point::to_render` reads `header.point_display_mode` for every point, so DDPTYPE applied to them too: opening a drawing authored in other software with a point style set stamps that glyph on every dimension end, and the drawing fills with crosses and circles that the user never placed.

`tessellate.rs` already names this failure in the `PDMODE == 0` branch — "otherwise the dimension def-points on the Defpoints layer litter the view with crosses" (#139) — but that only holds while the point style *is* 0. Any other DDPTYPE value goes down the glyph path and the litter comes back, which is what #790 reports.

## Change

Resolve PDMODE to 0 for points on `Defpoints` (matched case-insensitively, since DWG writers vary on the spelling) and leave them the single pixel-sized dot.

Both render paths go through the one resolution:

- `to_render`, the header-driven path.
- `relative_render`, the viewport-aware path for a relative PDSIZE — which now returns `None` for a definition point and lets it fall through to the dot, instead of handing the glyph builder a viewport size.

Points the user placed are untouched on both paths.

## Test plan

- Ran: `cargo test --lib entities::point` — 2 passed, 0 failed (both new).
- Ran: `cargo test --lib` — 418 passed, 0 failed, 1 ignored.
- The tests set PDMODE 34 (circle-enclosed cross, the style in the report) and assert a point on layer `0` still renders its glyph while `Defpoints` / `DEFPOINTS` / `defpoints` all stay a `Dot`, on both the absolute and relative PDSIZE paths.