### PR TITLE
fix(dimension): render DIMAUNIT 4 as a surveyor's bearing

### DIFF
--- a/src/entities/dimension.rs
+++ b/src/entities/dimension.rs
@@ -6567,6 +6567,8 @@ fn format_angular_value(measurement_deg: f64, style: Option<&DimStyle>) -> Strin
                 swap_decimal_sep(&apply_angular_zero_suppression(&raw, azin), decimal_separator)
             )
         }
+        // 4 = Surveyor's units
+        4 => format_surveyor(measurement_deg, adec, azin, decimal_separator),
         // 0 or unknown = Decimal Degrees
         _ => {
             let raw = format!("{:.*}", adec, measurement_deg);
@@ -6576,6 +6578,48 @@ fn format_angular_value(measurement_deg: f64, style: Option<&DimStyle>) -> Strin
             )
         }
     }
+}
+
+/// Surveyor's units (DIMAUNIT 4): a bearing away from north or south toward
+/// east or west, so the quoted angle never exceeds a quarter turn. Due north,
+/// south, east and west have no bearing to quote and are written as the single
+/// letter, which is also what keeps a quarter turn from reading as a
+/// contradictory `N 90d0'0" E`. The bearing is DMS, so it carries DIMADEC,
+/// DIMAZIN and DIMDSEP the same way the DMS format does.
+fn format_surveyor(deg: f64, sec_dec: usize, azin: i16, decimal_separator: i16) -> String {
+    // Quantise before choosing a cardinal or a quadrant, so a value a hair
+    // under a cardinal direction does not print a quarter-turn bearing.
+    let scale = 3600.0 * 10f64.powi(sec_dec.min(8) as i32);
+    let turn = 360.0 * scale;
+    let ticks = (deg.rem_euclid(360.0) * scale).round().rem_euclid(turn);
+    let at = |d: f64| (ticks - d * scale).abs() < 0.5;
+    if at(0.0) {
+        return "E".into();
+    }
+    if at(90.0) {
+        return "N".into();
+    }
+    if at(180.0) {
+        return "W".into();
+    }
+    if at(270.0) {
+        return "S".into();
+    }
+    let d = ticks / scale;
+    // Measured from the nearer pole, toward the side the angle falls on.
+    let (pole, bearing, side) = if d < 90.0 {
+        ("N", 90.0 - d, "E")
+    } else if d < 180.0 {
+        ("N", d - 90.0, "W")
+    } else if d < 270.0 {
+        ("S", 270.0 - d, "W")
+    } else {
+        ("S", d - 270.0, "E")
+    };
+    format!(
+        "{pole} {} {side}",
+        format_dms(bearing, sec_dec, azin, decimal_separator)
+    )
 }
 
 fn format_dms(deg: f64, sec_dec: usize, azin: i16, decimal_separator: i16) -> String {
@@ -7267,6 +7311,41 @@ mod dimtad_tests {
             "outside must clear the object side, got {}",
             below.y
         );
+    }
+}
+
+#[cfg(test)]
+mod angular_unit_tests {
+    use super::format_angular_value;
+    use acadrust::tables::DimStyle;
+
+    fn style(dimaunit: i16, dimadec: i16) -> DimStyle {
+        let mut s = DimStyle::standard();
+        s.dimaunit = dimaunit;
+        s.dimadec = dimadec;
+        s
+    }
+
+    // DIMAUNIT 4 is Surveyor's units. It used to fall through to the decimal
+    // branch, so an angular dimension in a drawing authored with surveyor
+    // units read as plain degrees while AUNITS=4 elsewhere wrote a bearing.
+    #[test]
+    fn surveyor_units_write_a_bearing() {
+        assert_eq!(format_angular_value(45.0, Some(&style(4, 0))), "N 45\u{b0}0'0\" E");
+        assert_eq!(format_angular_value(135.0, Some(&style(4, 0))), "N 45\u{b0}0'0\" W");
+        assert_eq!(format_angular_value(200.0, Some(&style(4, 0))), "S 70\u{b0}0'0\" W");
+        assert_eq!(format_angular_value(300.0, Some(&style(4, 0))), "S 30\u{b0}0'0\" E");
+        // A hair under a cardinal must not quote a quarter-turn bearing.
+        assert_eq!(format_angular_value(89.99999, Some(&style(4, 0))), "N");
+        assert_eq!(format_angular_value(90.0, Some(&style(4, 0))), "N");
+        assert_eq!(format_angular_value(0.0, Some(&style(4, 0))), "E");
+    }
+
+    // The other unit formats are untouched.
+    #[test]
+    fn other_angular_units_unchanged() {
+        assert_eq!(format_angular_value(45.5, Some(&style(1, 0))), "45\u{b0}30'0\"");
+        assert_eq!(format_angular_value(90.0, Some(&style(2, 1))), "100.0g");
     }
 }
 

--- a/src/ui/style/dimstyle.rs
+++ b/src/ui/style/dimstyle.rs
@@ -956,7 +956,7 @@ pub fn view_window<'a>(
                 t!("Unit format"),
                 DsField::Dimaunit,
                 vals.dimaunit,
-                &[("0", "Decimal degrees"), ("1", "Degrees, minutes, seconds"), ("2", "Gradians"), ("3", "Radians")],
+                &[("0", "Decimal degrees"), ("1", "Degrees, minutes, seconds"), ("2", "Gradians"), ("3", "Radians"), ("4", "Surveyor's units")],
             ),
             row![lbl(t!("Precision")), mk_field(DsField::Dimadec, vals.dimadec)]
                 .spacing(8).align_y(iced::Center),


### PR DESCRIPTION
## Problem

`format_angular_value` dispatches on DIMAUNIT with arms for 1 (DMS), 2 (gradians), 3 (radians) and a catch-all for decimal degrees. DIMAUNIT **4 is Surveyor's units**, and it lands in that catch-all — so an angular dimension in a drawing authored with surveyor units renders as `45.00°` instead of `N 45°0'0" E`.

The drawing itself already knows the format: `AUNITS = 4` in `entities/common.rs` writes a bearing (`format_angle` → `surveyor`), and `parse_angle` reads one back. So opening a DXF that uses surveyor units gives a coordinate readout in bearings and dimensions in decimal degrees — two conventions for the same angle in one drawing.

The dimension-style dialog also stopped its Unit-format list at Radians, so the value could arrive from a file but never be chosen or corrected in the UI.

## Fix

- Add the DIMAUNIT 4 arm, formatting the bearing through the dimension's own `format_dms` so it carries DIMADEC, DIMAZIN and DIMDSEP like every other angular format here (reusing `common::surveyor` would have written `d` where dimensions write `°`).
- Quantise to the precision before choosing the cardinal/quadrant, so an angle a hair under a cardinal prints `N` rather than the contradictory `N 90°0'0" E`. This mirrors the guard already in `common::surveyor` and the `surveyor_bearings_stay_inside_a_quadrant` test beside it.
- Offer `Surveyor's units` in the dimension-style dialog's Unit-format list.

## Scope

One new formatter and one match arm in `src/entities/dimension.rs`, plus one entry in the dialog's option list. Nothing changes for DIMAUNIT 0–3 — covered by `other_angular_units_unchanged`.

## Test plan

- Ran: `cargo test --lib angular_unit` → 2 passed. Covers all four quadrants, the four cardinals, the just-short-of-cardinal case, and that DMS/gradians are untouched.
- Ran: `cargo test --lib` → 523 passed, 1 failed. The failure is `join_keeps_source_thickness`, which fails identically on an unmodified checkout of `main` here.
