### PR TITLE
Complete 2D solid workflow and editing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,7 @@ checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
 [[package]]
 name = "acadrust"
 version = "0.4.1"
-source = "git+https://github.com/HakanSeven12/cadcodec.git?rev=0908da7#0908da7b6e4f702a6c78359a57f53e2b79cf39eb"
+source = "git+https://github.com/HakanSeven12/cadcodec.git?rev=8a92803#8a9280381d75a52ac5a35663449bdd44827e1463"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
@@ -878,7 +878,7 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 [[package]]
 name = "cadkernel"
 version = "0.1.0"
-source = "git+https://github.com/HakanSeven12/cadkernel.git?rev=ebeb2ec#ebeb2ecc2d17d92c588b0fa8bbe3864b156bc71f"
+source = "git+https://github.com/HakanSeven12/cadkernel.git?rev=b1901dd#b1901dde3351fc4bbcdffbdcf7328a5dec4d28d3"
 dependencies = [
  "acadrust",
  "cavalier_contours",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ glam = { version = "0.33", features = ["bytemuck"] }
 rfd = "0.17"
 clap = { version = "4", features = ["derive"] }
 env_logger = "0.11"
-acadrust = { git = "https://github.com/HakanSeven12/cadcodec.git", rev = "0908da7", features = ["serde"] }
-cadkernel = { git = "https://github.com/HakanSeven12/cadkernel.git", rev = "ebeb2ec", features = ["acis", "offset"] }
+acadrust = { git = "https://github.com/HakanSeven12/cadcodec.git", rev = "8a92803", features = ["serde"] }
+cadkernel = { git = "https://github.com/HakanSeven12/cadkernel.git", rev = "b1901dd", features = ["acis", "offset"] }
 dwg-thumbnailer = { path = "crates/dwg-thumbnailer" }
 flate2 = "1"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "bmp", "tiff"] }

--- a/crates/ocs_plugin_api/Cargo.toml
+++ b/crates/ocs_plugin_api/Cargo.toml
@@ -14,7 +14,7 @@ serde = { version = "1", features = ["derive"] }
 # Pulled in only by the `host` feature, which adds the `acadrust`-typed
 # `HostApi` runtime surface. The default crate stays dependency-free so engine
 # crates and external tooling can depend on the manifest/ribbon contract cheaply.
-acadrust = { git = "https://github.com/HakanSeven12/cadcodec.git", rev = "0908da7", optional = true, features = ["serde"] }
+acadrust = { git = "https://github.com/HakanSeven12/cadcodec.git", rev = "8a92803", optional = true, features = ["serde"] }
 
 # Runtime IPC and serialization (host feature only).
 interprocess = { version = "2", optional = true }
@@ -37,7 +37,7 @@ serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 cargo-lock = "11"
 # acadrust is scanned at build time to generate the embedded type registry.
-acadrust = { git = "https://github.com/HakanSeven12/cadcodec.git", rev = "0908da7", features = ["serde"] }
+acadrust = { git = "https://github.com/HakanSeven12/cadcodec.git", rev = "8a92803", features = ["serde"] }
 
 [dev-dependencies]
 serde_json = "1"

--- a/crates/ocs_web_worker/Cargo.toml
+++ b/crates/ocs_web_worker/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-acadrust = { git = "https://github.com/HakanSeven12/cadcodec.git", rev = "0908da7", features = ["serde"] }
+acadrust = { git = "https://github.com/HakanSeven12/cadcodec.git", rev = "8a92803", features = ["serde"] }
 bincode = "1.3"
 serde = { version = "1", features = ["derive"] }
 console_error_panic_hook = "0.1"

--- a/src/entities/solid.rs
+++ b/src/entities/solid.rs
@@ -1,28 +1,35 @@
 // SOLID entity — 2D filled quadrilateral (or triangle when p3 == p4).
 //
 // Wireframe: the 4 perimeter edges as RenderObject::Lines.
-// Filled:    two triangles on `fill_tris`, preserving the entity's full WCS
-//            plane both at top level and through block expansion. The scene
-//            keeps a separate 2-D HatchModel only for plot projection; screen
-//            rendering filters that flattened copy out.
+// Filled:    boundary triangles on `fill_tris`, plus the top and side faces for
+//            non-zero thickness. The full WCS plane is preserved both at top
+//            level and through block expansion. The scene keeps a separate 2-D
+//            HatchModel only for plot projection; screen rendering filters that
+//            flattened copy out.
 // Grips:     4 corner grip points.
 
 use acadrust::entities::Solid;
 use crate::t;
 
 use crate::command::EntityTransform;
