### PR TITLE
fix(render): improve dashed linetype rendering

### DIFF
--- a/src/scene/convert/tessellate.rs
+++ b/src/scene/convert/tessellate.rs
@@ -1535,6 +1535,8 @@ pub fn tessellate(
                             | EntityType::Circle(_)
                             | EntityType::Arc(_)
                             | EntityType::Ellipse(_)
+                            | EntityType::Spline(_)
+                            | EntityType::LwPolyline(_)
                     ) {
                         (pattern_length, pattern)
                     } else {

--- a/src/scene/project.rs
+++ b/src/scene/project.rs
@@ -250,7 +250,7 @@ impl Scene {
                 let source_length = stationed.then(|| wire.pattern_stations[wire.points.len()]);
                 let (clipped, mut clipped_stations) = clip_polyline_to_rect(
                     &projected_pts,
-                    stationed.then_some(&wire.pattern_stations[..wire.points.len()]),
+                    stationed.then(|| &wire.pattern_stations[..wire.points.len()]),
                     vp_x0,
                     vp_y0,
                     vp_x1,

--- a/src/scene/view/render.rs
+++ b/src/scene/view/render.rs
@@ -3795,14 +3795,21 @@ impl Scene {
             full_bounds,
             self.document.header.lineweight_display || display_plot_lineweights,
         );
-        if self.document.header.paper_space_linetype_scaling
+
+        // Model space: scale linetypes using the current annotation scale so their
+        // appearance can match a paper-space viewport at the same drawing scale.
+        if self.current_layout == "Model" {
+            if self.annotation_scale.is_finite() && self.annotation_scale > 1e-9 {
+                uniforms.linetype_scale = self.annotation_scale;
+            }
+        } else if self.document.header.paper_space_linetype_scaling
             && !inst.paper_sheet
-            && inst.tile_idx.is_none()
             && inst.handle != Handle::NULL
         {
             if let Some(EntityType::Viewport(vp)) = self.document.get_entity(inst.handle) {
                 let viewport_scale =
                     vp_effective_scale(vp.custom_scale, vp.view_height, vp.height);
+
                 if viewport_scale.is_finite() && viewport_scale > 1e-9 {
                     uniforms.linetype_scale = (1.0 / viewport_scale) as f32;
                 }


### PR DESCRIPTION
## Summary

This PR fixes several linetype rendering issues related to dashed and complex line patterns.

### Changes

- preserve linetype patterns for `SPLINE` entities
- preserve linetype patterns for `LWPOLYLINE` entities
- make Model Space linetype display follow the current annotation scale
- keep Paper Space linetype appearance consistent across viewport scales when `PSLTSCALE` is enabled
- prevent a viewport plotting panic when linetype pattern stations are not available

### Behavior

With `PSLTSCALE = 1`, dashed linetypes now keep a consistent visual size in Paper Space even when the viewport scale changes, such as from 1:100 to 1:500.

Model Space also uses the current annotation scale so the linetype appearance can better match a Paper Space viewport using the same drawing scale.

### Testing

Verified:

- dashed `SPLINE` rendering
- dashed `LWPOLYLINE` rendering
- ByLayer linetype resolution
- global `LTSCALE`
- per-entity linetype scale
- Paper Space viewport scaling with `PSLTSCALE = 1`
- Model Space annotation-scale behavior
- viewport plot/preview no longer panics in the tested case

Fixes #887