### PR TITLE
registry: add MCP Bridge

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -18,5 +18,10 @@
     "repo": "KevinGriffin-new/opencad-landsurvey-plugin",
     "name": "Land Survey",
     "description": "Survey points, PNEZD & LandXML import, TIN surfaces, earthwork volumes, COGO, and coordinate transforms (RTS / Helmert / resection)."
+  },
+  {
+    "repo": "piyton/ocs-mcp-bridge",
+    "name": "MCP Bridge",
+    "description": "Read/write bridge for external tools: serves the live selection and accepts draw/remove requests over a local socket (MCP servers, scripts)."
   }
 ]


### PR DESCRIPTION
Adds [MCP Bridge](https://github.com/piyton/ocs-mcp-bridge) (GPL-3.0) to the registry: a thin plugin that serves the live selection and accepts draw/remove requests over a local socket on 127.0.0.1, so MCP servers and scripts can read and write the open drawing without fighting the file lock. Every write is wrapped in an undo step.

Honest caveat: writing, snapshot reads, and the Connect-button capture work on stock 0.9.7; *live* selection tracking additionally needs #879 (the plugin degrades gracefully without it). If you would rather wait for #879 before listing it, that is entirely fine — happy to keep this PR open until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)