### PR TITLE
fix(grips): clear OTRACK after typed stretch commit

### DIFF
--- a/src/app/update/command.rs
+++ b/src/app/update/command.rs
@@ -475,6 +475,11 @@ pub(super) fn on_tab_close(&mut self, idx: usize) -> Task<Message> {
                                 // Distance / Angle fields as well.
                                 self.sync_dyn_fields();
 
+                                // A typed grip commit bypasses the normal viewport point-release
+                                // tracking cleanup. Drop the consumed OTRACK / Extension guide now
+                                // so no stale tracking ray remains visible after the grip edit.
+                                self.reset_tracking_after_point();
+
                                 return task;
                             }
                         }


### PR DESCRIPTION
## Summary

Fixes a stale OTRACK guide that could remain visible after completing a grip stretch with a typed distance.

## Fix

After the typed grip stretch is committed, clear the consumed tracking state so the OTRACK guide disappears immediately.

## Validation

- `cargo fmt`
- `cargo check --bin OpenCADStudio`
- `git diff --check`


<img width="1920" height="1080" alt="imagen" src="https://github.com/user-attachments/assets/4774f3ea-ca6d-462b-b3fc-e0fc16393343" />
