### PR TITLE
Prevent grip clicks from starting area selection

### DIFF
--- a/src/app/update/viewport.rs
+++ b/src/app/update/viewport.rs
@@ -2690,6 +2690,19 @@ impl OpenCADStudio {
         };
         let (vw, vh) = vp_size;
 
+        // An engaged grip owns the next left press (click-move-click placement
+        // or the release of a press-drag). Do not let the same press arm the
+        // normal box/lasso state or trigger another viewport control; the
+        // release path below will commit the grip.
+        if self.tabs[i].active_grip.is_some() {
+            self.tabs[i]
+                .scene
+                .selection
+                .borrow_mut()
+                .clear_left_selection_gesture();
+            return Task::none();
+        }
+
         // Interactive navigation tools reuse the middle-button movement path,
         // so no selection/pick logic runs while the left button drives them.
         if self.tabs[i].orbit_mode
@@ -2783,18 +2796,6 @@ impl OpenCADStudio {
             width: vw,
             height: vh,
         };
-
-        // An engaged grip owns the next left press (click-move-click placement
-        // or the release of a press-drag). Do not let the same press arm the
-        // normal box/lasso state; the release path below will commit the grip.
-        if self.tabs[i].active_grip.is_some() {
-            self.tabs[i]
-                .scene
-                .selection
-                .borrow_mut()
-                .clear_left_selection_gesture();
-            return Task::none();
-        }
 
         if self.tabs[i].active_cmd.is_none()
             && self.tabs[i].active_grip.is_none()

--- a/src/app/update/viewport.rs
+++ b/src/app/update/viewport.rs
@@ -2784,6 +2784,18 @@ impl OpenCADStudio {
             height: vh,
         };
 
+        // An engaged grip owns the next left press (click-move-click placement
+        // or the release of a press-drag). Do not let the same press arm the
+        // normal box/lasso state; the release path below will commit the grip.
+        if self.tabs[i].active_grip.is_some() {
+            self.tabs[i]
+                .scene
+                .selection
+                .borrow_mut()
+                .clear_left_selection_gesture();
+            return Task::none();
+        }
+
         if self.tabs[i].active_cmd.is_none()
             && self.tabs[i].active_grip.is_none()
             && !self.tabs[i].selected_grips.is_empty()
@@ -2879,6 +2891,11 @@ impl OpenCADStudio {
                     ));
                     self.grip_hover = None;
                     self.grip_popup = None;
+                    self.tabs[i]
+                        .scene
+                        .selection
+                        .borrow_mut()
+                        .clear_left_selection_gesture();
 
                     // A grip edit is not a CAD command, so explicitly seed the shared
                     // dynamic-input fields for the newly engaged grip.
@@ -2956,10 +2973,7 @@ impl OpenCADStudio {
             // click doesn't read as an in-progress drag on later moves.
             {
                 let mut sel = self.tabs[i].scene.selection.borrow_mut();
-                sel.left_down = false;
-                sel.left_press_pos = None;
-                sel.left_press_time = None;
-                sel.left_dragging = false;
+                sel.clear_left_selection_gesture();
             }
             let moved = grip.last_world != grip.origin_world;
             if is_click && !moved {

--- a/src/scene/pick/selection_state.rs
+++ b/src/scene/pick/selection_state.rs
@@ -56,3 +56,24 @@ pub struct SelectionState {
     pub middle_last_pos: Option<Point>,
     pub middle_last_press_time: Option<Instant>,
 }
+
+impl SelectionState {
+    /// End every left-button selection gesture without disturbing the previous
+    /// completed-window record or command-owned preview marquee. Grip editing
+    /// owns the left button while engaged and calls this before/after placement
+    /// so a small pointer move cannot also arm a box or lasso selection.
+    pub fn clear_left_selection_gesture(&mut self) {
+        self.left_down = false;
+        self.left_press_pos = None;
+        self.left_press_time = None;
+        self.left_dragging = false;
+        self.box_anchor = None;
+        self.box_anchor_world = None;
+        self.box_current = None;
+        self.box_crossing = false;
+        self.box_crossing_locked = false;
+        self.poly_active = false;
+        self.poly_points.clear();
+        self.poly_crossing = false;
+    }
+}


### PR DESCRIPTION
## Summary

- Gives an engaged entity grip exclusive ownership of its placement click before view, UCS, box, or lasso input can consume it.
- Clears all live left-selection gesture state when grip editing starts and ends.
- Preserves both click-move-click and press-drag-release grip workflows without disturbing completed selection windows.

## Verification

- Static diff and conflict-marker checks passed. Tests were not run at reviewer request.