-use crate::entities::common::{edit_prop as edit, ro_prop as ro, square_grip};
+use crate::entities::common::{edit_prop as edit, square_grip};
 use crate::entities::traits::{Grippable, PropertyEditable, Transformable, RenderConvertible};
 use crate::scene::convert::acad_to_render::{RenderEntity, RenderObject};
 use crate::scene::model::object::{GripApply, GripDef, PropSection};
 use crate::scene::model::wire_model::SnapHint;
 
-fn dvec3(v: &acadrust::types::Vector3) -> glam::DVec3 {
-    glam::DVec3::new(v.x, v.y, v.z)
+fn normal_tuple(solid: &Solid) -> (f64, f64, f64) {
+    let normal = glam::DVec3::new(solid.normal.x, solid.normal.y, solid.normal.z)
+        .normalize_or(glam::DVec3::Z);
+    (normal.x, normal.y, normal.z)
+}
+
+fn dvec3(v: [f64; 3]) -> glam::DVec3 {
+    glam::DVec3::from_array(v)
 }
 
 pub(crate) fn wcs_corners(solid: &Solid) -> [[f64; 3]; 4] {
-    let n = (solid.normal.x, solid.normal.y, solid.normal.z);
+    let n = normal_tuple(solid);
     let w = |v: &acadrust::types::Vector3| {
         let (x, y, z) = crate::scene::view::transform::ocs_point_to_wcs((v.x, v.y, v.z), n);
         [x, y, z]
@@ -35,81 +42,108 @@ pub(crate) fn wcs_corners(solid: &Solid) -> [[f64; 3]; 4] {
     ]
 }
 
-/// Return a non-self-intersecting perimeter for either conventional DXF SOLID
-/// Z-order or older/perimeter-ordered data. Prefer DXF order when both are
-/// valid, but recover legacy solids whose 1-2-4-3 walk forms a bow-tie.
-pub(crate) fn perimeter_indices(corners: &[[f64; 3]; 4]) -> [usize; 4] {
-    let p = |index: usize| glam::DVec3::from_array(corners[index]);
-    let edge = p(1) - p(0);
-    let mut normal = edge.cross(p(2) - p(0));
-    if normal.length_squared() < 1.0e-20 {
-        normal = edge.cross(p(3) - p(0));
-    }
-    if normal.length_squared() < 1.0e-20 {
-        return [0, 1, 3, 2];
-    }
-    let orient = |a: usize, b: usize, c: usize| {
-        (p(b) - p(a)).cross(p(c) - p(a)).dot(normal)
+fn set_wcs_corner(solid: &mut Solid, index: usize, point: glam::DVec3) {
+    let n = normal_tuple(solid);
+    let (x, y, z) = crate::scene::view::transform::wcs_point_to_ocs(
+        (point.x, point.y, point.z),
+        n,
+    );
+    let corner = match index {
+        0 => &mut solid.first_corner,
+        1 => &mut solid.second_corner,
+        2 => &mut solid.third_corner,
+        3 => &mut solid.fourth_corner,
+        _ => return,
     };
-    let segments_cross = |a: usize, b: usize, c: usize, d: usize| {
-        let ab_c = orient(a, b, c);
-        let ab_d = orient(a, b, d);
-        let cd_a = orient(c, d, a);
-        let cd_b = orient(c, d, b);
-        ((ab_c > 0.0 && ab_d < 0.0) || (ab_c < 0.0 && ab_d > 0.0))
-            && ((cd_a > 0.0 && cd_b < 0.0) || (cd_a < 0.0 && cd_b > 0.0))
-    };
-    let order_crosses = |order: [usize; 4]| {
-        segments_cross(order[0], order[1], order[2], order[3])
-            || segments_cross(order[1], order[2], order[3], order[0])
-    };
-    let dxf = [0, 1, 3, 2];
-    let perimeter = [0, 1, 2, 3];
-    if order_crosses(dxf) && !order_crosses(perimeter) {
-        perimeter
-    } else {
-        dxf
+    corner.x = x;
+    corner.y = y;
+    corner.z = z;
+}
+
+fn push_edge(lines: &mut Vec<[f64; 3]>, start: [f64; 3], end: [f64; 3]) {
+    lines.extend([start, end, [f64::NAN; 3]]);
+}
+
+fn push_fan(triangles: &mut Vec<[f64; 3]>, points: &[[f64; 3]], reverse: bool) {
+    for index in 1..points.len() - 1 {
+        if reverse {
+            triangles.extend([points[0], points[index + 1], points[index]]);
+        } else {
+            triangles.extend([points[0], points[index], points[index + 1]]);
+        }
     }
 }
 
 impl RenderConvertible for Solid {
     fn to_render(&self, _document: &acadrust::CadDocument) -> Option<RenderEntity> {
-        // SOLID corners are OCS. Map them to WCS, then resolve either the DXF
-        // Z-order or legacy perimeter order before building edges and fill.
+        // SOLID corners are OCS and the last two are stored in Z order. Preserve
+        // that ordering exactly: it is part of the entity geometry and can
+        // intentionally describe a crossing shape.
         let corners = wcs_corners(self);
-        let order = perimeter_indices(&corners);
-        let [p0, p1, p2, p3] = order.map(|index| corners[index]);
-        let pts = vec![
-            p0,
-            p1,
-            [f64::NAN; 3],
-            p1,
-            p2,
-            [f64::NAN; 3],
-            p2,
-            p3,
-            [f64::NAN; 3],
-            p3,
-            p0,
-        ];
-
-        let dvp = |p: [f64; 3]| glam::DVec3::from_array(p);
-        let snap = corners
+        let base = if self.is_triangle() {
+            vec![corners[0], corners[1], corners[2]]
+        } else {
+            vec![corners[0], corners[1], corners[3], corners[2]]
+        };
+        let normal = glam::DVec3::new(self.normal.x, self.normal.y, self.normal.z)
+            .normalize_or(glam::DVec3::Z);
+        let extruded = self.thickness.abs() > 1.0e-10;
+        let top: Vec<[f64; 3]> = base
             .iter()
-            .copied()
-            .map(|point| (dvp(point), SnapHint::Node))
+            .map(|point| {
+                (glam::DVec3::from_array(*point) + normal * self.thickness).to_array()
+            })
             .collect();
 
-        // Fill the resolved perimeter as two triangles. For a triangle the last
-        // two points coincide and the second triangle degenerates harmlessly.
-        let fill_tris = vec![p0, p1, p2, p0, p2, p3];
+        let mut lines = Vec::new();
+        for index in 0..base.len() {
+            push_edge(&mut lines, base[index], base[(index + 1) % base.len()]);
+        }
+        if extruded {
+            for index in 0..top.len() {
+                push_edge(&mut lines, top[index], top[(index + 1) % top.len()]);
+                push_edge(&mut lines, base[index], top[index]);
+            }
+        }
+
+        let mut fill_tris = Vec::new();
+        push_fan(&mut fill_tris, &base, false);
+        if extruded {
+            push_fan(&mut fill_tris, &top, true);
+            for index in 0..base.len() {
+                let next = (index + 1) % base.len();
+                fill_tris.extend([
+                    base[index],
+                    base[next],
+                    top[next],
+                    base[index],
+                    top[next],
+                    top[index],
+                ]);
+            }
+        }
+
+        let mut snap_points = base.clone();
+        if extruded {
+            snap_points.extend(top.iter().copied());
+        }
+        let snap = snap_points
+            .iter()
+            .copied()
+            .map(|point| (dvec3(point), SnapHint::Node))
+            .collect();
+        let pick_tris = if extruded {
+            fill_tris.clone()
+        } else {
+            Vec::new()
+        };
 
         Some(RenderEntity {
-            pick_tris: Vec::new(),
-            object: RenderObject::Lines(pts),
+            pick_tris,
+            object: RenderObject::Lines(lines),
             snap_pts: snap,
             tangent_geoms: vec![],
-            key_vertices: corners.to_vec(),
+            key_vertices: snap_points,
             fill_tris,
         })
     }
@@ -117,58 +151,51 @@ impl RenderConvertible for Solid {
 
 impl Grippable for Solid {
     fn grips(&self) -> Vec<GripDef> {
+        let corners = wcs_corners(self);
         vec![
-            square_grip(0, dvec3(&self.first_corner)),
-            square_grip(1, dvec3(&self.second_corner)),
-            square_grip(2, dvec3(&self.third_corner)),
-            square_grip(3, dvec3(&self.fourth_corner)),
+            square_grip(0, dvec3(corners[0])),
+            square_grip(1, dvec3(corners[1])),
+            square_grip(2, dvec3(corners[2])),
+            square_grip(3, dvec3(corners[3])),
         ]
     }
 
     fn apply_grip(&mut self, grip_id: usize, apply: GripApply) {
-        let corner = match grip_id {
-            0 => &mut self.first_corner,
-            1 => &mut self.second_corner,
-            2 => &mut self.third_corner,
-            3 => &mut self.fourth_corner,
-            _ => return,
+        let Some(current) = wcs_corners(self).get(grip_id).copied() else {
+            return;
         };
-        match apply {
-            GripApply::Translate(d) => {
-                corner.x += d.x as f64;
-                corner.y += d.y as f64;
-                corner.z += d.z as f64;
-            }
-            GripApply::Absolute(p) => {
-                corner.x = p.x as f64;
-                corner.y = p.y as f64;
-                corner.z = p.z as f64;
-            }
-        }
+        let point = match apply {
+            GripApply::Translate(delta) => dvec3(current) + delta,
+            GripApply::Absolute(point) => point,
+        };
+        set_wcs_corner(self, grip_id, point);
     }
 }
 
 impl PropertyEditable for Solid {
     fn geometry_properties(&self, _text_style_names: &[String]) -> Vec<PropSection> {
-        // Elevation is the OCS Z shared by the planar corners (no dedicated
-        // field on the entity); reported from the first corner's Z.
+        let corners = wcs_corners(self);
         let elevation = self.first_corner.z;
         vec![PropSection {
             title: t!("Geometry").into_owned(),
             props: vec![
-                edit(t!("Point 1 X").as_ref(), "sl_p1x", self.first_corner.x),
-                edit(t!("Point 1 Y").as_ref(), "sl_p1y", self.first_corner.y),
-                edit(t!("Point 1 Z").as_ref(), "sl_p1z", self.first_corner.z),
-                edit(t!("Point 2 X").as_ref(), "sl_p2x", self.second_corner.x),
-                edit(t!("Point 2 Y").as_ref(), "sl_p2y", self.second_corner.y),
-                edit(t!("Point 2 Z").as_ref(), "sl_p2z", self.second_corner.z),
-                edit(t!("Point 3 X").as_ref(), "sl_p3x", self.third_corner.x),
-                edit(t!("Point 3 Y").as_ref(), "sl_p3y", self.third_corner.y),
-                edit(t!("Point 3 Z").as_ref(), "sl_p3z", self.third_corner.z),
-                edit(t!("Point 4 X").as_ref(), "sl_p4x", self.fourth_corner.x),
-                edit(t!("Point 4 Y").as_ref(), "sl_p4y", self.fourth_corner.y),
-                edit(t!("Point 4 Z").as_ref(), "sl_p4z", self.fourth_corner.z),
-                ro(t!("Elevation").as_ref(), "sl_elev", format!("{:.4}", elevation)),
+                edit(t!("Point 1 X").as_ref(), "sl_p1x", corners[0][0]),
+                edit(t!("Point 1 Y").as_ref(), "sl_p1y", corners[0][1]),
+                edit(t!("Point 1 Z").as_ref(), "sl_p1z", corners[0][2]),
+                edit(t!("Point 2 X").as_ref(), "sl_p2x", corners[1][0]),
+                edit(t!("Point 2 Y").as_ref(), "sl_p2y", corners[1][1]),
+                edit(t!("Point 2 Z").as_ref(), "sl_p2z", corners[1][2]),
+                edit(t!("Point 3 X").as_ref(), "sl_p3x", corners[2][0]),
+                edit(t!("Point 3 Y").as_ref(), "sl_p3y", corners[2][1]),
+                edit(t!("Point 3 Z").as_ref(), "sl_p3z", corners[2][2]),
+                edit(t!("Point 4 X").as_ref(), "sl_p4x", corners[3][0]),
+                edit(t!("Point 4 Y").as_ref(), "sl_p4y", corners[3][1]),
+                edit(t!("Point 4 Z").as_ref(), "sl_p4z", corners[3][2]),
+                edit(t!("Elevation").as_ref(), "sl_elev", elevation),
+                edit(t!("Thickness").as_ref(), "sl_thickness", self.thickness),
+                edit(t!("Normal X").as_ref(), "sl_normal_x", self.normal.x),
+                edit(t!("Normal Y").as_ref(), "sl_normal_y", self.normal.y),
+                edit(t!("Normal Z").as_ref(), "sl_normal_z", self.normal.z),
             ],
         }]
     }
@@ -177,19 +204,56 @@ impl PropertyEditable for Solid {
         let Ok(v) = value.trim().parse::<f64>() else {
             return;
         };
+        let point_field = match field {
+            "sl_p1x" => Some((0, 0)),
+            "sl_p1y" => Some((0, 1)),
+            "sl_p1z" => Some((0, 2)),
+            "sl_p2x" => Some((1, 0)),
+            "sl_p2y" => Some((1, 1)),
+            "sl_p2z" => Some((1, 2)),
+            "sl_p3x" => Some((2, 0)),
+            "sl_p3y" => Some((2, 1)),
+            "sl_p3z" => Some((2, 2)),
+            "sl_p4x" => Some((3, 0)),
+            "sl_p4y" => Some((3, 1)),
+            "sl_p4z" => Some((3, 2)),
+            _ => None,
+        };
+        if let Some((point_index, component)) = point_field {
+            let mut point = dvec3(wcs_corners(self)[point_index]);
+            point[component] = v;
+            set_wcs_corner(self, point_index, point);
+            return;
+        }
+
         match field {
-            "sl_p1x" => self.first_corner.x = v,
-            "sl_p1y" => self.first_corner.y = v,
-            "sl_p1z" => self.first_corner.z = v,
-            "sl_p2x" => self.second_corner.x = v,
-            "sl_p2y" => self.second_corner.y = v,
-            "sl_p2z" => self.second_corner.z = v,
-            "sl_p3x" => self.third_corner.x = v,
-            "sl_p3y" => self.third_corner.y = v,
-            "sl_p3z" => self.third_corner.z = v,
-            "sl_p4x" => self.fourth_corner.x = v,
-            "sl_p4y" => self.fourth_corner.y = v,
-            "sl_p4z" => self.fourth_corner.z = v,
+            "sl_elev" => {
+                let delta = v - self.first_corner.z;
+                self.first_corner.z += delta;
+                self.second_corner.z += delta;
+                self.third_corner.z += delta;
+                self.fourth_corner.z += delta;
+            }
+            "sl_thickness" => self.thickness = v,
+            "sl_normal_x" | "sl_normal_y" | "sl_normal_z" => {
+                let world = wcs_corners(self);
+                let mut normal = glam::DVec3::new(self.normal.x, self.normal.y, self.normal.z);
+                match field {
+                    "sl_normal_x" => normal.x = v,
+                    "sl_normal_y" => normal.y = v,
+                    "sl_normal_z" => normal.z = v,
+                    _ => {}
+                }
+                if normal.length_squared() > 1.0e-20 {
+                    normal = normal.normalize();
+                    self.normal.x = normal.x;
+                    self.normal.y = normal.y;
+                    self.normal.z = normal.z;
+                    for (index, point) in world.into_iter().enumerate() {
+                        set_wcs_corner(self, index, dvec3(point));
+                    }
+                }
+            }
             _ => {}
         }
     }

--- a/src/modules/draw/draw/solid2d.rs
+++ b/src/modules/draw/draw/solid2d.rs
@@ -1,11 +1,10 @@
 // 2D solid tool — interactive command.
 //
-// Command: SOLID (reachable as SO / SOLID2D — the bare SOLID verb currently
-// toggles the shaded display) — pick three or four corner points and commit a
-// filled triangle or quadrilateral. Four points may be picked either around
-// the perimeter (the natural order shown by the rubber band) or in the
-// traditional Z pattern. The command normalizes both forms to the DXF corner
-// order before committing. Enter after the third point commits a triangle.
+// Command: SOLID (reachable as SO / SOLID2D) — pick three or four corner points
+// and commit a filled triangle or quadrilateral. Four-point input is preserved
+// in the entity's documented Z order; after a quadrilateral, its opposite edge
+// starts the next connected shape. Enter after the third point commits a
+// triangle.
 
 use acadrust::entities::Solid;
 use acadrust::types::Vector3;
@@ -49,42 +48,12 @@ impl Solid2dCommand {
         Vector3::new(p.x, p.y, p.z)
     }
 
-    /// True when walking the four points in pick order produces a bow-tie.
-    /// SOLID2D currently commits into the default world-XY OCS, so use that
-    /// same plane when deciding whether the last two points need swapping.
-    fn pick_order_crosses(points: &[DVec3]) -> bool {
-        if points.len() != 4 {
-            return false;
-        }
-        let orient = |a: DVec3, b: DVec3, c: DVec3| {
-            (b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x)
-        };
-        let crosses = |a: DVec3, b: DVec3, c: DVec3, d: DVec3| {
-            let ab_c = orient(a, b, c);
-            let ab_d = orient(a, b, d);
-            let cd_a = orient(c, d, a);
-            let cd_b = orient(c, d, b);
-            ((ab_c > 0.0 && ab_d < 0.0) || (ab_c < 0.0 && ab_d > 0.0))
-                && ((cd_a > 0.0 && cd_b < 0.0) || (cd_a < 0.0 && cd_b > 0.0))
-        };
-        crosses(points[0], points[1], points[2], points[3])
-            || crosses(points[1], points[2], points[3], points[0])
-    }
-
-    /// Convert either perimeter picks (1-2-3-4) or classic SOLID Z picks
-    /// (1-2-4-3 around the perimeter) into the entity's DXF Z order.
     fn solid_from_four_points(points: &[DVec3]) -> Solid {
-        let perimeter_order = !Self::pick_order_crosses(points);
-        let (third, fourth) = if perimeter_order {
-            (points[3], points[2])
-        } else {
-            (points[2], points[3])
-        };
         Solid::new(
             Self::v3(points[0]),
             Self::v3(points[1]),
-            Self::v3(third),
-            Self::v3(fourth),
+            Self::v3(points[2]),
+            Self::v3(points[3]),
         )
     }
 }
@@ -126,7 +95,10 @@ impl CadCommand for Solid2dCommand {
                 .map(|point| self.plane.to_local(*point))
                 .collect();
             let solid = Self::solid_from_four_points(&local);
-            CmdResult::CommitAndExit(self.plane.place_entity(EntityType::Solid(solid)))
+            let next_edge = [self.points[2], self.points[3]];
+            self.points.clear();
+            self.points.extend(next_edge);
+            CmdResult::CommitEntity(self.plane.place_entity(EntityType::Solid(solid)))
         } else {
             CmdResult::NeedPoint
         }
@@ -154,14 +126,22 @@ impl CadCommand for Solid2dCommand {
         if self.points.is_empty() {
             return None;
         }
-        // Outline the corners picked so far plus the cursor, closed back to the
-        // first point, as a rubber-band hint.
+        // Outline the exact Z-ordered boundary that would be committed. Do not
+        // reorder a crossing shape: point order is intentional geometry.
         let mut preview = self.points.clone();
         preview.push(pt);
-        if preview.len() == 4 && Self::pick_order_crosses(&preview) {
-            preview.swap(2, 3);
-        }
-        let mut pts: Vec<[f64; 3]> = preview.iter().map(|p| [p.x, p.y, p.z]).collect();
+        let display_order: Vec<usize> = if preview.len() == 4 {
+            vec![0, 1, 3, 2]
+        } else {
+            (0..preview.len()).collect()
+        };
+        let mut pts: Vec<[f64; 3]> = display_order
+            .iter()
+            .map(|index| {
+                let point = preview[*index];
+                [point.x, point.y, point.z]
+            })
+            .collect();
         pts.push([preview[0].x, preview[0].y, preview[0].z]);
         Some(WireModel::solid_f64(
             "rubber_band".to_string(),

--- a/src/scene/convert/tessellate.rs
+++ b/src/scene/convert/tessellate.rs
@@ -1260,7 +1260,7 @@ pub fn tessellate(
                         | EntityType::PolyfaceMesh(_)
                         | EntityType::PolygonMesh(_)
                         | EntityType::Mesh(_)
-                );
+                ) || matches!(entity, EntityType::Solid(solid) if solid.thickness.abs() > 1.0e-10);
                 // Thickness walls ride on the wire that carries their edges, not
                 // on a wire of their own: they are pick geometry for that entity,
                 // and `fill_tris` below deliberately splits off into a fill-only

--- a/src/scene/entity.rs
+++ b/src/scene/entity.rs
@@ -2158,8 +2158,8 @@ impl Scene {
     }
 
     /// Build a solid-fill HatchModel for a DXF Solid entity.
-    /// Conventional DXF SOLID corners use Z-order; legacy entities may already
-    /// be in perimeter order. Use the same non-crossing resolver as wire fill.
+    /// SOLID corners use Z-order. Preserve it in the projected hatch as well so
+    /// intentionally crossing geometry is not silently rewritten.
     pub(super) fn solid_hatch_model(solid: &DxfSolid, color: [f32; 4]) -> HatchModel {
         // Keep the corners in f64 until the AABB centre is known, then store
         // each as a small f32 offset from it — same precision-preserving anchor
@@ -2167,7 +2167,7 @@ impl Scene {
         // to f32 costs ~0.06 units of resolution at UTM magnitudes (~1e6), so
         // the quad snapped to a grid and the fill drifted off its outline.
         let wcs = crate::entities::solid::wcs_corners(solid);
-        let order = crate::entities::solid::perimeter_indices(&wcs);
+        let order = [0, 1, 3, 2];
         let corners: [[f64; 2]; 4] = order.map(|index| [wcs[index][0], wcs[index][1]]);
         let mut min = [f64::INFINITY; 2];
         let mut max = [f64::NEG_INFINITY; 2];

--- a/src/scene/pipeline/face3d_gpu.rs
+++ b/src/scene/pipeline/face3d_gpu.rs
@@ -22,6 +22,20 @@ use crate::scene::model::wire_model::WireModel;
 use iced::wgpu;
 use iced::wgpu::util::DeviceExt;
 
+fn planar_solid_faces_view(wire: &WireModel, view_dir: glam::Vec3) -> bool {
+    if !wire.fill_is_2d_solid || wire.fill_is_3d {
+        return true;
+    }
+    let view = view_dir.normalize_or_zero();
+    wire.fill_tris.chunks_exact(3).any(|triangle| {
+        let first = glam::Vec3::from_array(triangle[0]);
+        let second = glam::Vec3::from_array(triangle[1]);
+        let third = glam::Vec3::from_array(triangle[2]);
+        let normal = (second - first).cross(third - first).normalize_or_zero();
+        normal.length_squared() > 0.0 && normal.dot(view).abs() >= 1.0 - 1.0e-5
+    })
+}
+
 // ── Vertex layout ──────────────────────────────────────────────────────────
 
 #[repr(C)]
@@ -149,6 +163,7 @@ impl Face3DGpu {
         all_wires: &[WireModel],
         keep_3d_mesh_fills: bool,
         show_2d_solid_fills: bool,
+        view_dir: glam::Vec3,
         depth_map: &rustc_hash::FxHashMap<u64, [f32; 2]>,
     ) -> Self {
         let depth_of =
@@ -198,6 +213,9 @@ impl Face3DGpu {
                 continue;
             }
             if !show_2d_solid_fills && wire.fill_is_2d_solid {
+                continue;
+            }
+            if !planar_solid_faces_view(wire, view_dir) {
                 continue;
             }
             // A real 3-D surface fill (PolyfaceMesh / PolygonMesh) carries a
@@ -259,6 +277,7 @@ impl Face3DGpu {
             all_wires,
             keep_3d_mesh_fills,
             show_2d_solid_fills,
+            view_dir,
             depth_map,
         );
         Self {
@@ -275,6 +294,7 @@ fn upload_block_chunks(
     wires: &[WireModel],
     keep_3d_mesh_fills: bool,
     show_2d_solid_fills: bool,
+    view_dir: glam::Vec3,
     depth_map: &rustc_hash::FxHashMap<u64, [f32; 2]>,
 ) -> (Vec<BlockFace3DChunk>, Vec<BlockFace3DChunk>) {
     let mut slots = rustc_hash::FxHashMap::default();
@@ -285,6 +305,7 @@ fn upload_block_chunks(
         };
         if wire.fill_tris.is_empty()
             || (!show_2d_solid_fills && wire.fill_is_2d_solid)
+            || !planar_solid_faces_view(wire, view_dir)
             || (wire.fill_is_3d && !keep_3d_mesh_fills)
         {
             continue;

--- a/src/scene/pipeline/mod.rs
+++ b/src/scene/pipeline/mod.rs
@@ -312,12 +312,12 @@ pub struct Pipeline {
     /// a pick bumps only `selection_generation`, refreshing the overlay without
     /// touching the main wire buffers.
     pub cached_selection: (u64, u64),
-    /// `(wire_content_id, face3d_fill_active, show_2d_solid_fills)` the Face3D
+    /// `(wire_content_id, face3d_fill_active, show_2d_solid_fills, view_dir)` the Face3D
     /// edge/fill buffers were uploaded for. A stable content id avoids retaining
     /// the resident wire Arc:
     /// that Arc must stay uniquely owned by Scene so a small edit can splice it
     /// in place instead of rebuilding the whole drawing.
-    pub cached_face3d_key: (u64, bool, bool),
+    pub cached_face3d_key: (u64, bool, bool, [u32; 3]),
     /// Handle → indices into the resident wire set, built once per wire upload
     /// (when `cached_wire_id` changes). Lets the selection/hover xray overlay
     /// gather just the highlighted entity's wires (`O(highlighted)`) instead of
@@ -2323,7 +2323,7 @@ impl Pipeline {
             cached_epoch: (u64::MAX, u64::MAX, u64::MAX),
             cached_wire_id: u64::MAX,
             cached_selection: (u64::MAX, u64::MAX),
-            cached_face3d_key: (u64::MAX, false, false),
+            cached_face3d_key: (u64::MAX, false, false, [u32::MAX; 3]),
             wire_handle_index: std::sync::Arc::new(rustc_hash::FxHashMap::default()),
             render_sig: u64::MAX,
             skip_geometry: false,
@@ -3023,6 +3023,7 @@ impl Pipeline {
         all_wires: &[WireModel],
         wireframe_only: bool,
         show_2d_solid_fills: bool,
+        view_dir: glam::Vec3,
         depth_map: &rustc_hash::FxHashMap<u64, [f32; 2]>,
     ) {
         let perf_started = crate::perf::enabled().then(iced::time::Instant::now);
@@ -3056,6 +3057,7 @@ impl Pipeline {
                 all_wires,
                 keep_3d_mesh_fills,
                 show_2d_solid_fills,
+                view_dir,
                 depth_map,
             ));
         }

--- a/src/scene/view/render.rs
+++ b/src/scene/view/render.rs
@@ -378,7 +378,7 @@ impl shader::Primitive for Primitive {
                 inner.cached_wire_id = u64::MAX;
                 inner.cached_selection = (u64::MAX, u64::MAX);
                 inner.cached_mesh_content_id = u64::MAX;
-                inner.cached_face3d_key = (u64::MAX, false, false);
+                inner.cached_face3d_key = (u64::MAX, false, false, [u32::MAX; 3]);
                 inner.cached_hatch_source = None;
                 inner.cached_preview_hatch_source = None;
                 inner.cached_wipeout_source = None;
@@ -484,6 +484,12 @@ impl shader::Primitive for Primitive {
             // the view toggle so 2D fills stay on even when the user picks
             // the Wireframe overlay style.
             let face3d_fill_active = fill_mode && !vp.view_wireframe;
+            let solid_fill_active = fill_mode && vp.show_2d_solid_fills;
+            let view_dir_key = [
+                vp.view_dir.x.to_bits(),
+                vp.view_dir.y.to_bits(),
+                vp.view_dir.z.to_bits(),
+            ];
             let fill_changed = inner.cached_fill_mode != fill_mode;
             let hatch_changed = inner
                 .cached_hatch_source
@@ -574,14 +580,16 @@ impl shader::Primitive for Primitive {
                     && !face_pass_unchanged);
             if face3d_changed
                 || face3d_fill_active != inner.cached_face3d_key.1
-                || vp.show_2d_solid_fills != inner.cached_face3d_key.2
+                || solid_fill_active != inner.cached_face3d_key.2
+                || view_dir_key != inner.cached_face3d_key.3
             {
                 inner.upload_face3d(
                     device,
                     &vp.face3d_wires[..],
                     &vp_wires[..],
                     !face3d_fill_active,
-                    vp.show_2d_solid_fills,
+                    solid_fill_active,
+                    vp.view_dir,
                     &draw_depths,
                 );
                 inner.cached_face3d_source = Some(Arc::clone(&vp.face3d_wires));
@@ -590,7 +598,8 @@ impl shader::Primitive for Primitive {
             inner.cached_face3d_key = (
                 vp.wire_content_id,
                 face3d_fill_active,
-                vp.show_2d_solid_fills,
+                solid_fill_active,
+                view_dir_key,
             );
             // Wire buffers are world-space, so a camera move alone doesn't
             // change them — only the view_proj uniform (uploaded every frame).


### PR DESCRIPTION
1) Preserve documented Z-order input, retain intentionally crossing shapes, preview the actual boundary, and keep the command active for connected quadrilaterals.\n\n2) Show and edit corner coordinates in WCS, apply grips in WCS, and add functional elevation, thickness, and normal fields.\n\n3) Render non-zero thickness with top, bottom, side faces, complete edge and snap geometry, and 3D depth behavior.\n\n4) Apply FILLMODE to planar interiors and show them only when the view direction is orthogonal to the entity plane.\n\n5) Align the application and plugin workspace with the corrected codec and kernel revisions.\n\nDependencies: HakanSeven12/cadcodec#6 and HakanSeven12/cadkernel#3.