### PR TITLE
fix(offset, trim): preserve source layers and preselected cutting edges

### DIFF
--- a/src/app/command_driver.rs
+++ b/src/app/command_driver.rs
@@ -840,6 +840,10 @@ impl OpenCADStudio {
 
     fn apply_cmd_result_inner(&mut self, result: CmdResult) -> Task<Message> {
         let i = self.active_tab;
+        let preserve_commit_layer = self.tabs[i]
+        .active_cmd
+        .as_ref()
+        .is_some_and(|command| command.preserve_commit_layer());
         match result {
             CmdResult::NeedPoint => {
                 // ATTEDIT finished its entity pick: hand the chosen block off to
@@ -935,7 +939,11 @@ impl OpenCADStudio {
                 );
                 let association_enabled =
                     self.tabs[i].scene.document.header.dimension_associativity == 2;
-                let committed = self.commit_entity_handle(entity);
+                let committed = if preserve_commit_layer {
+                    self.commit_entity_handle_preserve_layer(entity)
+                } else {
+                    self.commit_entity_handle(entity)
+                };
                 if is_associative_dimension && association_enabled {
                     if let Some(handle) = committed {
                         let sources = self.tabs[i]
@@ -973,7 +981,11 @@ impl OpenCADStudio {
                     .all(|entity| self.delta_add_safe(i, entity));
                 let pending = self.begin_undo(i, label, entities.len(), delta_safe);
                 for entity in entities {
-                    self.commit_entity(entity);
+                    if preserve_commit_layer {
+                        let _ = self.commit_entity_handle_preserve_layer(entity);
+                    } else {
+                        self.commit_entity(entity);
+                    }
                 }
                 self.tabs[i].dirty = true;
                 self.tabs[i].scene.clear_preview_wire();

--- a/src/app/commands/dim.rs
+++ b/src/app/commands/dim.rs
@@ -1238,8 +1238,18 @@ impl OpenCADStudio {
                             .map(|e| (h, e))
                     })
                     .collect();
+                let initial_edges: Vec<acadrust::Handle> = self.tabs[i]
+                    .scene
+                    .selected_entities()
+                    .into_iter()
+                    .filter_map(|(handle, entity)| {
+                        crate::modules::draw::modify::trim::is_trim_boundary_entity(&entity)
+                            .then_some(handle)
+                    })
+                    .collect();
                 let all_entities: Vec<_> = entities.into_iter().map(|(_, e)| e).collect();
-                let new_cmd = TrimCommand::new(all_entities);
+                let new_cmd =
+                    TrimCommand::with_cutting_edges(all_entities, initial_edges);
                 self.command_line.push_info(&new_cmd.prompt());
                 self.tabs[i].active_cmd = Some(Box::new(new_cmd));
             }

--- a/src/app/properties.rs
+++ b/src/app/properties.rs
@@ -2596,14 +2596,33 @@ impl OpenCADStudio {
         &mut self,
         entity: acadrust::EntityType,
     ) -> Option<Handle> {
-        self.commit_entity_handle_with_dimension_policy(entity, false)
+        self.commit_entity_handle_with_policies(entity, false, false)
     }
 
-    /// Commit an entity, optionally preserving its source dimension style.
     pub(super) fn commit_entity_handle_with_dimension_policy(
+        &mut self,
+        entity: acadrust::EntityType,
+        preserve_dimension_layer_and_style: bool,
+    ) -> Option<Handle> {
+        self.commit_entity_handle_with_policies(
+            entity,
+            preserve_dimension_layer_and_style,
+            false,
+        )
+    }
+
+    pub(super) fn commit_entity_handle_preserve_layer(
+        &mut self,
+        entity: acadrust::EntityType,
+    ) -> Option<Handle> {
+        self.commit_entity_handle_with_policies(entity, false, true)
+    }
+
+    fn commit_entity_handle_with_policies(
         &mut self,
         mut entity: acadrust::EntityType,
         preserve_dimension_layer_and_style: bool,
+        preserve_entity_layer: bool,
     ) -> Option<Handle> {
         let i = self.active_tab;
         let tracks_dimension_chain = matches!(
@@ -2692,7 +2711,7 @@ impl OpenCADStudio {
         };
         if let Some(layer) = explicit_mleader_layer {
             entity.as_entity_mut().set_layer(layer);
-        } else {
+        } else if !preserve_entity_layer {
             let layer = &self.tabs[i].active_layer;
             if layer != "0" || entity.as_entity().layer().is_empty() {
                 entity.as_entity_mut().set_layer(layer.clone());

--- a/src/command.rs
+++ b/src/command.rs
@@ -1734,6 +1734,11 @@ impl InputKind {
 }
 
 pub trait CadCommand: Send {
+    /// Keep the layer already carried by entities committed by this command
+    /// instead of replacing it with the current drawing layer.
+    fn preserve_commit_layer(&self) -> bool {
+        false
+    }
     /// Short name shown in the command line prompt, e.g. `"LINE"`.
     #[allow(dead_code)]
     fn name(&self) -> &'static str;

--- a/src/modules/draw/modify/offset.rs
+++ b/src/modules/draw/modify/offset.rs
@@ -514,6 +514,9 @@ impl OffsetCommand {
 }
 
 impl CadCommand for OffsetCommand {
+    fn preserve_commit_layer(&self) -> bool {
+        true
+    }
     fn name(&self) -> &'static str {
         "OFFSET"
     }

--- a/src/modules/draw/modify/trim.rs
+++ b/src/modules/draw/modify/trim.rs
@@ -149,7 +149,22 @@ impl Geo {
         }
     }
 }
-
+pub fn is_trim_boundary_entity(entity: &EntityType) -> bool {
+    matches!(
+        entity,
+        EntityType::Line(_)
+            | EntityType::Arc(_)
+            | EntityType::Circle(_)
+            | EntityType::Ellipse(_)
+            | EntityType::Ray(_)
+            | EntityType::XLine(_)
+            | EntityType::Spline(_)
+            | EntityType::LwPolyline(_)
+            | EntityType::Polyline(_)
+            | EntityType::Polyline2D(_)
+            | EntityType::Polyline3D(_)
+    )
+}
 fn build_geos(entities: &[EntityType]) -> Vec<Geo> {
     let mut out = Vec::new();
     for e in entities {
@@ -2169,21 +2184,33 @@ pub struct TrimCommand {
 
 impl TrimCommand {
     pub fn new(all_entities: Vec<EntityType>) -> Self {
+        Self::with_cutting_edges(all_entities, Vec::new())
+    }
+
+    pub fn with_cutting_edges(
+        all_entities: Vec<EntityType>,
+        initial_edges: Vec<Handle>,
+    ) -> Self {
         let all_entities: Vec<EntityType> = all_entities
             .iter()
             .map(entity_with_lwpolyline_world_xy)
             .collect();
+
         let entity_index = ModifyEntityIndex::build(&all_entities);
-        let geos = build_geos(&all_entities);
-        Self {
+
+        let mut cmd = Self {
             all_entities,
             entity_index,
-            geos,
+            geos: Vec::new(),
             mode: TrimMode::Pick,
-            edge_set: Vec::new(),
+            edge_set: initial_edges,
             implied_edges: false,
             shift: false,
-        }
+        };
+
+        cmd.rebuild_geos();
+
+        cmd
     }
 
     /// Boundary geometry from the edge selection (or everything when none),


### PR DESCRIPTION
## Summary

Improves OFFSET and TRIM behavior to better preserve drawing intent and support a more conventional CAD workflow.

## OFFSET

OFFSET-created entities now preserve the layer of the source entity instead of being moved to the current active layer.

Previously:

- source entity could belong to another layer;
- running OFFSET created the new entity on the current layer.

Now:

- the offset result inherits the source entity layer;
- ordinary drawing commands continue using the current layer as before.

This applies specifically to commands that explicitly request source-layer preservation and does not change the normal entity creation behavior.

## TRIM

TRIM now honors valid cutting geometry selected before starting the command.

When one or more supported entities are preselected before launching TRIM, those entities are used as the cutting-edge set.

Supported cutting boundaries include:

- Line
- Arc
- Circle
- Ellipse
- Spline
- Ray
- XLine
- LwPolyline
- Polyline
- Polyline2D
- Polyline3D

Polylines continue to use their constituent segments internally as trim boundaries.

### Behavior

With preselection:

1. Select the desired cutting boundaries.
2. Start TRIM.
3. Only those preselected entities define the trim intersections.
4. Click the portions of other geometry that should be removed.

For example, with two preselected boundaries:

    boundary A                 boundary B
        |                          |
--------|---------- X -------------|--------

the clicked portion is trimmed using A and B as the relevant cutting limits, while unrelated intersecting geometry does not become an unintended cutting boundary.

Without preselection:

- TRIM keeps its existing quick-mode behavior;
- the current workflow remains unchanged.

## Why

This makes TRIM more useful in drawings where an entity crosses several unrelated objects.

The user can explicitly define which geometry should control the trim operation before starting the command, while preserving the current fast TRIM behavior when no cutting edges are preselected.

## Validation

- `cargo check --bin OpenCADStudio`
- `git diff --check`

Manual checks:

- OFFSET preserves the source layer when another layer is current.
- Normal entity creation still uses the current layer.
- TRIM with no preselection retains the existing behavior.
- TRIM honors preselected lines as cutting edges.
- TRIM honors multiple preselected cutting edges.
- TRIM accepts polylines as cutting boundaries.
- TRIM accepts circles and arcs as cutting boundaries.
- TRIM accepts ellipses and splines as cutting boundaries.