### PR TITLE
fix(ui): restore context menu actions

### DIFF
--- a/src/app/view/mod.rs
+++ b/src/app/view/mod.rs
@@ -2528,15 +2528,33 @@ fn doc_tab_context_menu(
 ) -> Element<'static, Message> {
     const MENU_W: f32 = 210.0;
 
-    let item = |label: &'static str, msg: Option<Message>| {
-        let mut item = button(text(label).size(12))
-        .style(button::subtle)
-        .padding([4, 12])
-        .width(Fill);
+    let item = |label: &'static str, msg: Option<Message>| -> Element<'static, Message> {
+        let enabled = msg.is_some();
+
+        let content = container(text(label).size(12))
+            .padding([4, 12])
+            .width(Fill)
+            .style(move |theme: &Theme| {
+                let palette = theme.palette();
+
+                container::Style {
+                    text_color: Some(if enabled {
+                        palette.background.base.text
+                    } else {
+                        palette.background.base.text.scale_alpha(0.42)
+                    }),
+                    ..Default::default()
+                }
+            });
+
         if let Some(msg) = msg {
-            item = item.on_press(msg);
+            mouse_area(content)
+                .on_press(msg)
+                .interaction(iced::mouse::Interaction::Pointer)
+                .into()
+        } else {
+            content.into()
         }
-        item
     };
 
     let mut menu = column![

--- a/src/ui/statusbar/mod.rs
+++ b/src/ui/statusbar/mod.rs
@@ -850,21 +850,26 @@ fn osnap_btn<'a>(
 // ── Helpers ───────────────────────────────────────────────────────────────
 
 fn layout_tab_context_menu(name: String) -> Element<'static, Message> {
-    let item = |label: std::borrow::Cow<'static, str>, msg: Message| {
-        button(text(label).size(12))
-            .on_press(msg)
-            .style(button::subtle)
+    let rename = mouse_area(
+        container(text(t!("Rename")).size(12))
             .padding([4, 12])
-            .width(Length::Fill)
-    };
+            .width(Length::Fill),
+    )
+    .on_press(Message::LayoutRenameStart(name.clone()))
+    .interaction(iced::mouse::Interaction::Pointer);
+
+    let delete = mouse_area(
+        container(text(t!("Delete")).size(12))
+            .padding([4, 12])
+            .width(Length::Fill),
+    )
+    .on_press(Message::LayoutDelete(name))
+    .interaction(iced::mouse::Interaction::Pointer);
 
     container(
-        column![
-            item(t!("Rename"), Message::LayoutRenameStart(name.clone())),
-            item(t!("Delete"), Message::LayoutDelete(name)),
-        ]
-        .spacing(0)
-        .width(160),
+        column![rename, delete]
+            .spacing(0)
+            .width(160),
     )
     .style(container::bordered_box)
     .padding([4, 0])


### PR DESCRIPTION
## Summary

Fix context menu actions that were displayed correctly but did not execute when clicked.

### Fixed

- Layout tab `Rename`
- Layout tab `Delete`
- Document tab context menu actions

### Cause

The affected context menus used regular `Button` widgets inside `iced_aw::ContextMenu`.

The context menu closes on mouse release before the button can complete its normal press/release cycle and publish its message.

### Solution

Use `MouseArea::on_press` for context menu actions so the message is published immediately on mouse press.

Disabled document-tab actions remain non-interactive and visually dimmed.

### Testing

Verified manually:

- Layout tab → Rename
- Layout tab → Delete
- document tab context menu actions
- layout tab reordering remains functional

Fixes #939