### PR TITLE
Complete associative centerline workflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,7 @@ checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
 [[package]]
 name = "acadrust"
 version = "0.4.1"
-source = "git+https://github.com/HakanSeven12/cadcodec.git?rev=0908da7#0908da7b6e4f702a6c78359a57f53e2b79cf39eb"
+source = "git+https://github.com/ramox81/cadcodec.git?rev=4f929bd#4f929bda328b2024eb408b69e70d5fc80a8b22ef"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
@@ -878,7 +878,7 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 [[package]]
 name = "cadkernel"
 version = "0.1.0"
-source = "git+https://github.com/HakanSeven12/cadkernel.git?rev=ebeb2ec#ebeb2ecc2d17d92c588b0fa8bbe3864b156bc71f"
+source = "git+https://github.com/ramox81/cadkernel.git?rev=33fd678#33fd678578de7d47c913121f147382c9d73d7830"
 dependencies = [
  "acadrust",
  "cavalier_contours",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,7 @@ checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
 [[package]]
 name = "acadrust"
 version = "0.4.1"
-source = "git+https://github.com/ramox81/cadcodec.git?rev=4f929bd#4f929bda328b2024eb408b69e70d5fc80a8b22ef"
+source = "git+https://github.com/ramox81/cadcodec.git?rev=1eeab52#1eeab52a4e743816e5974e1e6441422b5042001d"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
@@ -878,7 +878,7 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 [[package]]
 name = "cadkernel"
 version = "0.1.0"
-source = "git+https://github.com/ramox81/cadkernel.git?rev=33fd678#33fd678578de7d47c913121f147382c9d73d7830"
+source = "git+https://github.com/ramox81/cadkernel.git?rev=50c2551#50c2551d6bd46d19cfa664384bdc312b424269c4"
 dependencies = [
  "acadrust",
  "cavalier_contours",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ glam = { version = "0.33", features = ["bytemuck"] }
 rfd = "0.17"
 clap = { version = "4", features = ["derive"] }
 env_logger = "0.11"
-acadrust = { git = "https://github.com/HakanSeven12/cadcodec.git", rev = "0908da7", features = ["serde"] }
-cadkernel = { git = "https://github.com/HakanSeven12/cadkernel.git", rev = "ebeb2ec", features = ["acis", "offset"] }
+acadrust = { git = "https://github.com/ramox81/cadcodec.git", rev = "4f929bd", features = ["serde"] }
+cadkernel = { git = "https://github.com/ramox81/cadkernel.git", rev = "33fd678", features = ["acis", "offset"] }
 dwg-thumbnailer = { path = "crates/dwg-thumbnailer" }
 flate2 = "1"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "bmp", "tiff"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ glam = { version = "0.33", features = ["bytemuck"] }
 rfd = "0.17"
 clap = { version = "4", features = ["derive"] }
 env_logger = "0.11"
-acadrust = { git = "https://github.com/ramox81/cadcodec.git", rev = "4f929bd", features = ["serde"] }
-cadkernel = { git = "https://github.com/ramox81/cadkernel.git", rev = "33fd678", features = ["acis", "offset"] }
+acadrust = { git = "https://github.com/ramox81/cadcodec.git", rev = "1eeab52", features = ["serde"] }
+cadkernel = { git = "https://github.com/ramox81/cadkernel.git", rev = "50c2551", features = ["acis", "offset"] }
 dwg-thumbnailer = { path = "crates/dwg-thumbnailer" }
 flate2 = "1"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "bmp", "tiff"] }

--- a/crates/ocs_plugin_api/Cargo.toml
+++ b/crates/ocs_plugin_api/Cargo.toml
@@ -14,7 +14,7 @@ serde = { version = "1", features = ["derive"] }
 # Pulled in only by the `host` feature, which adds the `acadrust`-typed
 # `HostApi` runtime surface. The default crate stays dependency-free so engine
 # crates and external tooling can depend on the manifest/ribbon contract cheaply.
-acadrust = { git = "https://github.com/HakanSeven12/cadcodec.git", rev = "0908da7", optional = true, features = ["serde"] }
+acadrust = { git = "https://github.com/ramox81/cadcodec.git", rev = "4f929bd", optional = true, features = ["serde"] }
 
 # Runtime IPC and serialization (host feature only).
 interprocess = { version = "2", optional = true }
@@ -37,7 +37,7 @@ serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 cargo-lock = "11"
 # acadrust is scanned at build time to generate the embedded type registry.
-acadrust = { git = "https://github.com/HakanSeven12/cadcodec.git", rev = "0908da7", features = ["serde"] }
+acadrust = { git = "https://github.com/ramox81/cadcodec.git", rev = "4f929bd", features = ["serde"] }
 
 [dev-dependencies]
 serde_json = "1"

--- a/crates/ocs_plugin_api/Cargo.toml
+++ b/crates/ocs_plugin_api/Cargo.toml
@@ -14,7 +14,7 @@ serde = { version = "1", features = ["derive"] }
 # Pulled in only by the `host` feature, which adds the `acadrust`-typed
 # `HostApi` runtime surface. The default crate stays dependency-free so engine
 # crates and external tooling can depend on the manifest/ribbon contract cheaply.
-acadrust = { git = "https://github.com/ramox81/cadcodec.git", rev = "4f929bd", optional = true, features = ["serde"] }
+acadrust = { git = "https://github.com/ramox81/cadcodec.git", rev = "1eeab52", optional = true, features = ["serde"] }
 
 # Runtime IPC and serialization (host feature only).
 interprocess = { version = "2", optional = true }
@@ -37,7 +37,7 @@ serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 cargo-lock = "11"
 # acadrust is scanned at build time to generate the embedded type registry.
-acadrust = { git = "https://github.com/ramox81/cadcodec.git", rev = "4f929bd", features = ["serde"] }
+acadrust = { git = "https://github.com/ramox81/cadcodec.git", rev = "1eeab52", features = ["serde"] }
 
 [dev-dependencies]
 serde_json = "1"

--- a/crates/ocs_web_worker/Cargo.toml
+++ b/crates/ocs_web_worker/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-acadrust = { git = "https://github.com/ramox81/cadcodec.git", rev = "4f929bd", features = ["serde"] }
+acadrust = { git = "https://github.com/ramox81/cadcodec.git", rev = "1eeab52", features = ["serde"] }
 bincode = "1.3"
 serde = { version = "1", features = ["derive"] }
 console_error_panic_hook = "0.1"

--- a/crates/ocs_web_worker/Cargo.toml
+++ b/crates/ocs_web_worker/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-acadrust = { git = "https://github.com/HakanSeven12/cadcodec.git", rev = "0908da7", features = ["serde"] }
+acadrust = { git = "https://github.com/ramox81/cadcodec.git", rev = "4f929bd", features = ["serde"] }
 bincode = "1.3"
 serde = { version = "1", features = ["derive"] }
 console_error_panic_hook = "0.1"

