### PR TITLE
Align circle creation and editing behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,7 @@ checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
 [[package]]
 name = "acadrust"
 version = "0.4.1"
-source = "git+https://github.com/HakanSeven12/cadcodec.git?rev=0908da7#0908da7b6e4f702a6c78359a57f53e2b79cf39eb"
+source = "git+https://github.com/ramox81/cadcodec.git?rev=1ed82ad#1ed82ad1c1bb3c1732d6cc3e4ec22a2a1526ed7b"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ glam = { version = "0.33", features = ["bytemuck"] }
 rfd = "0.17"
 clap = { version = "4", features = ["derive"] }
 env_logger = "0.11"
-acadrust = { git = "https://github.com/HakanSeven12/cadcodec.git", rev = "0908da7", features = ["serde"] }
+acadrust = { git = "https://github.com/ramox81/cadcodec.git", rev = "1ed82ad", features = ["serde"] }
 cadkernel = { git = "https://github.com/HakanSeven12/cadkernel.git", rev = "ebeb2ec", features = ["acis", "offset"] }
 dwg-thumbnailer = { path = "crates/dwg-thumbnailer" }
 flate2 = "1"
@@ -59,6 +59,9 @@ ashpd = { version = "0.13.13", default-features = false, features = ["async-io",
 [patch.crates-io]
 iced_core = { git = "https://github.com/iced-rs/iced.git", rev = "23604ff22ab0aad9e00b9327cb7b8546ed84db39" }
 iced_widget = { git = "https://github.com/iced-rs/iced.git", rev = "23604ff22ab0aad9e00b9327cb7b8546ed84db39" }
+
+[patch."https://github.com/HakanSeven12/cadcodec.git"]
+acadrust = { git = "https://github.com/ramox81/cadcodec.git", rev = "1ed82ad" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 ocs_plugin_api = { path = "crates/ocs_plugin_api", features = ["host"] }

--- a/crates/ocs_plugin_api/Cargo.toml
+++ b/crates/ocs_plugin_api/Cargo.toml
@@ -14,7 +14,7 @@ serde = { version = "1", features = ["derive"] }
 # Pulled in only by the `host` feature, which adds the `acadrust`-typed
 # `HostApi` runtime surface. The default crate stays dependency-free so engine
 # crates and external tooling can depend on the manifest/ribbon contract cheaply.
-acadrust = { git = "https://github.com/HakanSeven12/cadcodec.git", rev = "0908da7", optional = true, features = ["serde"] }
+acadrust = { git = "https://github.com/ramox81/cadcodec.git", rev = "1ed82ad", optional = true, features = ["serde"] }
 
 # Runtime IPC and serialization (host feature only).
 interprocess = { version = "2", optional = true }
@@ -37,7 +37,7 @@ serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 cargo-lock = "11"
 # acadrust is scanned at build time to generate the embedded type registry.
-acadrust = { git = "https://github.com/HakanSeven12/cadcodec.git", rev = "0908da7", features = ["serde"] }
+acadrust = { git = "https://github.com/ramox81/cadcodec.git", rev = "1ed82ad", features = ["serde"] }
 
 [dev-dependencies]
 serde_json = "1"

--- a/crates/ocs_web_worker/Cargo.toml
+++ b/crates/ocs_web_worker/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-acadrust = { git = "https://github.com/HakanSeven12/cadcodec.git", rev = "0908da7", features = ["serde"] }
+acadrust = { git = "https://github.com/ramox81/cadcodec.git", rev = "1ed82ad", features = ["serde"] }
 bincode = "1.3"
 serde = { version = "1", features = ["derive"] }
 console_error_panic_hook = "0.1"

--- a/src/entities/circle.rs
+++ b/src/entities/circle.rs
@@ -25,8 +25,10 @@ fn to_render(circle: &Circle) -> RenderEntity {
     // definition answers here, in the tessellation and in a trim.
     let curve = crate::entities::curve::circle_curve(circle);
     let snap_pts = crate::entities::curve::snap_from(&curve).snap_pts;
-    let tangent = TangentGeom::Circle {
+    let tangent = TangentGeom::PlanarCircle {
         center: [cwx as f32, cwy as f32, cwz as f32],
+        axis_x: [ax.0 as f32, ax.1 as f32, ax.2 as f32],
+        axis_y: [ay.0 as f32, ay.1 as f32, ay.2 as f32],
         radius: rf,
     };
 

--- a/src/entities/circle.rs
+++ b/src/entities/circle.rs
@@ -95,26 +95,31 @@ fn to_render(circle: &Circle) -> RenderEntity {
 }
 
 fn grips(circle: &Circle) -> Vec<GripDef> {
-    let ctr = glam::DVec3::new(circle.center.x, circle.center.y, circle.center.z);
+    let center = circle.center_wcs();
+    let (axis_x, axis_y) = circle.axes_wcs();
+    let ctr = glam::DVec3::new(center.x, center.y, center.z);
+    let axis_x = glam::DVec3::new(axis_x.x, axis_x.y, axis_x.z);
+    let axis_y = glam::DVec3::new(axis_y.x, axis_y.y, axis_y.z);
     let r = circle.radius;
     vec![
         center_grip(0, ctr),
-        square_grip(1, ctr + glam::DVec3::new(r, 0.0, 0.0)),
-        square_grip(2, ctr + glam::DVec3::new(0.0, r, 0.0)),
-        square_grip(3, ctr - glam::DVec3::new(r, 0.0, 0.0)),
-        square_grip(4, ctr - glam::DVec3::new(0.0, r, 0.0)),
+        square_grip(1, ctr + axis_x * r),
+        square_grip(2, ctr + axis_y * r),
+        square_grip(3, ctr - axis_x * r),
+        square_grip(4, ctr - axis_y * r),
     ]
 }
 
 fn properties(circle: &Circle) -> Vec<PropSection> {
     use std::f64::consts::PI;
     let r = circle.radius;
+    let center = circle.center_wcs();
     vec![PropSection {
         title: t!("Geometry").into_owned(),
         props: vec![
-            edit(t!("Center X").as_ref(), "center_x", circle.center.x),
-            edit(t!("Center Y").as_ref(), "center_y", circle.center.y),
-            edit(t!("Center Z").as_ref(), "center_z", circle.center.z),
+            edit(t!("Center X").as_ref(), "center_x", center.x),
+            edit(t!("Center Y").as_ref(), "center_y", center.y),
+            edit(t!("Center Z").as_ref(), "center_z", center.z),
             edit(t!("Radius").as_ref(), "radius", r),
             edit(t!("Diameter").as_ref(), "diameter", r * 2.0),
             edit(t!("Circumference").as_ref(), "circumference", 2.0 * PI * r),
@@ -132,9 +137,22 @@ fn apply_geom_prop(circle: &mut Circle, field: &str, value: &str) {
         return;
     };
     match field {
-        "center_x" => circle.center.x = v,
-        "center_y" => circle.center.y = v,
-        "center_z" => circle.center.z = v,
+        "center_x" | "center_y" | "center_z" => {
+            let normal = (circle.normal.x, circle.normal.y, circle.normal.z);
+            let center = circle.center_wcs();
+            let (mut x, mut y, mut z) = (center.x, center.y, center.z);
+            match field {
+                "center_x" => x = v,
+                "center_y" => y = v,
+                "center_z" => z = v,
+                _ => {}
+            }
+            let (ox, oy, oz) =
+                crate::scene::view::transform::wcs_point_to_ocs((x, y, z), normal);
+            circle.center.x = ox;
+            circle.center.y = oy;
+            circle.center.z = oz;
+        }
         "radius" if v > 0.0 => circle.radius = v,
         "diameter" if v > 0.0 => circle.radius = v / 2.0,
         "circumference" if v > 0.0 => circle.radius = v / (2.0 * PI),
@@ -146,19 +164,31 @@ fn apply_geom_prop(circle: &mut Circle, field: &str, value: &str) {
 fn apply_grip(circle: &mut Circle, grip_id: usize, apply: GripApply) {
     match (grip_id, apply) {
         (0, GripApply::Absolute(p)) => {
-            circle.center.x = p.x as f64;
-            circle.center.y = p.y as f64;
-            circle.center.z = p.z as f64;
+            let (x, y, z) = crate::scene::view::transform::wcs_point_to_ocs(
+                (p.x, p.y, p.z),
+                (circle.normal.x, circle.normal.y, circle.normal.z),
+            );
+            circle.center.x = x;
+            circle.center.y = y;
+            circle.center.z = z;
         }
         (0, GripApply::Translate(d)) => {
-            circle.center.x += d.x as f64;
-            circle.center.y += d.y as f64;
-            circle.center.z += d.z as f64;
+            let (x, y, z) = crate::scene::view::transform::wcs_point_to_ocs(
+                (d.x, d.y, d.z),
+                (circle.normal.x, circle.normal.y, circle.normal.z),
+            );
+            circle.center.x += x;
+            circle.center.y += y;
+            circle.center.z += z;
         }
         (1..=4, GripApply::Absolute(p)) => {
-            let dx = p.x - circle.center.x;
-            let dy = p.y - circle.center.y;
-            circle.radius = (dx * dx + dy * dy).sqrt();
+            let plane = crate::entities::curve::circle_curve(circle).plane;
+            if let Some(point) = plane.project([p.x, p.y, p.z]) {
+                let radius = (point[0] - circle.center.x).hypot(point[1] - circle.center.y);
+                if radius > 1.0e-9 {
+                    circle.radius = radius;
+                }
+            }
         }
         _ => {}
     }
@@ -187,11 +217,12 @@ impl crate::entities::traits::MassPropsCalc for Circle {
     fn mass_props(&self) -> crate::entities::traits::MassProps {
         use std::f64::consts::{PI, TAU};
         let r = self.radius;
+        let center = self.center_wcs();
         crate::entities::traits::MassProps {
             area: PI * r * r,
             perimeter: TAU * r,
-            cx: self.center.x,
-            cy: self.center.y,
+            cx: center.x,
+            cy: center.y,
         }
     }
 }

--- a/src/modules/draw/defaults.rs
+++ b/src/modules/draw/defaults.rs
@@ -5,7 +5,6 @@ use std::cell::Cell;
 
 thread_local! {
     static CIRCLE_RADIUS:   Cell<f64> = Cell::new(1.0);
-    static CIRCLE_DIAM:     Cell<f64> = Cell::new(2.0);
     static ROTATE_ANGLE:    Cell<f64> = Cell::new(0.0);   // degrees
     static SCALE_FACTOR:    Cell<f64> = Cell::new(1.0);
     static OFFSET_DIST:     Cell<f64> = Cell::new(1.0);
@@ -34,7 +33,13 @@ macro_rules! accessors {
 }
 
 accessors!(get_circle_radius, set_circle_radius, CIRCLE_RADIUS);
-accessors!(get_circle_diam, set_circle_diam, CIRCLE_DIAM);
+pub fn get_circle_diam() -> f64 {
+    get_circle_radius() * 2.0
+}
+
+pub fn set_circle_diam(value: f64) {
+    set_circle_radius(value * 0.5);
+}
 accessors!(get_rotate_angle, set_rotate_angle, ROTATE_ANGLE);
 accessors!(get_scale_factor, set_scale_factor, SCALE_FACTOR);
 accessors!(get_offset_dist, set_offset_dist, OFFSET_DIST);

--- a/src/modules/draw/draw/circle.rs
+++ b/src/modules/draw/draw/circle.rs
@@ -538,6 +538,7 @@ impl CadCommand for Circle3PCommand {
         let (a, b, c) = (self.pts[0], self.pts[1], self.pts[2]);
         match circumcircle(a, b, c, self.plane) {
             Some((center, radius)) => {
+                defaults::set_circle_radius(radius);
                 CmdResult::CommitAndExit(make_circle(center, radius, self.plane))
             }
             None => {
@@ -857,6 +858,7 @@ fn ttt_solve_sign(objs: &[TangentObject; 3], eps: &[f64; 3]) -> Vec<(DVec3, f64)
 
 pub struct CircleTTRCommand {
     step: StepTTR,
+    default_r: f64,
     plane: WorkingPlane,
 }
 
@@ -878,8 +880,43 @@ impl CircleTTRCommand {
     pub fn new() -> Self {
         Self {
             step: StepTTR::First,
+            default_r: defaults::get_circle_radius(),
             plane: WorkingPlane::default(),
         }
+    }
+
+    fn result_for_radius(&self, radius: f64) -> CmdResult {
+        if radius <= 1.0e-9 {
+            return CmdResult::NeedPoint;
+        }
+        let StepTTR::Radius {
+            obj1,
+            obj2,
+            hit1,
+            hit2,
+        } = &self.step
+        else {
+            return CmdResult::NeedPoint;
+        };
+        let hint = (*hit1 + *hit2) * 0.5;
+        let candidates = ttr_candidates(*obj1, *obj2, radius);
+        let Some(center) = best_of(&candidates, hint) else {
+            return CmdResult::NeedPoint;
+        };
+        defaults::set_circle_radius(radius);
+        CmdResult::CommitAndExit(make_circle(
+            self.plane.to_world(center),
+            radius,
+            self.plane,
+        ))
+    }
+
+    fn radius_from_point(&self, point: DVec3) -> Option<f64> {
+        let StepTTR::Radius { hit2, .. } = &self.step else {
+            return None;
+        };
+        let point = self.plane.to_local(point);
+        Some((point.x - hit2.x).hypot(point.y - hit2.y))
     }
 }
 
@@ -912,12 +949,18 @@ impl CadCommand for CircleTTRCommand {
         match &self.step {
             StepTTR::First => crate::t!("CIRCLE TTR  Select first tangent object:").into_owned(),
             StepTTR::Second { .. } => crate::t!("CIRCLE TTR  Select second tangent object:").into_owned(),
-            StepTTR::Radius { .. } => crate::t!("CIRCLE TTR  Specify radius:").into_owned(),
+            StepTTR::Radius { .. } => format!(
+                "{} <{:.4}>",
+                crate::t!("CIRCLE TTR  Specify radius:"),
+                self.default_r
+            ),
         }
     }
 
-    fn on_point(&mut self, _pt: DVec3) -> CmdResult {
-        CmdResult::NeedPoint
+    fn on_point(&mut self, pt: DVec3) -> CmdResult {
+        self.radius_from_point(pt)
+            .map(|radius| self.result_for_radius(radius))
+            .unwrap_or(CmdResult::NeedPoint)
     }
 
     fn on_tangent_point(&mut self, obj: TangentObject, hit: DVec3) -> CmdResult {
@@ -946,41 +989,57 @@ impl CadCommand for CircleTTRCommand {
     }
 
     fn on_text_input(&mut self, text: &str) -> Option<CmdResult> {
-        let r: f64 = text.trim().parse().ok()?;
+        let r: f64 = text.trim().replace(',', ".").parse().ok()?;
         if r <= 0.0 {
-            return Some(CmdResult::Cancel);
+            return Some(CmdResult::NeedPoint);
         }
-        if let StepTTR::Radius {
+        matches!(self.step, StepTTR::Radius { .. }).then(|| self.result_for_radius(r))
+    }
+
+    fn on_enter(&mut self) -> CmdResult {
+        if matches!(self.step, StepTTR::Radius { .. }) {
+            self.result_for_radius(self.default_r)
+        } else {
+            CmdResult::Cancel
+        }
+    }
+    fn on_escape(&mut self) -> CmdResult {
+        CmdResult::Cancel
+    }
+    fn on_mouse_move(&mut self, pt: DVec3) -> Option<WireModel> {
+        let radius = self.radius_from_point(pt)?;
+        let StepTTR::Radius {
             obj1,
             obj2,
             hit1,
             hit2,
         } = &self.step
-        {
-            let hint = (*hit1 + *hit2) * 0.5;
-            let candidates = ttr_candidates(*obj1, *obj2, r);
-            if let Some(center) = best_of(&candidates, hint) {
-                Some(CmdResult::CommitAndExit(make_circle(
-                    self.plane.to_world(center),
-                    r,
-                    self.plane,
-                )))
-            } else {
-                Some(CmdResult::Cancel)
-            }
-        } else {
-            None
-        }
+        else {
+            return None;
+        };
+        let center = best_of(&ttr_candidates(*obj1, *obj2, radius), (*hit1 + *hit2) * 0.5)?;
+        Some(circle_wire(
+            self.plane.to_world(center),
+            radius,
+            self.plane,
+        ))
     }
 
-    fn on_enter(&mut self) -> CmdResult {
-        CmdResult::Cancel
+    fn dyn_spec(&self) -> Option<crate::command::DynSpec> {
+        use crate::command::{DynAnchor, DynFieldSpec, DynGuide, DynRole, DynSpec};
+        let StepTTR::Radius { hit2, .. } = &self.step else {
+            return None;
+        };
+        Some(DynSpec {
+            anchor: DynAnchor::Point(self.plane.to_world(*hit2)),
+            fields: vec![DynFieldSpec::new(DynRole::Radius)],
+            guide: DynGuide::Radius,
+            ref_point: None,
+        })
     }
-    fn on_escape(&mut self) -> CmdResult {
-        CmdResult::Cancel
-    }
-    fn on_mouse_move(&mut self, _pt: DVec3) -> Option<WireModel> {
-        None
+
+    fn dyn_live_value(&self, cursor: DVec3) -> Option<f64> {
+        self.radius_from_point(cursor)
     }
 }
 
@@ -1036,11 +1095,14 @@ impl CadCommand for CircleTTTCommand {
         let hint = self.hits.iter().fold(DVec3::ZERO, |a, &b| a + b) / 3.0;
         let candidates = ttt_candidates(self.objs[0], self.objs[1], self.objs[2]);
         match best_circle_of(&candidates, hint) {
-            Some((center, r)) => CmdResult::CommitAndExit(make_circle(
-                self.plane.to_world(center),
-                r,
-                self.plane,
-            )),
+            Some((center, r)) => {
+                defaults::set_circle_radius(r);
+                CmdResult::CommitAndExit(make_circle(
+                    self.plane.to_world(center),
+                    r,
+                    self.plane,
+                ))
+            }
             None => {
                 self.objs.pop();
                 self.hits.pop();

--- a/src/modules/draw/draw/circle.rs
+++ b/src/modules/draw/draw/circle.rs
@@ -65,7 +65,7 @@ pub const ICON: IconKind = ICON_CR;
 
 fn circle_wire(center: DVec3, radius: f64, plane: WorkingPlane) -> WireModel {
     let segs = 64u32;
-    let mut pts: Vec<[f64; 3]> = (0..=segs)
+    let pts: Vec<[f64; 3]> = (0..=segs)
         .map(|i| {
             let a = (i as f64) * TAU / segs as f64;
             let point = center
@@ -77,9 +77,6 @@ fn circle_wire(center: DVec3, radius: f64, plane: WorkingPlane) -> WireModel {
             [point.x, point.y, point.z]
         })
         .collect();
-    if let Some(first) = pts.first().cloned() {
-        pts.push(first);
-    }
     WireModel::solid_f64("rubber_band".into(), pts, WireModel::CYAN, false)
 }
 

--- a/src/modules/draw/draw/circle.rs
+++ b/src/modules/draw/draw/circle.rs
@@ -151,6 +151,7 @@ pub struct CircleCommand {
 enum StepCR {
     Center,
     Radius(DVec3),
+    Diameter(DVec3),
 }
 
 impl CircleCommand {
@@ -186,6 +187,11 @@ impl CadCommand for CircleCommand {
                 )
                 .into_owned()
             }
+            StepCR::Diameter(_) => crate::tf!(
+                "CIRCLE  Specify diameter  <{:.4}>:",
+                self.default_r * 2.0
+            )
+            .into_owned(),
         }
     }
 
@@ -196,15 +202,16 @@ impl CadCommand for CircleCommand {
                 CmdOption::new("3P", "3P"),
                 CmdOption::new("2P", "2P"),
                 CmdOption::new("Ttr", "TTR"),
-                CmdOption::new("Ttt", "TTT"),
+            ],
+            StepCR::Radius(_) => vec![
                 CmdOption::new(t!("Diameter").as_ref(), "D"),
             ],
-            StepCR::Radius(_) => vec![],
+            StepCR::Diameter(_) => vec![],
         }
     }
 
     fn point_step_accepts_keywords(&self) -> bool {
-        matches!(self.step, StepCR::Center)
+        !matches!(self.step, StepCR::Diameter(_))
     }
     fn on_point(&mut self, pt: DVec3) -> CmdResult {
         match &self.step {
@@ -214,27 +221,49 @@ impl CadCommand for CircleCommand {
             }
             StepCR::Radius(c) => {
                 let r = plane_distance(*c, pt, self.plane);
+                if r <= 1.0e-9 {
+                    return CmdResult::NeedPoint;
+                }
                 defaults::set_circle_radius(r);
                 CmdResult::CommitAndExit(make_circle(*c, r, self.plane))
+            }
+            StepCR::Diameter(c) => {
+                let radius = plane_distance(*c, pt, self.plane);
+                if radius <= 1.0e-9 {
+                    return CmdResult::NeedPoint;
+                }
+                defaults::set_circle_radius(radius);
+                CmdResult::CommitAndExit(make_circle(*c, radius, self.plane))
             }
         }
     }
     fn on_enter(&mut self) -> CmdResult {
-        if let StepCR::Radius(c) = &self.step {
-            let c = *c;
-            let r = self.default_r;
-            return CmdResult::CommitAndExit(make_circle(c, r, self.plane));
+        match self.step {
+            StepCR::Radius(center) => {
+                CmdResult::CommitAndExit(make_circle(center, self.default_r, self.plane))
+            }
+            StepCR::Diameter(center) => {
+                CmdResult::CommitAndExit(make_circle(center, self.default_r, self.plane))
+            }
+            StepCR::Center => CmdResult::Cancel,
         }
-        CmdResult::Cancel
     }
     fn on_escape(&mut self) -> CmdResult {
         CmdResult::Cancel
     }
     fn on_mouse_move(&mut self, pt: DVec3) -> Option<WireModel> {
-        if let StepCR::Radius(c) = &self.step {
-            Some(circle_wire(*c, plane_distance(*c, pt, self.plane), self.plane))
-        } else {
-            None
+        match self.step {
+            StepCR::Radius(center) => Some(circle_wire(
+                center,
+                plane_distance(center, pt, self.plane),
+                self.plane,
+            )),
+            StepCR::Diameter(center) => Some(circle_wire(
+                center,
+                plane_distance(center, pt, self.plane),
+                self.plane,
+            )),
+            StepCR::Center => None,
         }
     }
     fn on_text_input(&mut self, text: &str) -> Option<CmdResult> {
@@ -245,10 +274,14 @@ impl CadCommand for CircleCommand {
                 "3P" => Some(CmdResult::Dispatch("CIRCLE_3P".into())),
                 "2P" => Some(CmdResult::Dispatch("CIRCLE_2P".into())),
                 "T" | "TTR" => Some(CmdResult::Dispatch("CIRCLE_TTR".into())),
-                "TTT" => Some(CmdResult::Dispatch("CIRCLE_TTT".into())),
-                "D" | "DIAMETER" => Some(CmdResult::Dispatch("CIRCLE_CD".into())),
                 _ => None,
             };
+        }
+        if let StepCR::Radius(center) = &self.step {
+            if matches!(text.trim().to_uppercase().as_str(), "D" | "DIAMETER") {
+                self.step = StepCR::Diameter(*center);
+                return Some(CmdResult::NeedPoint);
+            }
         }
         if let StepCR::Radius(c) = &self.step {
             let r: f64 = text.trim().replace(',', ".").parse().ok()?;
@@ -257,12 +290,23 @@ impl CadCommand for CircleCommand {
                 return Some(CmdResult::CommitAndExit(make_circle(*c, r, self.plane)));
             }
         }
+        if let StepCR::Diameter(c) = &self.step {
+            let diameter: f64 = text.trim().replace(',', ".").parse().ok()?;
+            if diameter > 0.0 {
+                defaults::set_circle_diam(diameter);
+                return Some(CmdResult::CommitAndExit(make_circle(
+                    *c,
+                    diameter * 0.5,
+                    self.plane,
+                )));
+            }
+        }
         None
     }
     fn dyn_field(&self) -> DynField {
         match self.step {
             StepCR::Center => DynField::Point,
-            StepCR::Radius(_) => DynField::Distance,
+            StepCR::Radius(_) | StepCR::Diameter(_) => DynField::Distance,
         }
     }
 
@@ -276,6 +320,12 @@ impl CadCommand for CircleCommand {
             StepCR::Radius(c) => Some(DynSpec {
                 anchor: DynAnchor::Point(c),
                 fields: vec![DynFieldSpec::new(DynRole::Radius)],
+                guide: DynGuide::Radius,
+                ref_point: None,
+            }),
+            StepCR::Diameter(c) => Some(DynSpec {
+                anchor: DynAnchor::Point(c),
+                fields: vec![DynFieldSpec::new(DynRole::Diameter)],
                 guide: DynGuide::Radius,
                 ref_point: None,
             }),
@@ -312,28 +362,33 @@ impl CadCommand for CircleCDCommand {
     fn prompt(&self) -> String {
         match &self.step {
             StepCR::Center => t!("CIRCLE CD  Specify center point:").into_owned(),
-            StepCR::Radius(c) => crate::tf!(
+            StepCR::Diameter(c) => crate::tf!(
                 "CIRCLE CD  Specify diameter or type value  <{:.4}>  [center ({:.3},{:.3})]:",
                 self.default_d, c.x, c.y
             )
             .into_owned(),
+            StepCR::Radius(_) => unreachable!(),
         }
     }
     fn on_point(&mut self, pt: DVec3) -> CmdResult {
         match &self.step {
             StepCR::Center => {
-                self.step = StepCR::Radius(pt);
+                self.step = StepCR::Diameter(pt);
                 CmdResult::NeedPoint
             }
-            StepCR::Radius(c) => {
-                let d = plane_distance(*c, pt, self.plane) * 2.0;
-                defaults::set_circle_diam(d);
-                CmdResult::CommitAndExit(make_circle(*c, d / 2.0, self.plane))
+            StepCR::Diameter(c) => {
+                let radius = plane_distance(*c, pt, self.plane);
+                if radius <= 1.0e-9 {
+                    return CmdResult::NeedPoint;
+                }
+                defaults::set_circle_radius(radius);
+                CmdResult::CommitAndExit(make_circle(*c, radius, self.plane))
             }
+            StepCR::Radius(_) => unreachable!(),
         }
     }
     fn on_enter(&mut self) -> CmdResult {
-        if let StepCR::Radius(c) = &self.step {
+        if let StepCR::Diameter(c) = &self.step {
             let c = *c;
             let d = self.default_d;
             return CmdResult::CommitAndExit(make_circle(c, d / 2.0, self.plane));
@@ -344,15 +399,18 @@ impl CadCommand for CircleCDCommand {
         CmdResult::Cancel
     }
     fn on_mouse_move(&mut self, pt: DVec3) -> Option<WireModel> {
-        // Preview radius = distance to cursor; on commit that distance becomes the radius (diameter = 2x).
-        if let StepCR::Radius(c) = &self.step {
-            Some(circle_wire(*c, plane_distance(*c, pt, self.plane), self.plane))
+        if let StepCR::Diameter(c) = &self.step {
+            Some(circle_wire(
+                *c,
+                plane_distance(*c, pt, self.plane),
+                self.plane,
+            ))
         } else {
             None
         }
     }
     fn on_text_input(&mut self, text: &str) -> Option<CmdResult> {
-        if let StepCR::Radius(c) = &self.step {
+        if let StepCR::Diameter(c) = &self.step {
             let d: f64 = text.trim().replace(',', ".").parse().ok()?;
             if d > 0.0 {
                 defaults::set_circle_diam(d);
@@ -368,12 +426,13 @@ impl CadCommand for CircleCDCommand {
             StepCR::Center => None,
             // Diameter: the box shows/accepts twice the cursor radius; resolved
             // back to a radius point by the host (role scaling).
-            StepCR::Radius(c) => Some(DynSpec {
+            StepCR::Diameter(c) => Some(DynSpec {
                 anchor: DynAnchor::Point(c),
                 fields: vec![DynFieldSpec::new(DynRole::Diameter)],
                 guide: DynGuide::Radius,
                 ref_point: None,
             }),
+            StepCR::Radius(_) => None,
         }
     }
 }
@@ -418,6 +477,10 @@ impl CadCommand for Circle2PCommand {
             Some(p1) => {
                 let center = (p1 + pt) * 0.5;
                 let radius = plane_distance(p1, pt, self.plane) / 2.0;
+                if radius <= 1.0e-9 {
+                    return CmdResult::NeedPoint;
+                }
+                defaults::set_circle_radius(radius);
                 CmdResult::CommitAndExit(make_circle(center, radius, self.plane))
             }
         }

--- a/src/modules/draw/modify/break_cmd.rs
+++ b/src/modules/draw/modify/break_cmd.rs
@@ -126,8 +126,15 @@ fn break_circle(circle: &acadrust::entities::Circle, p1: DVec3, p2: DVec3) -> Ve
     let cx = circle.center.x;
     let cy = circle.center.y;
 
-    let a1 = angle_on_arc(cx, cy, p1);
-    let a2 = angle_on_arc(cx, cy, p2);
+    let plane = crate::entities::curve::circle_curve(circle).plane;
+    let Some(q1) = plane.project(p1.to_array()) else {
+        return vec![EntityType::Circle(circle.clone())];
+    };
+    let Some(q2) = plane.project(p2.to_array()) else {
+        return vec![EntityType::Circle(circle.clone())];
+    };
+    let a1 = angle_on_arc(cx, cy, DVec3::new(q1[0], q1[1], 0.0));
+    let a2 = angle_on_arc(cx, cy, DVec3::new(q2[0], q2[1], 0.0));
 
     if (a1 - a2).abs() < 0.01 {
         return vec![EntityType::Circle(circle.clone())];
@@ -139,6 +146,7 @@ fn break_circle(circle: &acadrust::entities::Circle, p1: DVec3, p2: DVec3) -> Ve
     arc.common.handle = Handle::NULL;
     arc.center = circle.center.clone();
     arc.radius = circle.radius;
+    arc.thickness = circle.thickness;
     arc.normal = circle.normal.clone();
     arc.start_angle = a2;
     arc.end_angle = a1;

--- a/src/modules/draw/modify/offset.rs
+++ b/src/modules/draw/modify/offset.rs
@@ -105,8 +105,8 @@ fn offset_xline(x: &XLineEnt, dist: f64, side_pt: Vec3) -> Option<EntityType> {
 // ── Circle offset ──────────────────────────────────────────────────────────
 
 fn offset_circle(c: &CircleEnt, dist: f64, side_pt: Vec3) -> Option<EntityType> {
-    let px = side_pt.x as f64;
-    let py = side_pt.y as f64;
+    let plane = crate::entities::curve::circle_curve(c).plane;
+    let [px, py] = plane.project(side_pt.as_dvec3().to_array())?;
     let dc = ((px - c.center.x).powi(2) + (py - c.center.y).powi(2)).sqrt();
 
     let new_r = if dc < c.radius {

--- a/src/scene/cache/block_cache.rs
+++ b/src/scene/cache/block_cache.rs
@@ -1227,7 +1227,8 @@ fn translated_prototype_wire(
                     p2[axis] += delta_f32[axis];
                 }
             }
-            TangentGeom::Circle { center, .. } => {
+            TangentGeom::Circle { center, .. }
+            | TangentGeom::PlanarCircle { center, .. } => {
                 for axis in 0..3 {
                     center[axis] += delta_f32[axis];
                 }
@@ -2280,6 +2281,37 @@ fn transform_tangent(
             TangentGeom::Circle {
                 center: [(c.x) as f32, (c.y) as f32, (c.z) as f32],
                 radius: radius * s,
+            }
+        }
+        TangentGeom::PlanarCircle {
+            center,
+            axis_x,
+            axis_y,
+            radius,
+        } => {
+            let c = t.apply(Vector3::new(
+                center[0] as f64,
+                center[1] as f64,
+                center[2] as f64,
+            ));
+            let x = t.apply_rotation(Vector3::new(
+                axis_x[0] as f64,
+                axis_x[1] as f64,
+                axis_x[2] as f64,
+            ));
+            let y = t.apply_rotation(Vector3::new(
+                axis_y[0] as f64,
+                axis_y[1] as f64,
+                axis_y[2] as f64,
+            ));
+            let scale = (x.length() + y.length()) * 0.5;
+            let x = x.normalize();
+            let y = y.normalize();
+            TangentGeom::PlanarCircle {
+                center: [c.x as f32, c.y as f32, c.z as f32],
+                axis_x: [x.x as f32, x.y as f32, x.z as f32],
+                axis_y: [y.x as f32, y.y as f32, y.z as f32],
+                radius: radius * scale as f32,
             }
         }
     }

--- a/src/scene/model/wire_model.rs
+++ b/src/scene/model/wire_model.rs
@@ -29,8 +29,15 @@ pub enum SnapHint {
 pub enum TangentGeom {
     /// Infinite line through these two world-space points.
     Line { p1: [f32; 3], p2: [f32; 3] },
-    /// Circle/arc.
+    /// Round geometry in the world XY plane.
     Circle { center: [f32; 3], radius: f32 },
+    /// Complete circle in an arbitrary world-space plane.
+    PlanarCircle {
+        center: [f32; 3],
+        axis_x: [f32; 3],
+        axis_y: [f32; 3],
+        radius: f32,
+    },
 }
 
 /// A 1-D entity (line, arc, polyline) represented as an ordered set of

--- a/src/snap.rs
+++ b/src/snap.rs
@@ -1661,6 +1661,73 @@ impl Snapper {
                                 });
                             (w, edge_d * edge_d)
                         }
+                        TangentGeom::PlanarCircle {
+                            center,
+                            axis_x,
+                            axis_y,
+                            radius,
+                        } => {
+                            let cv = Vec3::from(*center);
+                            let ux = Vec3::from(*axis_x).normalize_or_zero();
+                            let uy = Vec3::from(*axis_y).normalize_or_zero();
+                            let r = *radius;
+                            let candidate = self.from_point.and_then(|from| {
+                                let delta = from - cv;
+                                let px = delta.dot(ux);
+                                let py = delta.dot(uy);
+                                let d2 = px * px + py * py;
+                                if d2 <= r * r + 1.0e-6 {
+                                    return None;
+                                }
+                                let base = r * r / d2;
+                                let side = r * (d2 - r * r).sqrt() / d2;
+                                [
+                                    cv + ux * (base * px - side * py)
+                                        + uy * (base * py + side * px),
+                                    cv + ux * (base * px + side * py)
+                                        + uy * (base * py - side * px),
+                                ]
+                                .into_iter()
+                                .min_by(|a, b| {
+                                    let sa = world_to_screen(a.as_dvec3(), view_rot, eye, bounds);
+                                    let sb = world_to_screen(b.as_dvec3(), view_rot, eye, bounds);
+                                    dist2(sa, cursor_screen)
+                                        .total_cmp(&dist2(sb, cursor_screen))
+                                })
+                            });
+                            let fallback = || {
+                                (0..wire.points.len())
+                                    .map(|index| wp_f64(wire, index).as_vec3())
+                                    .filter(|point| point.is_finite())
+                                    .min_by(|a, b| {
+                                        let sa =
+                                            world_to_screen(a.as_dvec3(), view_rot, eye, bounds);
+                                        let sb =
+                                            world_to_screen(b.as_dvec3(), view_rot, eye, bounds);
+                                        dist2(sa, cursor_screen)
+                                            .total_cmp(&dist2(sb, cursor_screen))
+                                    })
+                                    .unwrap_or(cv)
+                            };
+                            let world = candidate.unwrap_or_else(fallback);
+                            let edge_d2 = wire
+                                .points
+                                .windows(2)
+                                .enumerate()
+                                .filter_map(|(index, _)| {
+                                    let a = wp_f64(wire, index);
+                                    let b = wp_f64(wire, index + 1);
+                                    (a.is_finite() && b.is_finite()).then(|| {
+                                        dist2_to_segment(
+                                            cursor_screen,
+                                            world_to_screen(a, view_rot, eye, bounds),
+                                            world_to_screen(b, view_rot, eye, bounds),
+                                        )
+                                    })
+                                })
+                                .fold(f32::INFINITY, f32::min);
+                            (world, edge_d2)
+                        }
                     };
                     let (tier, sub) = (
                         snap_tier(SnapType::Tangent),
@@ -1687,6 +1754,16 @@ impl Snapper {
                                 ),
                                 radius: *radius as f64,
                             },
+                            TangentGeom::PlanarCircle { center, radius, .. } => {
+                                TangentObject::Circle {
+                                    center: glam::DVec3::new(
+                                        center[0] as f64,
+                                        center[1] as f64,
+                                        center[2] as f64,
+                                    ),
+                                    radius: *radius as f64,
+                                }
+                            }
                         };
                         best = Some(SnapResult {
                             world: world_pt.as_dvec3(),


### PR DESCRIPTION
1) Move Diameter to the post-center radius step, keep the ribbon Center/Diameter entry, share one remembered circle size and reject zero-radius pointer input.

2) Keep the remembered size synchronized across center, diameter, two-point, three-point, TTR and TTT workflows; add TTR default acceptance, pointer input, dynamic value and live candidate preview.

3) Show and edit center coordinates in world space, place all five grips in the entity plane and report the mass-properties center consistently.

4) Carry explicit world-space plane axes for complete-circle tangent snapping, including translated and transformed block instances.

5) Project OFFSET and BREAK picks into the circle plane and retain thickness when BREAK converts a circle into an arc.

6) Remove the duplicate preview closing point that created a zero-length segment.

7) Consume the general circle geometry fix from HakanSeven12/cadcodec#9 while overriding the kernel's transitive codec source to the same revision.

Validation: cargo check