### PR TITLE
fix(expr-eval): make ^ right-associative

### DIFF
--- a/src/app/expr_eval.rs
+++ b/src/app/expr_eval.rs
@@ -207,7 +207,13 @@ impl Parser {
         Ok(left)
     }
 
-    // power → unary ('^' unary)?
+    // power → unary ('^' power)?
+    //
+    // The exponent recurses into `parse_power`, not `parse_unary`, so `^` is
+    // right-associative — `2^3^2` is `2^(3^2)`, the standard reading. Binding
+    // it to the left both gave the wrong number and left the trailing `^2`
+    // unconsumed, which the caller's scan then handed back as literal text:
+    // `2^3^2` evaluated to the string "8^2" instead of 512.
     fn parse_power(&mut self, depth: usize) -> Result<f64, ()> {
         if depth > MAX_RECURSION {
             return Err(());
@@ -215,7 +221,7 @@ impl Parser {
         let base = self.parse_unary(depth + 1)?;
         if let Some(Token::Caret) = self.peek() {
             self.advance();
-            let exp = self.parse_unary(depth + 1)?;
+            let exp = self.parse_power(depth + 1)?;
             return Ok(base.powf(exp));
         }
         Ok(base)
@@ -589,6 +595,21 @@ mod tests {
     fn nested_parens() {
         assert_eq!(eval_to_string("((2+3))"), "5");
         assert_eq!(eval_to_string("(((10)))"), "10");
+    }
+
+    // `^` is right-associative, so a chained exponent evaluates as one number
+    // instead of stopping at the first `^` and leaving the rest as text.
+    #[test]
+    fn power_is_right_associative() {
+        assert_eq!(eval_to_string("2^3^2"), "512");
+        assert_eq!(eval_to_string("2^3^2+1"), "513");
+        assert_eq!(eval_to_string("4^0.5^2"), "1.4142135623730951"); // 4^(1/4)
+        assert_eq!(eval_to_string("2^2^2^2"), "65536");
+        // A single exponent, and a parenthesised one, are unaffected.
+        assert_eq!(eval_to_string("2^3"), "8");
+        assert_eq!(eval_to_string("2^(3^2)"), "512");
+        assert_eq!(eval_to_string("(2^3)^2"), "64");
+        assert_eq!(eval_to_string("2^-1"), "0.5");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`parse_power` was written as `unary ('^' unary)?` — at most one exponent. A chained power therefore stopped after the first `^`, and nothing above it consumes a `^` either (`parse_product` handles only `* / %`). The trailing operator is simply left in the token stream.

`eval_to_string` falls back to scanning for the longest evaluable substring when the whole string does not evaluate, so the unconsumed tail comes back as literal text. The result is not a wrong number — it is not a number at all:

| input | before | expected |
|---|---|---|
| `2^3^2` | `"8^2"` | `512` |
| `2^3^2+1` | `"8^3"` | `513` |
| `2^2^2^2` | `"4^2^2"` | `65536` |

Anywhere a value is typed — coordinate entry, distance, a property field — a chained exponent yields a string the caller cannot use.

## Fix

Recurse into `parse_power` for the exponent, making `^` right-associative: `2^3^2` is `2^(3^2)`, which is how the operator reads in standard notation and in AutoCAD. The whole expression is then consumed, so the fallback scan never sees a leftover `^`.

## Scope

One line in `parse_power` (plus the comment above it) in `src/app/expr_eval.rs`. A single `^`, a parenthesised exponent, and a negative exponent are all unchanged — asserted in the new test.

## Test plan

- Ran: `cargo test --lib expr_eval` → 33 passed. New `power_is_right_associative` covers the chained cases above plus `2^3`, `2^(3^2)`, `(2^3)^2` and `2^-1`.
