### PR TITLE
Correct plot style mode behavior

### DIFF
--- a/src/app/properties.rs
+++ b/src/app/properties.rs
@@ -203,11 +203,15 @@ impl OpenCADStudio {
                             })
                             .unwrap_or_else(|| "ByLayer".to_string())
                     };
-                    let plot_style = match header.current_plotstyle_type {
-                        1 => "ByBlock",
-                        2 => "ByColor",
-                        3 => "ByObject",
-                        _ => "ByLayer",
+                    let plot_style = if header.plotstyle_mode {
+                        "ByColor"
+                    } else {
+                        match header.current_plotstyle_type {
+                            1 => "ByBlock",
+                            2 => "Normal",
+                            3 => "ByObject",
+                            _ => "ByLayer",
+                        }
                     };
                     let layout_plot_table = doc.objects.values().find_map(|object| {
                         let acadrust::objects::ObjectType::Layout(layout) = object else {
@@ -316,7 +320,7 @@ impl OpenCADStudio {
                                 Property {
                                     label: t!("Plot style").into_owned(),
                                     field: "plot_style",
-                                    value: if header.plotstyle_mode {
+                                    value: if !header.plotstyle_mode {
                                         PropValue::Choice {
                                             selected: plot_style.to_string(),
                                             options: vec![
@@ -327,7 +331,7 @@ impl OpenCADStudio {
                                         }
                                     } else {
                                         PropValue::ReadOnlyWithTooltip {
-                                            value: plot_style.to_string(),
+                                            value: "ByColor".to_string(),
                                             tooltip: t!("Plot style is locked to color in Color-Dependent (CTB) mode").into_owned(),
                                         }
                                     },
@@ -344,9 +348,9 @@ impl OpenCADStudio {
                                 read_only(
                                     t!("Plot table type").as_ref(),
                                     if header.plotstyle_mode {
-                                        "Named plot styles".to_string()
-                                    } else {
                                         "Color-dependent plot styles".to_string()
+                                    } else {
+                                        "Named plot styles".to_string()
                                     },
                                 ),
                             ],
@@ -746,11 +750,10 @@ impl OpenCADStudio {
                         }
                     }
 
-                    // In named plot-style mode (PSTYLEMODE=1) the Plot style row
-                    // picks a named style from the drawing's plot style table. In
-                    // the color-dependent mode it stays read-only (the object's
-                    // color drives the plot style), so it is left untouched.
-                    if self.tabs[i].scene.document.header.plotstyle_mode {
+                    // Named plot-style mode exposes the drawing's styles. In
+                    // color-dependent mode the object's color determines the
+                    // style, so the row is locked to ByColor.
+                    if !self.tabs[i].scene.document.header.plotstyle_mode {
                         let doc = &self.tabs[i].scene.document;
                         let dict_h = doc.header.acad_plotstylename_dict_handle;
                         let common = entity.common();
@@ -797,15 +800,8 @@ impl OpenCADStudio {
                             if let Some(row) =
                                 section.props.iter_mut().find(|p| p.field == "plot_style")
                             {
-                                let common = entity.common();
-                                let plot_style_str = match common.plotstyle_flags {
-                                    0 => "ByLayer",
-                                    1 => "ByBlock",
-                                    2 => "Normal",
-                                    _ => "ByColor",
-                                };
                                 row.value = crate::scene::model::object::PropValue::ReadOnlyWithTooltip {
-                                    value: plot_style_str.to_string(),
+                                    value: "ByColor".to_string(),
                                     tooltip: t!("Plot style is locked to color in Color-Dependent (CTB) mode").into_owned(),
                                 };
                             }

--- a/src/app/update/command.rs
+++ b/src/app/update/command.rs
@@ -2169,6 +2169,10 @@ pub(super) fn on_tab_close(&mut self, idx: usize) -> Task<Message> {
                             }
                         }
                     } else if field == "plot_style" {
+                        if self.tabs[i].scene.document.header.plotstyle_mode {
+                            self.refresh_properties();
+                            return Task::none();
+                        }
                         // Named plot-style pick: ByLayer / ByBlock clear the
                         // handle; a named style resolves through the drawing's
                         // ACAD_PLOTSTYLENAME dictionary to its placeholder handle.
@@ -2349,11 +2353,15 @@ pub(super) fn on_tab_close(&mut self, idx: usize) -> Task<Message> {
                             self.refresh_properties();
                         }
                         "plot_style" => {
+                            if self.tabs[i].scene.document.header.plotstyle_mode {
+                                self.refresh_properties();
+                                return Task::none();
+                            }
                             match value.as_str() {
                                 "ByBlock" => {
                                     self.tabs[i].scene.document.header.current_plotstyle_type = 1
                                 }
-                                "Normal" | "ByColor" => {
+                                "Normal" => {
                                     self.tabs[i].scene.document.header.current_plotstyle_type = 2
                                 }
                                 _ => self.tabs[i].scene.document.header.current_plotstyle_type = 0,


### PR DESCRIPTION
## Summary

1) Correct the drawing plot-style mode mapping so the application distinguishes color-dependent tables from named-style tables using the actual document flag semantics.

2) In color-dependent mode, show `ByColor` for selected entities and expose it as read-only because no per-entity named style can be assigned in that mode.

3) Apply the same `ByColor` and read-only behavior to the current drawing properties used for newly created entities, keeping selected-object and current-property panels consistent.

4) In named-style mode, populate the available named plot-style choices and keep the row editable so a selected entity can receive a valid style.

5) Guard the write path against stale UI state: attempts to write a named plot style while the drawing is in color-dependent mode are ignored instead of storing an invalid override.

6) Report the plot-style table type consistently across Properties reads, current-property reads, and writes so switching documents or modes does not invert the displayed state.

## Verification

Release build completed successfully.