### PR TITLE
Remember the last polygon side count

### DIFF
--- a/src/modules/draw/defaults.rs
+++ b/src/modules/draw/defaults.rs
@@ -19,6 +19,7 @@ thread_local! {
     static ARRAY_P_COUNT:   Cell<f64> = Cell::new(6.0);
     static ARRAY_P_ANGLE:   Cell<f64> = Cell::new(360.0); // degrees
     static ARRAY_PATH_COUNT: Cell<f64> = Cell::new(6.0);
+    static POLYGON_SIDES:   Cell<f64> = Cell::new(6.0);
 }
 
 macro_rules! accessors {
@@ -47,3 +48,4 @@ accessors!(get_array_col_sp, set_array_col_sp, ARRAY_COL_SP);
 accessors!(get_array_p_count, set_array_p_count, ARRAY_P_COUNT);
 accessors!(get_array_p_angle, set_array_p_angle, ARRAY_P_ANGLE);
 accessors!(get_array_path_count, set_array_path_count, ARRAY_PATH_COUNT);
+accessors!(get_polygon_sides, set_polygon_sides, POLYGON_SIDES);

--- a/src/modules/draw/draw/shapes.rs
+++ b/src/modules/draw/draw/shapes.rs
@@ -16,6 +16,7 @@ use acadrust::{EntityType, LwPolyline};
 use crate::t;
 
 use crate::command::{CadCommand, CmdResult, WorkingPlane};
+use crate::modules::draw::defaults;
 use crate::modules::IconKind;
 use crate::scene::model::wire_model::WireModel;
 use glam::DVec3;
@@ -470,7 +471,7 @@ pub struct PolyCommand {
 impl PolyCommand {
     pub fn new() -> Self {
         Self {
-            sides: 6,
+            sides: defaults::get_polygon_sides() as u32,
             step: 0,
             center: DVec3::ZERO,
             plane: WorkingPlane::default(),
@@ -544,6 +545,7 @@ impl CadCommand for PolyCommand {
         if let Ok(n) = text.trim().parse::<u32>() {
             if (3..=1024).contains(&n) {
                 self.sides = n;
+                defaults::set_polygon_sides(n as f64);
             }
         }
         self.step = 1;
@@ -619,7 +621,7 @@ pub struct PolyCCommand {
 impl PolyCCommand {
     pub fn new() -> Self {
         Self {
-            sides: 6,
+            sides: defaults::get_polygon_sides() as u32,
             step: 0,
             center: DVec3::ZERO,
             plane: WorkingPlane::default(),
@@ -652,6 +654,7 @@ impl CadCommand for PolyCCommand {
         if let Ok(n) = text.trim().parse::<u32>() {
             if (3..=1024).contains(&n) {
                 self.sides = n;
+                defaults::set_polygon_sides(n as f64);
             }
         }
         self.step = 1;
@@ -751,7 +754,7 @@ pub struct PolyECommand {
 impl PolyECommand {
     pub fn new() -> Self {
         Self {
-            sides: 6,
+            sides: defaults::get_polygon_sides() as u32,
             step: 0,
             a: DVec3::ZERO,
             plane: WorkingPlane::default(),
@@ -784,6 +787,7 @@ impl CadCommand for PolyECommand {
         if let Ok(n) = text.trim().parse::<u32>() {
             if (3..=1024).contains(&n) {
                 self.sides = n;
+                defaults::set_polygon_sides(n as f64);
             }
         }
         self.step = 1;


### PR DESCRIPTION
1) Store the last valid polygon side count in the shared session command defaults and reuse it across inscribed, circumscribed, and edge creation methods.

Verification:
- cargo check --locked