### PR TITLE
fix(ltscale): show current value before prompt

### DIFF
--- a/src/app/commands/styleprops.rs
+++ b/src/app/commands/styleprops.rs
@@ -2134,7 +2134,17 @@ impl OpenCADStudio {
             }
             "LTSCALE" => {
                 use crate::command::ValuePromptCommand;
-                let c = ValuePromptCommand::new("LTSCALE", "LTSCALE  new global line-type scale:");
+
+                let current = self.tabs[i].scene.document.header.linetype_scale;
+
+                self.command_line
+                    .push_output(crate::tf!("LTSCALE = {current:.4}").as_ref());
+
+                let c = ValuePromptCommand::new(
+                    "LTSCALE",
+                    "LTSCALE  new global line-type scale:",
+                );
+
                 self.command_line.push_info(&c.prompt());
                 self.tabs[i].active_cmd = Some(Box::new(c));
             }


### PR DESCRIPTION
## Summary

- show the current global linetype scale when running `LTSCALE`
- keep the existing prompt for entering a new value
- leave the existing LTSCALE update and geometry refresh behavior unchanged

## Behavior

Before:

```text
LTSCALE  new global line-type scale:
```

Now:

```text
LTSCALE = 1.0000
LTSCALE  new global line-type scale:
```

The displayed value reflects the current drawing setting.

## Testing

Manually verified:

- current LTSCALE value is displayed before the input prompt
- changing LTSCALE updates the reported value
- decimal values work correctly
- invalid and non-positive values are rejected
- cancelling the command does not change the value
- `SETVAR LTSCALE` continues to work
- linetype geometry updates immediately after changing LTSCALE
- saved LTSCALE values persist after reopening the drawing

Fixes #858