--- a/crates/plugin-template-api2/Cargo.toml
+++ b/crates/plugin-template-api2/Cargo.toml
@@ -10,4 +10,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 ocs_plugin_api = { path = "../ocs_plugin_api", features = ["host"] }
-acadrust = { git = "https://github.com/ramox81/cadcodec.git", rev = "4f929bd", features = ["serde"] }
+acadrust = { git = "https://github.com/ramox81/cadcodec.git", rev = "1eeab52", features = ["serde"] }

--- a/crates/plugin-template-api2/Cargo.toml
+++ b/crates/plugin-template-api2/Cargo.toml
@@ -10,4 +10,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 ocs_plugin_api = { path = "../ocs_plugin_api", features = ["host"] }
-acadrust = "0.3.4"
+acadrust = { git = "https://github.com/ramox81/cadcodec.git", rev = "4f929bd", features = ["serde"] }

--- a/src/app/commands/draw.rs
+++ b/src/app/commands/draw.rs
@@ -473,9 +473,43 @@ impl OpenCADStudio {
 
             "CENTERLINE" => {
                 use crate::modules::draw::draw::centerline::CenterLineCommand;
-                let new_cmd = CenterLineCommand::new();
+                let settings = self.tabs[i].scene.centerline_settings();
+                let new_cmd = CenterLineCommand::new(settings);
                 self.command_line.push_info(&new_cmd.prompt());
                 self.tabs[i].active_cmd = Some(Box::new(new_cmd));
+            }
+
+            "CENTERRESET" => {
+                let handles = self.tabs[i].scene.selected_handles_in_order();
+                self.push_undo_snapshot(i, "CENTERRESET");
+                let count = self.tabs[i].scene.reset_centerlines(&handles);
+                if count > 0 {
+                    self.tabs[i].dirty = true;
+                }
+                self.command_line
+                    .push_output(&format!("CENTERRESET: {count} centerline(s) updated."));
+            }
+
+            "CENTERREASSOCIATE" => {
+                let handles = self.tabs[i].scene.selected_handles_in_order();
+                self.push_undo_snapshot(i, "CENTERREASSOCIATE");
+                let count = self.tabs[i].scene.set_centerline_association(&handles, true);
+                if count > 0 {
+                    self.tabs[i].dirty = true;
+                }
+                self.command_line
+                    .push_output(&format!("CENTERREASSOCIATE: {count} centerline(s) associated."));
+            }
+
+            "CENTERDISASSOCIATE" => {
+                let handles = self.tabs[i].scene.selected_handles_in_order();
+                self.push_undo_snapshot(i, "CENTERDISASSOCIATE");
+                let count = self.tabs[i].scene.set_centerline_association(&handles, false);
+                if count > 0 {
+                    self.tabs[i].dirty = true;
+                }
+                self.command_line
+                    .push_output(&format!("CENTERDISASSOCIATE: {count} centerline(s) detached."));
             }
 
             "DIMCENTER" | "CENTERMARK" => {

--- a/src/app/commands/styleprops.rs
+++ b/src/app/commands/styleprops.rs
@@ -933,6 +933,11 @@ impl OpenCADStudio {
                     | "SKETCHINC"
                     | "SKPOLY"
                     | "SKTOLERANCE"
+                    | "CENTEREXE"
+                    | "CENTERLAYER"
+                    | "CENTERLTYPE"
+                    | "CENTERLTSCALE"
+                    | "CENTERLTYPEFILE"
             ) =>
             {
                 return self.dispatch_styleprops(&format!("SETVAR {cmd}"), i);
@@ -955,7 +960,7 @@ impl OpenCADStudio {
                 let value = it.next().map(|s| s.trim().to_string());
                 if name.is_empty() || name == "?" {
                     self.command_line.push_info(
-                        "SETVAR: LTSCALE CELTSCALE PDMODE PDSIZE TEXTSIZE ORTHOMODE FILLMODE MIRRTEXT FRAME IMAGEFRAME PDFFRAME WIPEOUTFRAME XCLIPFRAME POINTCLOUDCLIPFRAME ZOOMWHEEL ZOOMFACTOR CURSORSIZE PICKBOX CURSORTYPE SNAPANG ATTREQ ATTDIA DIMASSOC ANGBASE ANGDIR SKETCHINC SKPOLY SKTOLERANCE | CLAYER CELTYPE TEXTSTYLE (read-only)",
+                        "SETVAR: LTSCALE CELTSCALE PDMODE PDSIZE TEXTSIZE ORTHOMODE FILLMODE MIRRTEXT FRAME IMAGEFRAME PDFFRAME WIPEOUTFRAME XCLIPFRAME POINTCLOUDCLIPFRAME ZOOMWHEEL ZOOMFACTOR CURSORSIZE PICKBOX CURSORTYPE SNAPANG ATTREQ ATTDIA DIMASSOC ANGBASE ANGDIR SKETCHINC SKPOLY SKTOLERANCE CENTEREXE CENTERLAYER CENTERLTYPE CENTERLTSCALE CENTERLTYPEFILE | CLAYER CELTYPE TEXTSTYLE (read-only)",
                     );
                 } else {
                     let frame_kind = crate::scene::frame::kind_for_name(&name);
@@ -1029,6 +1034,39 @@ impl OpenCADStudio {
                                 ).as_ref());
                                 self.pending_setvar = Some(name.clone());
                             }
+                        }
+                        return Some(self.finish_dispatch(cmd));
+                    }
+                    if matches!(
+                        name.as_str(),
+                        "CENTEREXE"
+                            | "CENTERLAYER"
+                            | "CENTERLTYPE"
+                            | "CENTERLTSCALE"
+                            | "CENTERLTYPEFILE"
+                    ) {
+                        let settings = self.tabs[i].scene.centerline_settings();
+                        let current = match name.as_str() {
+                            "CENTEREXE" => settings.extension.to_string(),
+                            "CENTERLAYER" => settings.layer,
+                            "CENTERLTYPE" => settings.linetype,
+                            "CENTERLTSCALE" => settings.linetype_scale.to_string(),
+                            "CENTERLTYPEFILE" => settings.linetype_file,
+                            _ => unreachable!(),
+                        };
+                        if let Some(value) = &value {
+                            match self.tabs[i].scene.set_centerline_setting(&name, value) {
+                                Ok(message) => {
+                                    self.tabs[i].dirty = true;
+                                    self.command_line.push_output(&message);
+                                }
+                                Err(error) => self.command_line.push_error(&error),
+                            }
+                        } else {
+                            self.command_line.push_output(crate::tf!(
+                                "Enter new value for {name} <{current}>:"
+                            ).as_ref());
+                            self.pending_setvar = Some(name.clone());
                         }
                         return Some(self.finish_dispatch(cmd));
                     }

--- a/src/app/properties.rs
+++ b/src/app/properties.rs
@@ -1844,6 +1844,36 @@ impl OpenCADStudio {
             &mut entity,
         );
 
+        // Smart centre lines carry their own drawing-level creation style.
+        // Apply it after the generic ribbon style so ordinary LINE entities
+        // keep the existing path while centre lines honour their settings.
+        if acadrust::entities::CenterLineAssociation::read(
+            &entity.common().extended_data,
+        )
+        .is_some()
+        {
+            let settings = self.tabs[i].scene.centerline_settings();
+            if !settings.layer.eq_ignore_ascii_case("Current") {
+                entity.common_mut().layer = settings.layer;
+            }
+            if !settings.linetype.eq_ignore_ascii_case("Current") {
+                entity.common_mut().linetype = settings.linetype;
+            }
+            entity.common_mut().linetype_scale = settings.linetype_scale;
+            if !self.tabs[i]
+                .scene
+                .document
+                .app_ids
+                .contains(acadrust::entities::CENTERLINE_XDATA_APPLICATION)
+            {
+                let mut app = acadrust::tables::AppId::new(
+                    acadrust::entities::CENTERLINE_XDATA_APPLICATION,
+                );
+                app.handle = self.tabs[i].scene.document.allocate_handle();
+                let _ = self.tabs[i].scene.document.app_ids.add(app);
+            }
+        }
+
         let text_style_annotative = match &entity {
             acadrust::EntityType::Text(text) => {
                 crate::scene::annotative::text_style_is_annotative(

--- a/src/entities/line.rs
+++ b/src/entities/line.rs
@@ -3,7 +3,8 @@ use crate::t;
 
 use crate::command::EntityTransform;
 use crate::entities::common::{
-    center_grip, edit_prop as edit, parse_f64, ro_prop as ro, square_grip,
+    center_grip, edit_prop as edit, oriented_triangle_grip, parse_f64, ro_prop as ro,
+    square_grip,
 };
 use crate::entities::traits::RenderConvertible;
 use crate::scene::convert::acad_to_render::{extrusion_wall_tris, RenderEntity, RenderObject};
@@ -67,10 +68,51 @@ fn grips(line: &Line) -> Vec<GripDef> {
     let s = glam::DVec3::new(line.start.x, line.start.y, line.start.z);
     let e = glam::DVec3::new(line.end.x, line.end.y, line.end.z);
     let m = (s + e) * 0.5;
+    if let Some(association) =
+        acadrust::entities::CenterLineAssociation::read(&line.common.extended_data)
+    {
+        let direction = (e - s).normalize_or(glam::DVec3::X);
+        let start_extension = association.start_extension + association.start_length_adjustment;
+        let end_extension = association.end_extension + association.end_length_adjustment;
+        let base_start = s + direction * start_extension;
+        let base_end = e - direction * end_extension;
+        return vec![
+            square_grip(0, base_start),
+            square_grip(1, base_end),
+            center_grip(2, m),
+            oriented_triangle_grip(3, s, -direction),
+            oriented_triangle_grip(4, e, direction),
+        ];
+    }
     vec![square_grip(0, s), square_grip(1, e), center_grip(2, m)]
 }
 
 fn properties(line: &Line) -> Vec<PropSection> {
+    if let Some(association) =
+        acadrust::entities::CenterLineAssociation::read(&line.common.extended_data)
+    {
+        return vec![PropSection {
+            title: t!("Geometry").into_owned(),
+            props: vec![
+                edit(
+                    "Start extension",
+                    "centerline_start_extension",
+                    association.start_extension,
+                ),
+                edit(
+                    "End extension",
+                    "centerline_end_extension",
+                    association.end_extension,
+                ),
+                ro(t!("Length").as_ref(), "length", format!("{:.4}", line.length())),
+                ro(
+                    "Associative",
+                    "centerline_associative",
+                    if association.associated { "Yes" } else { "No" },
+                ),
+            ],
+        }];
+    }
     let dx = line.end.x - line.start.x;
     let dy = line.end.y - line.start.y;
     let dz = line.end.z - line.start.z;
@@ -97,6 +139,33 @@ fn apply_geom_prop(line: &mut Line, field: &str, value: &str) {
     let Some(v) = parse_f64(value) else {
         return;
     };
+    if let Some(mut association) =
+        acadrust::entities::CenterLineAssociation::read(&line.common.extended_data)
+    {
+        if !v.is_finite() || v < 0.0 {
+            return;
+        }
+        let start = glam::DVec3::new(line.start.x, line.start.y, line.start.z);
+        let end = glam::DVec3::new(line.end.x, line.end.y, line.end.z);
+        let direction = (end - start).normalize_or(glam::DVec3::X);
+        match field {
+            "centerline_start_extension" => {
+                let delta = v - association.start_extension;
+                let moved = start - direction * delta;
+                line.start = acadrust::types::Vector3::new(moved.x, moved.y, moved.z);
+                association.start_extension = v;
+            }
+            "centerline_end_extension" => {
+                let delta = v - association.end_extension;
+                let moved = end + direction * delta;
+                line.end = acadrust::types::Vector3::new(moved.x, moved.y, moved.z);
+                association.end_extension = v;
+            }
+            _ => return,
+        }
+        association.write(&mut line.common.extended_data);
+        return;
+    }
     match field {
         "start_x" => line.start.x = v,
         "start_y" => line.start.y = v,
@@ -109,6 +178,55 @@ fn apply_geom_prop(line: &mut Line, field: &str, value: &str) {
 }
 
 fn apply_grip(line: &mut Line, grip_id: usize, apply: GripApply) {
+    if let Some(mut association) =
+        acadrust::entities::CenterLineAssociation::read(&line.common.extended_data)
+    {
+        let start = glam::DVec3::new(line.start.x, line.start.y, line.start.z);
+        let end = glam::DVec3::new(line.end.x, line.end.y, line.end.z);
+        let direction = (end - start).normalize_or(glam::DVec3::X);
+        let start_total = association.start_extension + association.start_length_adjustment;
+        let end_total = association.end_extension + association.end_length_adjustment;
+        let base_start = start + direction * start_total;
+        let base_end = end - direction * end_total;
+        match (grip_id, apply) {
+            (0, GripApply::Absolute(point)) => {
+                let delta = (point - base_start).dot(direction);
+                association.start_length_adjustment -= delta;
+                let moved = start + direction * delta;
+                line.start = acadrust::types::Vector3::new(moved.x, moved.y, moved.z);
+            }
+            (1, GripApply::Absolute(point)) => {
+                let delta = (point - base_end).dot(direction);
+                association.end_length_adjustment += delta;
+                let moved = end + direction * delta;
+                line.end = acadrust::types::Vector3::new(moved.x, moved.y, moved.z);
+            }
+            (2, GripApply::Translate(delta)) => {
+                line.start.x += delta.x;
+                line.start.y += delta.y;
+                line.start.z += delta.z;
+                line.end.x += delta.x;
+                line.end.y += delta.y;
+                line.end.z += delta.z;
+                association.associated = false;
+            }
+            (3, GripApply::Absolute(point)) => {
+                let total = (base_start - point).dot(direction).max(0.0);
+                association.start_extension = (total - association.start_length_adjustment).max(0.0);
+                let moved = base_start - direction * (association.start_extension + association.start_length_adjustment);
+                line.start = acadrust::types::Vector3::new(moved.x, moved.y, moved.z);
+            }
+            (4, GripApply::Absolute(point)) => {
+                let total = (point - base_end).dot(direction).max(0.0);
+                association.end_extension = (total - association.end_length_adjustment).max(0.0);
+                let moved = base_end + direction * (association.end_extension + association.end_length_adjustment);
+                line.end = acadrust::types::Vector3::new(moved.x, moved.y, moved.z);
+            }
+            _ => return,
+        }
+        association.write(&mut line.common.extended_data);
+        return;
+    }
     match (grip_id, apply) {
         (0, GripApply::Absolute(p)) => {
             line.start.x = p.x as f64;
@@ -133,6 +251,12 @@ fn apply_grip(line: &mut Line, grip_id: usize, apply: GripApply) {
 }
 
 fn apply_transform(line: &mut Line, t: &EntityTransform) {
+    if let Some(mut association) =
+        acadrust::entities::CenterLineAssociation::read(&line.common.extended_data)
+    {
+        association.associated = false;
+        association.write(&mut line.common.extended_data);
+    }
     match t {
         EntityTransform::Translate(d) => {
             line.translate(acadrust::types::Vector3::new(

--- a/src/entities/traits.rs
+++ b/src/entities/traits.rs
@@ -111,6 +111,14 @@ pub trait TextContent {
 pub fn entity_type_name(et: &EntityType) -> &str {
     match et {
         EntityType::Point(_) => "Point",
+        EntityType::Line(line)
+            if acadrust::entities::CenterLineAssociation::read(
+                &line.common.extended_data,
+            )
+            .is_some() =>
+        {
+            "CenterLine"
+        }
         EntityType::Line(_) => "Line",
         EntityType::Circle(_) => "Circle",
         EntityType::Arc(_) => "Arc",

--- a/src/io/linetypes.rs
+++ b/src/io/linetypes.rs
@@ -265,12 +265,21 @@ pub fn extract_pattern(desc: &str) -> String {
 
 /// Add all standard OpenCADStudio linetypes to `doc`, skipping existing ones.
 pub fn populate_document(doc: &mut CadDocument) {
-    for mut lt in parse(LIN_SOURCE) {
+    populate_document_from_source(doc, LIN_SOURCE);
+}
+
+/// Add all simple linetypes parsed from a caller-supplied `.lin` source.
+/// Returns the number of definitions newly registered in the drawing.
+pub fn populate_document_from_source(doc: &mut CadDocument, source: &str) -> usize {
+    let mut added = 0;
+    for mut lt in parse(source) {
         if !doc.line_types.contains(&lt.name) {
             lt.set_handle(doc.allocate_handle());
             doc.line_types.add(lt).ok();
+            added += 1;
         }
     }
+    added
 }
 
 

--- a/src/modules/draw/draw/centerline.rs
+++ b/src/modules/draw/draw/centerline.rs
@@ -1,218 +1,50 @@
-// Centre line tool — interactive command.
-//
-// Command: CENTERLINE — pick two straight Line entities and draw a single
-// centre line between them, committed as one Line entity.
-//
-//   * If the two picked lines are (near) parallel, the result is the midline:
-//     a line running between the two, centred on the average of their
-//     midpoints, oriented along the averaged direction, with a length equal to
-//     the longer of the two source lines.
-//   * If the two picked lines cross, the result is the bisector of the acute
-//     angle at their intersection point, drawn symmetrically either side of
-//     that point.
-//
-// The command picks the first line on the first click, stores it, prompts for
-// the second line, then computes the centre line and ends.
+//! Associative centre-line construction from lines and linear polyline segments.
 
+use acadrust::entities::{CenterLineAssociation, CenterLineSource};
 use acadrust::types::Vector3;
-use acadrust::{EntityType, Handle, Line};
+use acadrust::{EntityType, Handle};
 use glam::DVec3;
-use crate::t;
 
 use crate::command::{CadCommand, CmdResult, WorkingPlane};
 use crate::modules::{IconKind, ModuleEvent, ToolDef};
+use crate::scene::centerline::{construct_line, picked_source, CenterLineSettings};
+use crate::t;
 
-// ── Ribbon definition ─────────────────────────────────────────────────────
-
-#[allow(dead_code)] // ribbon definition ready for wiring; command works via the command line
+#[allow(dead_code)]
 pub fn tool() -> ToolDef {
     ToolDef {
         id: "CENTERLINE",
         label: "Center Line",
         icon: IconKind::Svg(include_bytes!("../../../../assets/icons/line.svg")),
-        event: ModuleEvent::Command("CENTERLINE".to_string()),
+        event: ModuleEvent::Command("CENTERLINE".to_owned()),
     }
 }
 
-// ── Geometry helpers ──────────────────────────────────────────────────────
-
-/// A line reduced to the quantities the centre-line maths needs.
-#[derive(Clone, Copy)]
-struct LineGeom {
+#[derive(Clone)]
+struct PickedSource {
+    source: CenterLineSource,
     start: DVec3,
     end: DVec3,
 }
 
-impl LineGeom {
-    fn from_line(line: &Line) -> Self {
-        Self {
-            start: DVec3::new(line.start.x, line.start.y, line.start.z),
-            end: DVec3::new(line.end.x, line.end.y, line.end.z),
-        }
-    }
-
-    fn midpoint(&self) -> DVec3 {
-        (self.start + self.end) * 0.5
-    }
-
-    fn length(&self) -> f64 {
-        (self.end - self.start).length()
-    }
-
-    /// Normalized direction in 3D, or `None` if the line is degenerate.
-    fn dir(&self) -> Option<DVec3> {
-        let d = self.end - self.start;
-        let len = d.length();
-        if len <= 1e-9 {
-            None
-        } else {
-            Some(d / len)
-        }
-    }
+fn vector(point: DVec3) -> Vector3 {
+    Vector3::new(point.x, point.y, point.z)
 }
-
-/// 2D cross product of the XY components of two vectors.
-fn cross_xy(a: DVec3, b: DVec3) -> f64 {
-    a.x * b.y - a.y * b.x
-}
-
-fn to_v3(p: DVec3) -> Vector3 {
-    Vector3::new(p.x, p.y, p.z)
-}
-
-/// Compute the centre line between two source lines. `None` when the result
-/// would be degenerate (zero-length sources, or coincident parallel lines that
-/// give no usable direction).
-fn compute_center_line(a: LineGeom, b: LineGeom) -> Option<Line> {
-    let da = a.dir()?;
-    let db = b.dir()?;
-
-    // Average Z of the four endpoints keeps the result on a sensible plane even
-    // when the picked lines sit at slightly different elevations.
-    let avg_z = (a.start.z + a.end.z + b.start.z + b.end.z) * 0.25;
-
-    let parallel = cross_xy(da, db).abs() <= 1e-9;
-
-    if parallel {
-        // Midline: average direction (flip db so the two add constructively),
-        // centred on the average of the two midpoints, length = longer source.
-        let db_aligned = if da.dot(db) < 0.0 { -db } else { db };
-        let avg = da + db_aligned;
-        let dir = if avg.length() <= 1e-9 {
-            da
-        } else {
-            avg / avg.length()
-        };
-        let dir = DVec3::new(dir.x, dir.y, 0.0);
-        let dir = if dir.length() <= 1e-9 {
-            return None;
-        } else {
-            dir / dir.length()
-        };
-
-        let mid = (a.midpoint() + b.midpoint()) * 0.5;
-        let half = a.length().max(b.length()) * 0.5;
-        if half <= 1e-9 {
-            return None;
-        }
-        let center = DVec3::new(mid.x, mid.y, avg_z);
-        let p0 = center - dir * half;
-        let p1 = center + dir * half;
-        Some(Line::from_points(to_v3(p0), to_v3(p1)))
-    } else {
-        // Intersecting: bisector of the acute angle at the intersection point.
-        // Solve the 2D line-line intersection in XY.
-        //   a.start + t*da = b.start + s*db
-        let r = da; // direction of line a
-        let s = db; // direction of line b
-        let denom = cross_xy(r, s);
-        if denom.abs() <= 1e-12 {
-            return None;
-        }
-        let qp = b.start - a.start;
-        let t = cross_xy(qp, s) / denom;
-        let ix = a.start.x + r.x * t;
-        let iy = a.start.y + r.y * t;
-        let p = DVec3::new(ix, iy, avg_z);
-
-        // Orient both directions away from the intersection point, choosing the
-        // half of each line whose midpoint lies on the side we keep, so the two
-        // oriented directions bisect the acute angle between the lines.
-        let a_away = orient_away(p, a);
-        let b_away = orient_away(p, b);
-        // For an acute-angle bisector, flip b_away if the two oriented dirs open
-        // obtuse (their dot is negative).
-        let b_oriented = if a_away.dot(b_away) < 0.0 {
-            -b_away
-        } else {
-            b_away
-        };
-        let bis = a_away + b_oriented;
-        let bis = DVec3::new(bis.x, bis.y, 0.0);
-        if bis.length() <= 1e-9 {
-            return None;
-        }
-        let dir = bis / bis.length();
-
-        let half = ((a.length() + b.length()) * 0.5) * 0.5;
-        if half <= 1e-9 {
-            return None;
-        }
-        let p0 = p - dir * half;
-        let p1 = p + dir * half;
-        Some(Line::from_points(to_v3(p0), to_v3(p1)))
-    }
-}
-
-/// Unit direction from `p` toward the farther endpoint of `line` (the side that
-/// extends away from the intersection point).
-fn orient_away(p: DVec3, line: LineGeom) -> DVec3 {
-    let to_start = line.start - p;
-    let to_end = line.end - p;
-    let pick = if to_end.length() >= to_start.length() {
-        to_end
-    } else {
-        to_start
-    };
-    let len = pick.length();
-    if len <= 1e-9 {
-        // Fall back to the raw line direction if the pick degenerates.
-        line.dir().unwrap_or(DVec3::X)
-    } else {
-        pick / len
-    }
-}
-
-// ── Command implementation ────────────────────────────────────────────────
 
 pub struct CenterLineCommand {
-    /// First picked Line's geometry, captured once the first pick lands.
-    first: Option<LineGeom>,
-    /// The entity injected by the host before `on_entity_pick` runs; `None`
-    /// until the host injects it.
+    first: Option<PickedSource>,
     picked: Option<EntityType>,
     plane: WorkingPlane,
+    settings: CenterLineSettings,
 }
 
 impl CenterLineCommand {
-    pub fn new() -> Self {
+    pub(crate) fn new(settings: CenterLineSettings) -> Self {
         Self {
             first: None,
             picked: None,
             plane: WorkingPlane::default(),
-        }
-    }
-
-    /// Extract a `LineGeom` from a picked entity; `None` for anything else.
-    fn as_line(&self, entity: &EntityType) -> Option<LineGeom> {
-        match entity {
-            EntityType::Line(line) => {
-                let mut geom = LineGeom::from_line(line);
-                geom.start = self.plane.to_local(geom.start);
-                geom.end = self.plane.to_local(geom.end);
-                Some(geom)
-            }
-            _ => None,
+            settings,
         }
     }
 }
@@ -246,39 +78,53 @@ impl CadCommand for CenterLineCommand {
         self.picked = Some(entity);
     }
 
-    fn on_entity_pick(&mut self, handle: Handle, _pt: DVec3) -> CmdResult {
+    fn on_entity_pick(&mut self, handle: Handle, point: DVec3) -> CmdResult {
         if handle.is_null() {
             return CmdResult::NeedPoint;
         }
-        // Resolve the just-picked entity; ignore the pick if it isn't a Line.
-        let picked = self.picked.take();
-        let geom = match picked.as_ref().and_then(|entity| self.as_line(entity)) {
-            Some(g) => g,
-            None => return CmdResult::NeedPoint,
+        let Some(entity) = self.picked.take() else {
+            return CmdResult::NeedPoint;
         };
-        // Reject zero-length picks rather than corrupting the result.
-        if geom.length() <= 1e-9 {
+        let Some((source, start, end)) = picked_source(&entity, handle, point) else {
+            return CmdResult::NeedPoint;
+        };
+        let picked = PickedSource { source, start, end };
+        let Some(first) = self.first.take() else {
+            self.first = Some(picked);
+            return CmdResult::NeedPoint;
+        };
+        if first.source.handle == picked.source.handle
+            && first.source.segment_index == picked.source.segment_index
+        {
+            self.first = Some(first);
             return CmdResult::NeedPoint;
         }
 
-        match self.first {
-            None => {
-                // First line captured; keep prompting for the second.
-                self.first = Some(geom);
-                CmdResult::NeedPoint
-            }
-            Some(first) => match compute_center_line(first, geom) {
-                Some(line) => CmdResult::CommitAndExit(
-                    self.plane.place_entity(EntityType::Line(line)),
-                ),
-                // Degenerate combination (coincident / no usable result):
-                // keep prompting for a usable second line.
-                None => CmdResult::NeedPoint,
-            },
-        }
+        let association = CenterLineAssociation {
+            first: first.source.clone(),
+            second: picked.source.clone(),
+            plane_origin: vector(self.plane.origin),
+            plane_x: vector(self.plane.x),
+            plane_y: vector(self.plane.y),
+            start_extension: self.settings.extension,
+            end_extension: self.settings.extension,
+            start_length_adjustment: 0.0,
+            end_length_adjustment: 0.0,
+            associated: true,
+        };
+        let Some(mut line) = construct_line(
+            (first.start, first.end),
+            (picked.start, picked.end),
+            &association,
+        ) else {
+            self.first = Some(first);
+            return CmdResult::NeedPoint;
+        };
+        association.write(&mut line.common.extended_data);
+        CmdResult::CommitAndExit(EntityType::Line(line))
     }
 
-    fn on_point(&mut self, _pt: DVec3) -> CmdResult {
+    fn on_point(&mut self, _point: DVec3) -> CmdResult {
         CmdResult::NeedPoint
     }
 
@@ -291,7 +137,11 @@ impl CadCommand for CenterLineCommand {
     }
 }
 
-// ── Autocomplete registry ─────────────────────────────────
 inventory::submit!(crate::command::CommandRegistration {
-    names: &["CENTERLINE"]
-}); // CenterLineCommand
+    names: &[
+        "CENTERLINE",
+        "CENTERRESET",
+        "CENTERREASSOCIATE",
+        "CENTERDISASSOCIATE",
+    ]
+});

--- a/src/scene/centerline.rs
+++ b/src/scene/centerline.rs
@@ -24,7 +24,7 @@ impl Default for CenterLineSettings {
         Self {
             extension: 0.12,
             layer: "Current".to_owned(),
-            linetype: "CENTER".to_owned(),
+            linetype: "CENTER2".to_owned(),
             linetype_scale: 1.0,
             linetype_file: String::new(),
         }
@@ -206,7 +206,10 @@ pub(crate) fn construct_line(
 
 impl Scene {
     pub(crate) fn centerline_settings(&self) -> CenterLineSettings {
-        let defaults = CenterLineSettings::default();
+        let mut defaults = CenterLineSettings::default();
+        if matches!(self.document.header.insertion_units, 4..=7 | 11..=17) {
+            defaults.extension = 3.5;
+        }
         let Some(layout) = self.current_layout_object_handle() else { return defaults; };
         let Some(record) = self.document.xrecord(layout, SETTINGS_RECORD) else { return defaults; };
         let value = |code| record.entries.iter().find(|entry| entry.code == code).map(|entry| &entry.value);
@@ -251,8 +254,8 @@ impl Scene {
             "CENTERLAYER" => (1, XRecordValue::String(value.to_owned()), value.to_owned()),
             "CENTERLTYPE" => (2, XRecordValue::String(value.to_owned()), value.to_owned()),
             "CENTERLTSCALE" => {
-                let number = value.parse::<f64>().map_err(|_| "CENTERLTSCALE requires a positive number.".to_owned())?;
-                if !number.is_finite() || number <= 0.0 { return Err("CENTERLTSCALE requires a positive number.".to_owned()); }
+                let number = value.parse::<f64>().map_err(|_| "CENTERLTSCALE requires a non-zero number.".to_owned())?;
+                if !number.is_finite() || number == 0.0 { return Err("CENTERLTSCALE requires a non-zero number.".to_owned()); }
                 (41, XRecordValue::Double(number), number.to_string())
             }
             "CENTERLTYPEFILE" => (3, XRecordValue::String(value.to_owned()), value.to_owned()),

--- a/src/scene/centerline.rs
+++ b/src/scene/centerline.rs
@@ -1,0 +1,361 @@
+use super::*;
+use acadrust::entities::{
+    CenterLineAssociation, CenterLineSource, CenterLineSourceKind,
+};
+use acadrust::objects::{XRecordEntry, XRecordValue};
+use acadrust::types::Vector3;
+use cadkernel::geom2d::{centerline_between, Line as KernelLine};
+use glam::DVec3;
+use crate::command::WorkingPlane;
+
+const SETTINGS_RECORD: &str = "OPEN_CAD_CENTERLINE_SETTINGS";
+
+#[derive(Clone, Debug)]
+pub(crate) struct CenterLineSettings {
+    pub extension: f64,
+    pub layer: String,
+    pub linetype: String,
+    pub linetype_scale: f64,
+    pub linetype_file: String,
+}
+
+impl Default for CenterLineSettings {
+    fn default() -> Self {
+        Self {
+            extension: 0.12,
+            layer: "Current".to_owned(),
+            linetype: "CENTER".to_owned(),
+            linetype_scale: 1.0,
+            linetype_file: String::new(),
+        }
+    }
+}
+
+fn vector(point: DVec3) -> Vector3 {
+    Vector3::new(point.x, point.y, point.z)
+}
+
+fn dvec(point: Vector3) -> DVec3 {
+    DVec3::new(point.x, point.y, point.z)
+}
+
+fn ocs_point(point: (f64, f64, f64), normal: Vector3) -> DVec3 {
+    let point = crate::scene::view::transform::ocs_point_to_wcs(
+        point,
+        (normal.x, normal.y, normal.z),
+    );
+    DVec3::new(point.0, point.1, point.2)
+}
+
+fn distance_to_segment(point: DVec3, start: DVec3, end: DVec3) -> f64 {
+    let span = end - start;
+    let length_squared = span.length_squared();
+    if length_squared <= 1.0e-20 {
+        return point.distance(start);
+    }
+    let parameter = ((point - start).dot(span) / length_squared).clamp(0.0, 1.0);
+    point.distance(start + span * parameter)
+}
+
+fn segment_indices(vertex_count: usize, closed: bool) -> impl Iterator<Item = (usize, usize)> {
+    let count = if closed && vertex_count > 2 {
+        vertex_count
+    } else {
+        vertex_count.saturating_sub(1)
+    };
+    (0..count).map(move |start| (start, (start + 1) % vertex_count.max(1)))
+}
+
+/// Resolve a user pick to a line or the closest linear polyline segment.
+pub(crate) fn picked_source(
+    entity: &EntityType,
+    handle: Handle,
+    pick: DVec3,
+) -> Option<(CenterLineSource, DVec3, DVec3)> {
+    match entity {
+        EntityType::Line(line) if line.length() > 1.0e-10 => Some((
+            CenterLineSource {
+                handle,
+                kind: CenterLineSourceKind::Line,
+                segment_index: -1,
+                pick_point: vector(pick),
+            },
+            dvec(line.start),
+            dvec(line.end),
+        )),
+        EntityType::LwPolyline(polyline) => segment_indices(polyline.vertices.len(), polyline.is_closed)
+            .filter(|(start, _)| polyline.vertices[*start].bulge.abs() <= 1.0e-12)
+            .filter_map(|(start, end)| {
+                let a = polyline.vertices[start].location;
+                let b = polyline.vertices[end].location;
+                let a = ocs_point((a.x, a.y, polyline.elevation), polyline.normal);
+                let b = ocs_point((b.x, b.y, polyline.elevation), polyline.normal);
+                (a.distance(b) > 1.0e-10).then_some((start, a, b))
+            })
+            .min_by(|(_, a, b), (_, c, d)| {
+                distance_to_segment(pick, *a, *b)
+                    .total_cmp(&distance_to_segment(pick, *c, *d))
+            })
+            .map(|(index, start, end)| (
+                CenterLineSource {
+                    handle,
+                    kind: CenterLineSourceKind::LwPolylineSegment,
+                    segment_index: index as i32,
+                    pick_point: vector(pick),
+                },
+                start,
+                end,
+            )),
+        EntityType::Polyline2D(polyline) => segment_indices(polyline.vertices.len(), polyline.is_closed())
+            .filter(|(start, _)| polyline.vertices[*start].bulge.abs() <= 1.0e-12)
+            .filter_map(|(start, end)| {
+                let a = polyline.vertices[start].location;
+                let b = polyline.vertices[end].location;
+                let a = ocs_point((a.x, a.y, polyline.elevation), polyline.normal);
+                let b = ocs_point((b.x, b.y, polyline.elevation), polyline.normal);
+                (a.distance(b) > 1.0e-10).then_some((start, a, b))
+            })
+            .min_by(|(_, a, b), (_, c, d)| {
+                distance_to_segment(pick, *a, *b)
+                    .total_cmp(&distance_to_segment(pick, *c, *d))
+            })
+            .map(|(index, start, end)| (
+                CenterLineSource {
+                    handle,
+                    kind: CenterLineSourceKind::Polyline2DSegment,
+                    segment_index: index as i32,
+                    pick_point: vector(pick),
+                },
+                start,
+                end,
+            )),
+        _ => None,
+    }
+}
+
+fn resolve_source(document: &acadrust::CadDocument, source: &CenterLineSource) -> Option<(DVec3, DVec3)> {
+    let entity = document.get_entity(source.handle)?;
+    let (_, start, end) = picked_source(entity, source.handle, dvec(source.pick_point))?;
+    match source.kind {
+        CenterLineSourceKind::Line => matches!(entity, EntityType::Line(_)).then_some((start, end)),
+        CenterLineSourceKind::LwPolylineSegment => {
+            let EntityType::LwPolyline(polyline) = entity else { return None; };
+            let index = usize::try_from(source.segment_index).ok()?;
+            let end_index = if index + 1 < polyline.vertices.len() { index + 1 } else if polyline.is_closed { 0 } else { return None; };
+            if polyline.vertices.get(index)?.bulge.abs() > 1.0e-12 { return None; }
+            let a = polyline.vertices[index].location;
+            let b = polyline.vertices[end_index].location;
+            Some((
+                ocs_point((a.x, a.y, polyline.elevation), polyline.normal),
+                ocs_point((b.x, b.y, polyline.elevation), polyline.normal),
+            ))
+        }
+        CenterLineSourceKind::Polyline2DSegment => {
+            let EntityType::Polyline2D(polyline) = entity else { return None; };
+            let index = usize::try_from(source.segment_index).ok()?;
+            let end_index = if index + 1 < polyline.vertices.len() { index + 1 } else if polyline.is_closed() { 0 } else { return None; };
+            if polyline.vertices.get(index)?.bulge.abs() > 1.0e-12 { return None; }
+            let a = polyline.vertices[index].location;
+            let b = polyline.vertices[end_index].location;
+            Some((
+                ocs_point((a.x, a.y, polyline.elevation), polyline.normal),
+                ocs_point((b.x, b.y, polyline.elevation), polyline.normal),
+            ))
+        }
+    }
+}
+
+fn rebuild_line(
+    document: &acadrust::CadDocument,
+    association: &CenterLineAssociation,
+) -> Option<acadrust::Line> {
+    let first = resolve_source(document, &association.first)?;
+    let second = resolve_source(document, &association.second)?;
+    construct_line(first, second, association)
+}
+
+pub(crate) fn construct_line(
+    first: (DVec3, DVec3),
+    second: (DVec3, DVec3),
+    association: &CenterLineAssociation,
+) -> Option<acadrust::Line> {
+    let plane = WorkingPlane::new(
+        dvec(association.plane_origin),
+        dvec(association.plane_x),
+        dvec(association.plane_y),
+    );
+    let first_start = plane.to_local(first.0);
+    let first_end = plane.to_local(first.1);
+    let second_start = plane.to_local(second.0);
+    let second_end = plane.to_local(second.1);
+    let first_pick = plane.to_local(dvec(association.first.pick_point));
+    let second_pick = plane.to_local(dvec(association.second.pick_point));
+    let geometry = centerline_between(
+        KernelLine { start: [first_start.x, first_start.y], end: [first_end.x, first_end.y] },
+        KernelLine { start: [second_start.x, second_start.y], end: [second_end.x, second_end.y] },
+        [first_pick.x, first_pick.y],
+        [second_pick.x, second_pick.y],
+        association.start_extension + association.start_length_adjustment,
+        association.end_extension + association.end_length_adjustment,
+    )?;
+    let elevation = (first_start.z + first_end.z + second_start.z + second_end.z) * 0.25;
+    let start = plane.to_world(DVec3::new(geometry.start[0], geometry.start[1], elevation));
+    let end = plane.to_world(DVec3::new(geometry.end[0], geometry.end[1], elevation));
+    Some(acadrust::Line::from_points(vector(start), vector(end)))
+}
+
+impl Scene {
+    pub(crate) fn centerline_settings(&self) -> CenterLineSettings {
+        let defaults = CenterLineSettings::default();
+        let Some(layout) = self.current_layout_object_handle() else { return defaults; };
+        let Some(record) = self.document.xrecord(layout, SETTINGS_RECORD) else { return defaults; };
+        let value = |code| record.entries.iter().find(|entry| entry.code == code).map(|entry| &entry.value);
+        CenterLineSettings {
+            extension: value(40).and_then(XRecordValue::as_double).unwrap_or(defaults.extension),
+            layer: value(1).and_then(XRecordValue::as_string).unwrap_or(&defaults.layer).to_owned(),
+            linetype: value(2).and_then(XRecordValue::as_string).unwrap_or(&defaults.linetype).to_owned(),
+            linetype_scale: value(41).and_then(XRecordValue::as_double).unwrap_or(defaults.linetype_scale),
+            linetype_file: value(3).and_then(XRecordValue::as_string).unwrap_or(&defaults.linetype_file).to_owned(),
+        }
+    }
+
+    pub(crate) fn set_centerline_setting(&mut self, name: &str, value: &str) -> Result<String, String> {
+        let Some(layout) = self.current_layout_object_handle() else { return Err("No active layout.".to_owned()); };
+        if name == "CENTERLTYPE"
+            && !value.eq_ignore_ascii_case("Current")
+            && !self.document.line_types.contains(value)
+        {
+            return Err(format!("CENTERLTYPE: linetype \"{value}\" is not loaded."));
+        }
+        if name == "CENTERLTYPEFILE" && !value.trim().is_empty() {
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                let source = std::fs::read_to_string(value)
+                    .map_err(|error| format!("CENTERLTYPEFILE: {error}"))?;
+                crate::io::linetypes::populate_document_from_source(
+                    &mut self.document,
+                    &source,
+                );
+            }
+            #[cfg(target_arch = "wasm32")]
+            return Err("CENTERLTYPEFILE is unavailable in the web build.".to_owned());
+        }
+        self.document.ensure_xrecord(layout, SETTINGS_RECORD);
+        let record = self.document.xrecord_mut(layout, SETTINGS_RECORD).ok_or_else(|| "Cannot store centerline settings.".to_owned())?;
+        let (code, replacement, display) = match name {
+            "CENTEREXE" => {
+                let number = value.parse::<f64>().map_err(|_| "CENTEREXE requires a non-negative number.".to_owned())?;
+                if !number.is_finite() || number < 0.0 { return Err("CENTEREXE requires a non-negative number.".to_owned()); }
+                (40, XRecordValue::Double(number), number.to_string())
+            }
+            "CENTERLAYER" => (1, XRecordValue::String(value.to_owned()), value.to_owned()),
+            "CENTERLTYPE" => (2, XRecordValue::String(value.to_owned()), value.to_owned()),
+            "CENTERLTSCALE" => {
+                let number = value.parse::<f64>().map_err(|_| "CENTERLTSCALE requires a positive number.".to_owned())?;
+                if !number.is_finite() || number <= 0.0 { return Err("CENTERLTSCALE requires a positive number.".to_owned()); }
+                (41, XRecordValue::Double(number), number.to_string())
+            }
+            "CENTERLTYPEFILE" => (3, XRecordValue::String(value.to_owned()), value.to_owned()),
+            _ => return Err(format!("Unknown centerline setting: {name}")),
+        };
+        if let Some(entry) = record.entries.iter_mut().find(|entry| entry.code == code) {
+            entry.value = replacement;
+        } else {
+            record.entries.push(XRecordEntry { code, value: replacement });
+        }
+        Ok(format!("{name} = {display}"))
+    }
+
+    pub(crate) fn refresh_associative_centerlines(&mut self, changes: &[(Handle, ChangeKind)]) -> Vec<(Handle, ChangeKind)> {
+        let changed: rustc_hash::FxHashSet<_> = changes.iter().map(|(handle, _)| *handle).collect();
+        if changed.is_empty() { return Vec::new(); }
+        let candidates: Vec<_> = self.document.entities().filter_map(|entity| {
+            let EntityType::Line(line) = entity else { return None; };
+            let association = CenterLineAssociation::read(&line.common.extended_data)?;
+            (association.associated && (changed.contains(&association.first.handle) || changed.contains(&association.second.handle)))
+                .then_some((line.common.handle, association))
+        }).collect();
+        let mut result = Vec::new();
+        for (handle, mut association) in candidates {
+            if self.is_recording_undo() {
+                let before = self.document.get_entity_arc(handle);
+                self.record_undo_before(handle, before);
+            }
+            let refreshed = resolve_source(&self.document, &association.first)
+                .zip(resolve_source(&self.document, &association.second))
+                .and_then(|(first, second)| construct_line(first, second, &association));
+            let Some(mut new_line) = refreshed else {
+                association.associated = false;
+                if let Some(EntityType::Line(line)) = self.document.get_entity_mut(handle) {
+                    association.write(&mut line.common.extended_data);
+                    result.push((handle, ChangeKind::Modified));
+                }
+                continue;
+            };
+            if let Some(EntityType::Line(line)) = self.document.get_entity_mut(handle) {
+                new_line.common = line.common.clone();
+                *line = new_line;
+                result.push((handle, ChangeKind::Modified));
+            }
+        }
+        result
+    }
+
+    pub(crate) fn reset_centerlines(&mut self, handles: &[Handle]) -> usize {
+        let extension = self.centerline_settings().extension;
+        let candidates: Vec<_> = handles.iter().filter_map(|handle| {
+            let EntityType::Line(line) = self.document.get_entity(*handle)? else { return None; };
+            let mut association = CenterLineAssociation::read(&line.common.extended_data)?;
+            association.start_extension = extension;
+            association.end_extension = extension;
+            rebuild_line(&self.document, &association).map(|line| (*handle, association, line))
+        }).collect();
+        for (handle, association, rebuilt) in &candidates {
+            if self.is_recording_undo() {
+                let before = self.document.get_entity_arc(*handle);
+                self.record_undo_before(*handle, before);
+            }
+            if let Some(EntityType::Line(line)) = self.document.get_entity_mut(*handle) {
+                let mut rebuilt = rebuilt.clone();
+                rebuilt.common = line.common.clone();
+                association.write(&mut rebuilt.common.extended_data);
+                *line = rebuilt;
+            }
+        }
+        if !candidates.is_empty() {
+            let changes: Vec<_> = candidates.iter().map(|(handle, _, _)| (*handle, ChangeKind::Modified)).collect();
+            self.bump_entities(&changes);
+        }
+        candidates.len()
+    }
+
+    pub(crate) fn set_centerline_association(&mut self, handles: &[Handle], associated: bool) -> usize {
+        let candidates: Vec<_> = handles.iter().filter_map(|handle| {
+            let EntityType::Line(line) = self.document.get_entity(*handle)? else { return None; };
+            let mut association = CenterLineAssociation::read(&line.common.extended_data)?;
+            association.associated = associated;
+            let rebuilt = associated.then(|| rebuild_line(&self.document, &association)).flatten();
+            (!associated || rebuilt.is_some()).then_some((*handle, association, rebuilt))
+        }).collect();
+        for (handle, association, rebuilt) in &candidates {
+            if self.is_recording_undo() {
+                let before = self.document.get_entity_arc(*handle);
+                self.record_undo_before(*handle, before);
+            }
+            if let Some(EntityType::Line(line)) = self.document.get_entity_mut(*handle) {
+                if let Some(mut rebuilt) = rebuilt.clone() {
+                    rebuilt.common = line.common.clone();
+                    association.write(&mut rebuilt.common.extended_data);
+                    *line = rebuilt;
+                } else {
+                    association.write(&mut line.common.extended_data);
+                }
+            }
+        }
+        if !candidates.is_empty() {
+            let changes: Vec<_> = candidates.iter().map(|(handle, _, _)| (*handle, ChangeKind::Modified)).collect();
+            self.bump_entities(&changes);
+        }
+        candidates.len()
+    }
+}

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -21,6 +21,7 @@ pub mod view;
 // blocks and/or free functions). Pure text-move from the original mod.rs.
 mod boundary;
 mod camera_ops;
+pub(crate) mod centerline;
 mod entity;
 mod group_layer;
 mod layout;
@@ -2393,6 +2394,11 @@ impl Scene {
             self.associative_hatch_source_cache.borrow_mut().take();
         }
         let mut changes = changes.to_vec();
+        for change in self.refresh_associative_centerlines(&changes) {
+            if !changes.iter().any(|(handle, _)| *handle == change.0) {
+                changes.push(change);
+            }
+        }
         for change in self.refresh_associative_hatches(&changes) {
             if !changes.iter().any(|(handle, _)| *handle == change.0) {
                 changes.push(change);


### PR DESCRIPTION
1) Accept Line and linear LwPolyline/2D Polyline segments, resolve the clicked segment, and use both pick locations to construct the intended finite midline or angular bisector.

2) Preserve both source references, segment indices, construction plane, independent extensions, length adjustments, and association state; regenerate the centerline whenever either source changes and detach safely when a source becomes invalid.

3) Replace generic Line geometry rows with centerline-specific editable start/end extensions, length, and association state; add separate square length grips and directional triangle extension grips.

4) Add CENTERRESET, CENTERREASSOCIATE, and CENTERDISASSOCIATE for selected centerlines, including undo-aware updates.

5) Add drawing-persisted CENTEREXE, CENTERLAYER, CENTERLTYPE, CENTERLTSCALE, and CENTERLTYPEFILE settings. Custom linetype files are parsed into the drawing and selected linetypes are validated.

6) Route the finite-segment geometry through cadkernel PR #4 and persistence through cadcodec PR #7; keep every workspace consumer on the same dependency revisions.

7) Correct the shared defaults and validation: use CENTER2 as the default centre linetype, allow every finite non-zero centre linetype scale, and choose the default extension from the drawing unit system.

Dependencies:
- https://github.com/HakanSeven12/cadcodec/pull/7
- https://github.com/HakanSeven12/cadkernel/pull/4
