### PR TITLE
Complete aligned dimension workflow and properties

### DIFF
--- a/src/app/command_driver.rs
+++ b/src/app/command_driver.rs
@@ -801,19 +801,24 @@ impl OpenCADStudio {
                 // the structure snapshot fallback.
                 let delta_safe = self.delta_add_safe(i, &entity);
                 let pending = self.begin_undo(i, label, 1, delta_safe);
-                let is_linear_dimension = matches!(
+                let is_associative_dimension = matches!(
                     entity,
-                    acadrust::EntityType::Dimension(acadrust::entities::Dimension::Linear(_))
+                    acadrust::EntityType::Dimension(
+                        acadrust::entities::Dimension::Linear(_)
+                            | acadrust::entities::Dimension::Aligned(_)
+                    )
                 );
+                let association_enabled =
+                    self.tabs[i].scene.document.header.dimension_associativity == 2;
                 let committed = self.commit_entity_handle(entity);
-                if is_linear_dimension {
+                if is_associative_dimension && association_enabled {
                     if let Some(handle) = committed {
                         let sources = self.tabs[i]
                             .scene
-                            .infer_linear_dimension_sources(handle);
+                            .infer_dimension_sources(handle);
                         self.tabs[i]
                             .scene
-                            .attach_linear_dimension_association(handle, sources);
+                            .attach_dimension_association(handle, sources);
                     }
                 }
                 self.tabs[i].dirty = true;
@@ -1205,19 +1210,24 @@ impl OpenCADStudio {
                 let label = self.history_label_from_active_cmd(i, "ENTITY");
                 let delta_safe = self.delta_add_safe(i, &entity);
                 let pending = self.begin_undo(i, label, 1, delta_safe);
-                let is_linear_dimension = matches!(
+                let is_associative_dimension = matches!(
                     entity,
-                    acadrust::EntityType::Dimension(acadrust::entities::Dimension::Linear(_))
+                    acadrust::EntityType::Dimension(
+                        acadrust::entities::Dimension::Linear(_)
+                            | acadrust::entities::Dimension::Aligned(_)
+                    )
                 );
+                let association_enabled =
+                    self.tabs[i].scene.document.header.dimension_associativity == 2;
                 let committed = self.commit_entity_handle(entity);
-                if is_linear_dimension {
+                if is_associative_dimension && association_enabled {
                     if let Some(handle) = committed {
                         let sources = self.tabs[i]
                             .scene
-                            .infer_linear_dimension_sources(handle);
+                            .infer_dimension_sources(handle);
                         self.tabs[i]
                             .scene
-                            .attach_linear_dimension_association(handle, sources);
+                            .attach_dimension_association(handle, sources);
                     }
                 }
                 self.tabs[i].dirty = true;
@@ -1229,25 +1239,62 @@ impl OpenCADStudio {
                     self.commit_undo_delta(i, pd);
                 }
             }
-            CmdResult::CommitAssociativeDimension { entity, source } => {
-                let label = self.history_label_from_active_cmd(i, "DIMLINEAR");
-                let pending = self.begin_undo(i, label, 1, false);
-                if let Some(handle) = self.commit_entity_handle(entity) {
-                    self.tabs[i]
-                        .scene
-                        .attach_linear_dimension_association(handle, [Some(source), Some(source)]);
-                    self.tabs[i].scene.bump_entities(&[
-                        (handle, crate::scene::ChangeKind::Modified),
-                        (source, crate::scene::ChangeKind::Modified),
-                    ]);
-                }
+            CmdResult::CommitDimension { mut entity, source } => {
+                let label = self.history_label_from_active_cmd(i, "DIMENSION");
+                let association_mode = self.tabs[i]
+                    .scene
+                    .document
+                    .header
+                    .dimension_associativity;
+                let pending = if association_mode == 0 {
+                    crate::scene::creation_style::apply_current_creation_styles(
+                        &self.tabs[i].scene.document,
+                        &mut entity,
+                    );
+                    let pieces = crate::modules::draw::modify::explode::explode_entity(
+                        &entity,
+                        &self.tabs[i].scene.document,
+                    );
+                    let delta_safe = pieces
+                        .iter()
+                        .all(|piece| self.delta_add_safe(i, piece));
+                    let pending = self.begin_undo(i, label, pieces.len(), delta_safe);
+                    for piece in pieces {
+                        self.commit_entity(piece);
+                    }
+                    pending
+                } else {
+                    let delta_safe = self.delta_add_safe(i, &entity);
+                    let pending = self.begin_undo(i, label, 1, delta_safe);
+                    if let Some(handle) = self.commit_entity_handle(entity) {
+                        if association_mode == 2 {
+                            let sources = source.map_or_else(
+                                || self.tabs[i].scene.infer_dimension_sources(handle),
+                                |source| [Some(source), Some(source)],
+                            );
+                            self.tabs[i]
+                                .scene
+                                .attach_dimension_association(handle, sources);
+                            let mut changes = vec![
+                                (handle, crate::scene::ChangeKind::Modified),
+                            ];
+                            changes.extend(sources.into_iter().flatten().map(|source| {
+                                (source, crate::scene::ChangeKind::Modified)
+                            }));
+                            changes.sort_by_key(|(handle, _)| handle.value());
+                            changes.dedup_by_key(|(handle, _)| handle.value());
+                            self.tabs[i].scene.bump_entities(&changes);
+                        }
+                    }
+                    pending
+                };
                 self.tabs[i].dirty = true;
                 self.tabs[i].scene.clear_preview_wire();
                 self.tabs[i].active_cmd = None;
                 self.tabs[i].snap_result = None;
                 self.restore_pre_cmd_tangent();
-                if let Some(pending) = pending {
-                    self.commit_undo_delta(i, pending);
+                if let Some(pd) = pending {
+                    self.commit_undo_delta(i, pd);
                 }
             }
             CmdResult::CommitSolid {

--- a/src/command.rs
+++ b/src/command.rs
@@ -1212,10 +1212,12 @@ pub enum CmdResult {
     CommitEntitiesAndExit(Vec<EntityType>),
     /// Commit an acadrust entity to the document and end the command.
     CommitAndExit(EntityType),
-    /// Commit an object-selected linear dimension and retain its source link.
-    CommitAssociativeDimension {
+    /// Commit a linear/aligned dimension while honoring the drawing's
+    /// association mode. `source` is present for object-selection workflows;
+    /// point-created dimensions resolve sources from their snapped endpoints.
+    CommitDimension {
         entity: EntityType,
-        source: Handle,
+        source: Option<Handle>,
     },
     /// Commit a Model-tab 3D solid: the acadrust entity (for selection /
     /// persistence) plus its B-rep (cached for boolean ops + shaded

--- a/src/entities/dimension.rs
+++ b/src/entities/dimension.rs
@@ -4484,15 +4484,19 @@ fn alternate_units_text(measurement: f64, style: Option<&DimStyle>) -> Option<St
     if !s.dimalt {
         return None;
     }
-    let mut v = measurement * s.dimaltf;
+    let scaled = measurement * s.dimaltf;
+    let use_sub_units = s.dimaltz & 4 != 0
+        && scaled.abs() < 1.0
+        && s.dimaltmzf.abs() > 1e-12;
+    // DIMALTMZF replaces the ordinary alternate-unit factor for sub-unit
+    // values; it is not an additional multiplier.
+    let mut v = if use_sub_units {
+        measurement * s.dimaltmzf
+    } else {
+        scaled
+    };
     if s.dimaltrnd > 1e-12 {
         v = (v / s.dimaltrnd).round() * s.dimaltrnd;
-    }
-    let use_sub_units = s.dimaltz & 4 != 0
-        && v.abs() < 1.0
-        && s.dimaltmzf.abs() > 1e-12;
-    if use_sub_units {
-        v *= s.dimaltmzf;
     }
     let dec = s.dimaltd.max(0) as usize;
     let raw = format_with_unit(v, s.dimaltu, dec, s.dimfrac, s.dimaltz, true);
@@ -4659,13 +4663,17 @@ fn format_linear_value(measurement: f64, style: Option<&DimStyle>) -> String {
         .unwrap_or((4, 8, 1.0, 0.0, 46, 2, 0, 1.0, ""));
 
     let lfac = if lfac.abs() < 1e-12 { 1.0 } else { lfac };
-    let mut v = measurement * lfac;
+    let scaled = measurement * lfac;
+    let use_sub_units = zin & 4 != 0 && scaled.abs() < 1.0 && sub_factor.abs() > 1e-12;
+    // For values below one unit, DIMMZF replaces DIMLFAC; applying it after
+    // DIMLFAC multiplies both factors and reports the wrong sub-unit value.
+    let mut v = if use_sub_units {
+        measurement * sub_factor
+    } else {
+        scaled
+    };
     if rnd > 1e-12 {
         v = (v / rnd).round() * rnd;
-    }
-    let use_sub_units = zin & 4 != 0 && v.abs() < 1.0 && sub_factor.abs() > 1e-12;
-    if use_sub_units {
-        v *= sub_factor;
     }
     let dec = dec.max(0) as usize;
     let raw = format_with_unit(v, lunit, dec, frac, zin, false);

--- a/src/entities/dimension.rs
+++ b/src/entities/dimension.rs
@@ -86,8 +86,21 @@ fn base_props(base: &DimensionBase) -> Vec<crate::scene::model::object::Property
 }
 
 fn properties(dim: &Dimension) -> Vec<PropSection> {
-    if let Dimension::Linear(d) = dim {
-        let base = &d.base;
+    let compact_linear = match dim {
+        Dimension::Linear(d) => Some((
+            &d.base,
+            d.rotation,
+            d.ext_line_rotation,
+        )),
+        Dimension::Aligned(d) => Some((
+            &d.base,
+            (d.second_point.y - d.first_point.y)
+                .atan2(d.second_point.x - d.first_point.x),
+            d.ext_line_rotation,
+        )),
+        _ => None,
+    };
+    if let Some((base, rotation, ext_line_rotation)) = compact_linear {
         return vec![PropSection {
             title: t!("Misc").into_owned(),
             props: vec![
@@ -98,11 +111,15 @@ fn properties(dim: &Dimension) -> Vec<PropSection> {
                         base.style_name.clone(),
                     ),
                 },
-                edit_angle(t!("Dim line angle").as_ref(), "rotation", d.rotation.to_degrees()),
+                edit_angle(
+                    t!("Dim line angle").as_ref(),
+                    "rotation",
+                    rotation.to_degrees(),
+                ),
                 edit_angle(
                     t!("Extension line angle").as_ref(),
                     "ext_line_rotation",
-                    d.ext_line_rotation.to_degrees(),
+                    ext_line_rotation.to_degrees(),
                 ),
             ],
         }];
@@ -354,6 +371,29 @@ fn apply_geom_prop(dim: &mut Dimension, field: &str, value: &str) {
 }
 
 fn apply_linear_fields_aligned(d: &mut DimensionAligned, field: &str, value: &str) {
+    if field == "rotation" {
+        let Some(angle) = parse_f64(value).map(f64::to_radians) else {
+            return;
+        };
+        let old_angle = (d.second_point.y - d.first_point.y)
+            .atan2(d.second_point.x - d.first_point.x);
+        let delta = angle - old_angle;
+        let origin_x = d.first_point.x;
+        let origin_y = d.first_point.y;
+        let rotate = |point: &mut acadrust::types::Vector3| {
+            let x = point.x - origin_x;
+            let y = point.y - origin_y;
+            let (sin, cos) = delta.sin_cos();
+            point.x = origin_x + x * cos - y * sin;
+            point.y = origin_y + x * sin + y * cos;
+        };
+        rotate(&mut d.second_point);
+        rotate(&mut d.definition_point);
+        rotate(&mut d.base.definition_point);
+        rotate(&mut d.base.text_middle_point);
+        rotate(&mut d.base.insertion_point);
+        return;
+    }
     apply_linear_common(
         &mut d.first_point,
         &mut d.second_point,
@@ -1495,6 +1535,7 @@ pub fn style_sections(
 
     let s = style;
     let dimfxlon = int(ov::DIMFXLON, s.dimfxlon as i16) != 0;
+    let dimtix = int(ov::DIMTIX, s.dimtix as i16) != 0;
     let dimlunit = int(ov::DIMLUNIT, s.dimlunit);
     let dimfrac = int(ov::DIMFRAC, s.dimfrac);
     let dimalt = int(ov::DIMALT, s.dimalt as i16) != 0;
@@ -1859,7 +1900,7 @@ pub fn style_sections(
                     "dim_text_inside_align",
                     on(int(ov::DIMTIH, s.dimtih as i16) != 0),
                     &["On", "Off"],
-                    true,
+                    dimtix,
                 ),
                 property(
                     t!("Text position X").as_ref(),
@@ -1925,7 +1966,7 @@ pub fn style_sections(
                 choice(
                     t!("Text inside").as_ref(),
                     "dim_text_inside",
-                    on(int(ov::DIMTIX, s.dimtix as i16) != 0),
+                    on(dimtix),
                     &["On", "Off"],
                     true,
                 ),

--- a/src/entities/dimension.rs
+++ b/src/entities/dimension.rs
@@ -2233,14 +2233,14 @@ pub fn style_sections(
                     "dim_tolerance_pos_vert",
                     tolerance_vertical_label(int(ov::DIMTOLJ, s.dimtolj)),
                     &["Bottom", "Middle", "Top"],
-                    tolerance_enabled,
+                    true,
                 ),
                 choice(
                     t!("Tolerance alignment").as_ref(),
                     "dim_tolerance_alignment",
                     tolerance_alignment_label(int(ov::DIMTALN, 0)),
                     &["Align decimal separators", "Align operational symbols"],
-                    tolerance_display == "Deviation",
+                    true,
                 ),
                 choice(
                     t!("Tolerance suppress leading zeros").as_ref(),

--- a/src/modules/annotate/aligned_dim.rs
+++ b/src/modules/annotate/aligned_dim.rs
@@ -1,7 +1,7 @@
 // DIMALIGNED command — aligned dimension (measures true distance between two points).
 
 use acadrust::entities::{Dimension, DimensionAligned};
-use acadrust::types::Vector3;
+use acadrust::types::{Handle, Vector3};
 use acadrust::EntityType;
 use glam::DVec3;
 
@@ -38,6 +38,14 @@ pub struct AlignedDimensionCommand {
     text_angle: Option<f64>,
     /// True while the next typed value is captured as the text angle.
     awaiting_angle: bool,
+    /// True while Enter-at-the-first-prompt is waiting for an entity pick.
+    selecting_object: bool,
+    /// Entity data injected by the host before `on_entity_pick`.
+    picked_entity: Option<EntityType>,
+    /// Source retained when both extension origins came from one entity.
+    source_handle: Option<Handle>,
+    /// Distinguishes the formatted-text option from the plain-text option.
+    mtext_override: bool,
 }
 
 impl AlignedDimensionCommand {
@@ -49,6 +57,10 @@ impl AlignedDimensionCommand {
             awaiting_text: false,
             text_angle: None,
             awaiting_angle: false,
+            selecting_object: false,
+            picked_entity: None,
+            source_handle: None,
+            mtext_override: false,
         }
     }
 }
@@ -64,18 +76,29 @@ impl CadCommand for AlignedDimensionCommand {
 
     fn prompt(&self) -> String {
         if self.awaiting_text {
-            return t!("DIMALIGNED  Enter dimension text (blank = measured value):").into_owned();
+            return if self.mtext_override {
+                t!("DIMALIGNED  Enter formatted dimension text (blank = measured value):")
+                    .into_owned()
+            } else {
+                t!("DIMALIGNED  Enter dimension text (blank = measured value):").into_owned()
+            };
         }
         if self.awaiting_angle {
             return t!("DIMALIGNED  Specify text angle (degrees):").into_owned();
         }
+        if self.selecting_object {
+            return t!("DIMALIGNED  Select object to dimension:").into_owned();
+        }
         match self.step {
-            Step::First => t!("DIMALIGNED  Specify first extension line origin:").into_owned(),
+            Step::First => t!(
+                "DIMALIGNED  Specify first extension line origin or press Enter to select object:"
+            )
+            .into_owned(),
             Step::Second(_) => {
-                t!("DIMALIGNED  Specify second extension line origin  [Text/Angle]:").into_owned()
+                t!("DIMALIGNED  Specify second extension line origin:").into_owned()
             }
             Step::DimLine { .. } => {
-                t!("DIMALIGNED  Specify dimension line location  [Text/Angle]:").into_owned()
+                t!("DIMALIGNED  Specify dimension line location  [Mtext/Text/Angle]:").into_owned()
             }
         }
     }
@@ -87,6 +110,9 @@ impl CadCommand for AlignedDimensionCommand {
                 CmdResult::NeedPoint
             }
             Step::Second(p1) => {
+                if pt.distance_squared(p1) <= 1e-24 {
+                    return CmdResult::NeedPoint;
+                }
                 self.step = Step::DimLine { p1, p2: pt };
                 CmdResult::NeedPoint
             }
@@ -110,14 +136,18 @@ impl CadCommand for AlignedDimensionCommand {
                 dim.base.text_middle_point = v3((d1 + d2) * 0.5);
                 dim.base.insertion_point = dim.base.text_middle_point;
                 dim.base.actual_measurement = dim.measurement();
-                dim.base.user_text = self.text_override.clone();
+                crate::entities::dimension::set_dimension_text_override(
+                    &mut dim.base,
+                    self.text_override.clone(),
+                );
                 // An explicit text angle overrides the default rotation.
                 if let Some(a) = self.text_angle {
                     dim.base.text_rotation = a;
                 }
-                CmdResult::CommitAndExit(self.plane.place_entity(EntityType::Dimension(
-                    Dimension::Aligned(dim),
-                )))
+                CmdResult::CommitDimension {
+                    entity: self.plane.place_entity(EntityType::Dimension(Dimension::Aligned(dim))),
+                    source: self.source_handle,
+                }
             }
         }
     }
@@ -130,6 +160,10 @@ impl CadCommand for AlignedDimensionCommand {
         }
         if self.awaiting_angle {
             self.awaiting_angle = false;
+            return CmdResult::NeedPoint;
+        }
+        if matches!(self.step, Step::First) {
+            self.selecting_object = true;
             return CmdResult::NeedPoint;
         }
         CmdResult::Cancel
@@ -173,8 +207,17 @@ impl CadCommand for AlignedDimensionCommand {
             self.awaiting_angle = false;
             return Some(CmdResult::NeedPoint);
         }
+        if !matches!(self.step, Step::DimLine { .. }) {
+            return None;
+        }
         match text.trim().to_uppercase().as_str() {
-            "T" | "TEXT" | "M" | "MTEXT" => {
+            "T" | "TEXT" => {
+                self.mtext_override = false;
+                self.awaiting_text = true;
+                Some(CmdResult::NeedPoint)
+            }
+            "M" | "MTEXT" => {
+                self.mtext_override = true;
                 self.awaiting_text = true;
                 Some(CmdResult::NeedPoint)
             }
@@ -184,6 +227,38 @@ impl CadCommand for AlignedDimensionCommand {
             }
             _ => None,
         }
+    }
+
+    fn needs_entity_pick(&self) -> bool {
+        self.selecting_object
+    }
+
+    fn entity_pick_highlights_hover(&self) -> bool {
+        true
+    }
+
+    fn inject_before_entity_pick(&self) -> bool {
+        true
+    }
+
+    fn inject_picked_entity(&mut self, entity: EntityType) {
+        self.picked_entity = Some(entity);
+    }
+
+    fn on_entity_pick(&mut self, handle: Handle, point: DVec3) -> CmdResult {
+        let Some(entity) = self.picked_entity.take() else {
+            return CmdResult::NeedPoint;
+        };
+        let Some((p1, p2)) = super::linear_dim::dimension_source_points(&entity, point) else {
+            return CmdResult::NeedPoint;
+        };
+        if p1.distance_squared(p2) <= 1e-24 {
+            return CmdResult::NeedPoint;
+        }
+        self.source_handle = Some(handle);
+        self.selecting_object = false;
+        self.step = Step::DimLine { p1, p2 };
+        CmdResult::NeedPoint
     }
 
     fn on_mouse_move(&mut self, pt: DVec3) -> Option<WireModel> {
@@ -272,13 +347,15 @@ fn dim_line_endpoints(p1: DVec3, p2: DVec3, dim_pt: DVec3) -> (DVec3, DVec3) {
 }
 
 fn preview_aligned(p1: DVec3, p2: DVec3, dim_pt: DVec3) -> WireModel {
-    // Show ext lines + dim line.
     let (d1, d2) = dim_line_endpoints(p1, p2, dim_pt);
-    // Preview WireModel points are screen/GPU-side: downcast to f32.
-    let p1 = p1.as_vec3();
-    let p2 = p2.as_vec3();
-    let d1 = d1.as_vec3();
-    let d2 = d2.as_vec3();
+    let axis = (d2 - d1).normalize_or_zero();
+    let perp = DVec3::new(-axis.y, axis.x, 0.0);
+    let nan = [f32::NAN, 0.0, 0.0];
+    let arrow = 0.22;
+    let text = (d1 + d2) * 0.5 + perp * 0.15;
+    let half_width = ((p2 - p1).length().log10().max(0.0) + 1.0) * 0.18;
+    let half_height = 0.16;
+    let to_point = |point: DVec3| point.as_vec3().to_array();
     WireModel {
         point_marker: None,
         taper_widths: Vec::new(),
@@ -292,19 +369,33 @@ fn preview_aligned(p1: DVec3, p2: DVec3, dim_pt: DVec3) -> WireModel {
         render_instance: None,
         pick_tris: Vec::new(),
         pick_tris_low: Vec::new(),
-            dash_from_start: false,
-            dash_align_end: None,
-            text_verts: Vec::new(),
+        dash_from_start: false,
+        dash_align_end: None,
+        text_verts: Vec::new(),
         name: "dimaligned_preview".into(),
         points: vec![
-            [p1.x, p1.y, p1.z],
-            [d1.x, d1.y, d1.z],
-            [f32::NAN, 0.0, 0.0],
-            [p2.x, p2.y, p2.z],
-            [d2.x, d2.y, d2.z],
-            [f32::NAN, 0.0, 0.0],
-            [d1.x, d1.y, d1.z],
-            [d2.x, d2.y, d2.z],
+            to_point(p1),
+            to_point(d1),
+            nan,
+            to_point(p2),
+            to_point(d2),
+            nan,
+            to_point(d1),
+            to_point(d2),
+            nan,
+            to_point(d1 + axis * arrow + perp * arrow * 0.45),
+            to_point(d1),
+            to_point(d1 + axis * arrow - perp * arrow * 0.45),
+            nan,
+            to_point(d2 - axis * arrow + perp * arrow * 0.45),
+            to_point(d2),
+            to_point(d2 - axis * arrow - perp * arrow * 0.45),
+            nan,
+            to_point(text - axis * half_width - perp * half_height),
+            to_point(text + axis * half_width - perp * half_height),
+            to_point(text + axis * half_width + perp * half_height),
+            to_point(text - axis * half_width + perp * half_height),
+            to_point(text - axis * half_width - perp * half_height),
         ],
         points_low: Vec::new(),
         color: WireModel::CYAN,

--- a/src/modules/annotate/linear_dim.rs
+++ b/src/modules/annotate/linear_dim.rs
@@ -193,10 +193,9 @@ impl CadCommand for LinearDimensionCommand {
                 let entity = self.plane.place_entity(EntityType::Dimension(
                     Dimension::Linear(dim),
                 ));
-                if let Some(source) = self.source_handle {
-                    CmdResult::CommitAssociativeDimension { entity, source }
-                } else {
-                    CmdResult::CommitAndExit(entity)
+                CmdResult::CommitDimension {
+                    entity,
+                    source: self.source_handle,
                 }
             }
         }
@@ -366,11 +365,42 @@ fn dimension_line_offset(second: DVec3, point: DVec3, axis: DVec3) -> f64 {
     (point - second).dot(perpendicular)
 }
 
-fn dimension_source_points(entity: &EntityType, click: DVec3) -> Option<(DVec3, DVec3)> {
+pub(crate) fn dimension_source_points(
+    entity: &EntityType,
+    click: DVec3,
+) -> Option<(DVec3, DVec3)> {
     let point = |p: Vector3| DVec3::new(p.x, p.y, p.z);
     match entity {
         EntityType::Line(line) => Some((point(line.start), point(line.end))),
         EntityType::Arc(arc) => Some((point(arc.start_point_wcs()), point(arc.end_point_wcs()))),
+        EntityType::Circle(circle) => {
+            let click = crate::scene::view::transform::wcs_point_to_ocs(
+                (click.x, click.y, click.z),
+                (circle.normal.x, circle.normal.y, circle.normal.z),
+            );
+            let delta = DVec3::new(
+                click.0 - circle.center.x,
+                click.1 - circle.center.y,
+                0.0,
+            );
+            let direction = if delta.length_squared() > 1e-24 {
+                delta.normalize()
+            } else {
+                DVec3::X
+            };
+            let first = [
+                circle.center.x + direction.x * circle.radius,
+                circle.center.y + direction.y * circle.radius,
+            ];
+            let second = [
+                circle.center.x - direction.x * circle.radius,
+                circle.center.y - direction.y * circle.radius,
+            ];
+            Some((
+                ocs_point(first, circle.center.z, circle.normal),
+                ocs_point(second, circle.center.z, circle.normal),
+            ))
+        }
         EntityType::LwPolyline(polyline) => nearest_planar_source(
             polyline
                 .vertices

--- a/src/scene/dimension_assoc.rs
+++ b/src/scene/dimension_assoc.rs
@@ -56,6 +56,9 @@ fn source_points(entity: &EntityType) -> Vec<Vector3> {
 }
 
 fn source_marker(entity: &EntityType, point: Vector3) -> Option<i32> {
+    if matches!(entity, EntityType::Circle(_)) {
+        return Some(0);
+    }
     source_points(entity)
         .into_iter()
         .enumerate()
@@ -69,9 +72,80 @@ fn source_marker(entity: &EntityType, point: Vector3) -> Option<i32> {
 fn resolve_reference(scene: &Scene, reference: &AssocDimensionReference) -> Option<Vector3> {
     let source = *reference.xrefs.first()?;
     let entity = scene.document.get_entity(source)?;
+    if let EntityType::Circle(circle) = entity {
+        let stored = crate::scene::view::transform::wcs_point_to_ocs(
+            (
+                reference.osnap_point.x,
+                reference.osnap_point.y,
+                reference.osnap_point.z,
+            ),
+            (circle.normal.x, circle.normal.y, circle.normal.z),
+        );
+        let dx = stored.0 - circle.center.x;
+        let dy = stored.1 - circle.center.y;
+        let length = dx.hypot(dy);
+        let stored_angle = dy.atan2(dx);
+        let angle = if reference.osnap_distance.abs() > 1e-12
+            || stored_angle.abs() <= 1e-12
+        {
+            reference.osnap_distance
+        } else {
+            stored_angle
+        };
+        let (sin, cos) = angle.sin_cos();
+        let (ux, uy) = if angle.is_finite() {
+            (cos, sin)
+        } else if length > 1e-12 {
+            (dx / length, dy / length)
+        } else {
+            (1.0, 0.0)
+        };
+        return Some(ocs_point(
+            circle.center.x + ux * circle.radius,
+            circle.center.y + uy * circle.radius,
+            circle.center.z,
+            circle.normal,
+        ));
+    }
     source_points(entity)
         .get(reference.main_gs_marker.max(0) as usize)
         .copied()
+}
+
+fn dimension_points(dimension: &Dimension) -> Option<[Vector3; 2]> {
+    match dimension {
+        Dimension::Linear(linear) => Some([linear.first_point, linear.second_point]),
+        Dimension::Aligned(aligned) => Some([aligned.first_point, aligned.second_point]),
+        _ => None,
+    }
+}
+
+fn source_distance_squared(entity: &EntityType, point: Vector3) -> Option<f64> {
+    if let EntityType::Circle(circle) = entity {
+        let point = crate::scene::view::transform::wcs_point_to_ocs(
+            (point.x, point.y, point.z),
+            (circle.normal.x, circle.normal.y, circle.normal.z),
+        );
+        let radial_error =
+            (point.0 - circle.center.x).hypot(point.1 - circle.center.y) - circle.radius;
+        let plane_error = point.2 - circle.center.z;
+        return Some(radial_error * radial_error + plane_error * plane_error);
+    }
+    source_points(entity)
+        .into_iter()
+        .map(|candidate| point_distance_squared(candidate, point))
+        .min_by(f64::total_cmp)
+}
+
+fn source_parameter(entity: &EntityType, point: Vector3) -> f64 {
+    let EntityType::Circle(circle) = entity else {
+        return 0.0;
+    };
+    let point = crate::scene::view::transform::wcs_point_to_ocs(
+        (point.x, point.y, point.z),
+        (circle.normal.x, circle.normal.y, circle.normal.z),
+    );
+    (point.1 - circle.center.y).atan2(point.0 - circle.center.x)
 }
 
 pub(crate) fn dimension_is_associative(
@@ -97,34 +171,43 @@ pub(crate) fn dimension_is_associative(
 }
 
 impl Scene {
-    pub(crate) fn attach_linear_dimension_association(
+    pub(crate) fn attach_dimension_association(
         &mut self,
         dimension: Handle,
         sources: [Option<Handle>; 2],
     ) {
-        let Some(EntityType::Dimension(Dimension::Linear(linear))) =
-            self.document.get_entity(dimension)
+        let Some(EntityType::Dimension(entity)) = self.document.get_entity(dimension)
         else {
             return;
         };
-        let first_point = linear.first_point;
-        let second_point = linear.second_point;
-        let source_data = [first_point, second_point].map(|point| point);
-        let resolved: [Option<(Handle, i32)>; 2] = std::array::from_fn(|index| {
+        let Some(source_data) = dimension_points(entity) else {
+            return;
+        };
+        let resolved: [Option<(Handle, i32, f64)>; 2] = std::array::from_fn(|index| {
             let source = sources[index]?;
             let entity = self.document.get_entity(source)?;
-            source_marker(entity, source_data[index]).map(|marker| (source, marker))
+            source_marker(entity, source_data[index]).map(|marker| {
+                (
+                    source,
+                    marker,
+                    source_parameter(entity, source_data[index]),
+                )
+            })
         });
         if resolved.iter().all(Option::is_none) {
             return;
         }
 
-        let reference = |source: Handle, marker: i32, point: Vector3| AssocDimensionReference {
+        let reference = |source: Handle,
+                         marker: i32,
+                         parameter: f64,
+                         point: Vector3| AssocDimensionReference {
             class_name: "AcDbOsnapPointRef".to_string(),
             osnap_type: 1,
             xrefs: vec![source],
             main_subent_type: 1,
             main_gs_marker: marker,
+            osnap_distance: parameter,
             osnap_point: point,
             ..AssocDimensionReference::default()
         };
@@ -132,9 +215,14 @@ impl Scene {
             std::array::from_fn(|_| Vec::new());
         let mut associativity = 0;
         for (index, resolved) in resolved.into_iter().enumerate() {
-            if let Some((source, marker)) = resolved {
+            if let Some((source, marker, parameter)) = resolved {
                 associativity |= 1 << index;
-                references[index].push(reference(source, marker, source_data[index]));
+                references[index].push(reference(
+                    source,
+                    marker,
+                    parameter,
+                    source_data[index],
+                ));
             }
         }
 
@@ -165,24 +253,23 @@ impl Scene {
         }
     }
 
-    pub(crate) fn infer_linear_dimension_sources(
+    pub(crate) fn infer_dimension_sources(
         &self,
         dimension: Handle,
     ) -> [Option<Handle>; 2] {
-        let Some(EntityType::Dimension(Dimension::Linear(linear))) =
-            self.document.get_entity(dimension)
+        let Some(EntityType::Dimension(entity)) = self.document.get_entity(dimension)
         else {
             return [None, None];
         };
-        [linear.first_point, linear.second_point].map(|point| {
+        let Some(points) = dimension_points(entity) else {
+            return [None, None];
+        };
+        points.map(|point| {
             self.document
                 .entities()
                 .filter(|entity| entity.common().handle != dimension)
                 .filter_map(|entity| {
-                    source_points(entity)
-                        .into_iter()
-                        .map(|candidate| point_distance_squared(candidate, point))
-                        .min_by(f64::total_cmp)
+                    source_distance_squared(entity, point)
                         .map(|distance| (distance, entity.common().handle))
                 })
                 .filter(|(distance, _)| *distance <= 1e-16)
@@ -231,19 +318,35 @@ impl Scene {
             if first.is_none() && second.is_none() {
                 continue;
             }
-            if let Some(EntityType::Dimension(Dimension::Linear(linear))) =
+            let Some(EntityType::Dimension(dimension)) =
                 self.document.get_entity_mut(association.dimension)
-            {
-                if let Some(first) = first {
-                    linear.first_point = first;
+            else {
+                continue;
+            };
+            match dimension {
+                Dimension::Linear(linear) => {
+                    if let Some(first) = first {
+                        linear.first_point = first;
+                    }
+                    if let Some(second) = second {
+                        linear.second_point = second;
+                    }
+                    linear.base.actual_measurement = linear.measurement();
+                    linear.base.definition_point = linear.definition_point;
                 }
-                if let Some(second) = second {
-                    linear.second_point = second;
+                Dimension::Aligned(aligned) => {
+                    if let Some(first) = first {
+                        aligned.first_point = first;
+                    }
+                    if let Some(second) = second {
+                        aligned.second_point = second;
+                    }
+                    aligned.base.actual_measurement = aligned.measurement();
+                    aligned.base.definition_point = aligned.definition_point;
                 }
-                linear.base.actual_measurement = linear.measurement();
-                linear.base.definition_point = linear.definition_point;
-                refreshed.push((association.dimension, ChangeKind::Modified));
+                _ => continue,
             }
+            refreshed.push((association.dimension, ChangeKind::Modified));
         }
         refreshed
     }


### PR DESCRIPTION
## Summary

1) Complete the aligned-dimension command stages, including ordinary point input and Enter-based object selection.

2) Allow object selection from lines, arcs, circles, and straight or curved polyline segments, resolve the correct source points, and reject zero-length geometry before commit.

3) Add correctly staged `Mtext`, `Text`, and `Angle` options. Formatted and plain text follow separate input paths, blank/`<>` restores measured text, and angle input is not misrouted as a geometry point.

4) Add an arrow- and text-aware live placement preview so the dimension line location reflects the current measurement and available fit space before commit.

5) Generalize dimension associations for both linear and aligned subtypes. Drawing association modes 0/1/2 are respected, selected endpoints use stable references, and circle/polyline source parameters remain recoverable.

6) Refresh aligned endpoints, definition geometry, manual text relation, and cached measurement when associated source geometry changes.

7) Replace raw internal Geometry rows with the compact aligned Misc layout, keep Dimension style and Annotative controls in the expected order, and remove implementation-only coordinates from Properties.

8) Make Dim line angle and Extension line angle real editors. Each writer updates the entity geometry, redraws immediately, and persists through the dimension model.

9) Match dependent editability in the Text section: Text inside align is enabled only while Text inside is enabled, rather than opening or closing the entire section together.

10) Keep Tolerance pos vert and Tolerance alignment independently editable, preserve both per-entity override values, and apply them when tolerance text is rendered.

11) Correct primary sub-unit scaling so the configured sub-unit factor replaces the ordinary linear factor for the sub-unit branch instead of multiplying both factors.

12) Apply the same scale correction to alternate units and keep style values, per-entity overrides, formatted text, rendering, and persistence connected.

## Verification

Release build completed successfully.