### PR TITLE
Keep REVOLVE arc previews responsive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -878,7 +878,7 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 [[package]]
 name = "cadkernel"
 version = "0.1.0"
-source = "git+https://github.com/HakanSeven12/cadkernel.git?rev=5fc881c0f6fbc7fb96d483cd3a4efe145ba6133f#5fc881c0f6fbc7fb96d483cd3a4efe145ba6133f"
+source = "git+https://github.com/HakanSeven12/cadkernel.git?rev=1a1505c7bb8e26770f14b49859587660c7519a25#1a1505c7bb8e26770f14b49859587660c7519a25"
 dependencies = [
  "acadrust",
  "cavalier_contours",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ rfd = "0.17"
 clap = { version = "4", features = ["derive"] }
 env_logger = "0.11"
 acadrust = { git = "https://github.com/HakanSeven12/cadcodec.git", rev = "393d6c0857447f9ca678bed97a612707f0a842c6", features = ["serde"] }
-cadkernel = { git = "https://github.com/HakanSeven12/cadkernel.git", rev = "5fc881c0f6fbc7fb96d483cd3a4efe145ba6133f", features = ["acis", "offset"] }
+cadkernel = { git = "https://github.com/HakanSeven12/cadkernel.git", rev = "1a1505c7bb8e26770f14b49859587660c7519a25", features = ["acis", "offset"] }
 dwg-thumbnailer = { path = "crates/dwg-thumbnailer" }
 flate2 = "1"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "bmp", "tiff"] }

--- a/src/modules/insert/solid3d_cmds.rs
+++ b/src/modules/insert/solid3d_cmds.rs
@@ -168,7 +168,9 @@ fn preview_body_wires(
     color: [f32; 4],
     isolines: usize,
 ) -> Vec<WireModel> {
-    let mesh = cadkernel::brep::mesh::tessellate(
+    // This overlay only consumes curves. Do not triangulate the body's faces
+    // on every cursor event just to discard the resulting surface mesh.
+    let wireframe = cadkernel::brep::mesh::tessellate_wireframe(
         body,
         cadkernel::brep::mesh::TessellationTolerance::new(
             cadkernel::tessellation::DEFAULT_ANGLE,
@@ -176,7 +178,7 @@ fn preview_body_wires(
         )
         .with_isolines(isolines),
     );
-    let mut wires = mesh
+    let mut wires = wireframe
         .edges
         .into_iter()
         .filter(|edge| edge.positions.len() >= 2)
@@ -190,7 +192,7 @@ fn preview_body_wires(
         })
         .collect::<Vec<_>>();
     wires.extend(
-        mesh.isolines
+        wireframe.isolines
             .into_iter()
             .filter(|line| line.positions.len() >= 2)
             .map(|line| {


### PR DESCRIPTION
1) Route the live sweep wire overlay through cadkernel::brep::mesh::tessellate_wireframe instead of the full face tessellator. Mouse movement during REVOLVE no longer generates and discards constrained spherical or toroidal triangle meshes.

2) Preserve topological boundary lines and the existing REVOLVE cage isolines, including their exact sampled positions, count, color, wire names, and angular/linear tolerances. No lower-quality preview approximation or application-specific geometry algorithm is introduced.

3) Keep angle measurement, start-angle selection, reverse direction, dynamic input, solid/surface mode, source consumption, and final body creation unchanged. Completed objects continue to use full display tessellation.

4) Apply the same curve-only path to the shared EXTRUDE preview helper. EXTRUDE still requests zero isolines and keeps its existing boundary-wire output while avoiding unused face mesh work.

5) Pin cadkernel in Cargo.toml and Cargo.lock to 1a1505c7bb8e26770f14b49859587660c7519a25. The general geometry implementation is in HakanSeven12/cadkernel#20; merge that dependency before this PR. No other dependency versions are changed.

6) Optimized local geometry profiling covered semicircular and minor-arc sheets at 15, 45, 90, 120, 180, 270, 359, and 360 degrees. All 16 cases had exactly equal edge and isoline arrays and zero missing faces. For the 359-degree minor arc, full tessellation took 649.072 ms and curve-only tessellation took 0.636 ms. These are geometry preparation timings, not end-to-end frame-rate claims.

7) Independent review found no issues in the kernel extraction and application integration; git diff --check passed. No formatter or test commands were run. cargo build --release --locked completed successfully in 9m 17s. Only existing unused-code warnings were emitted.

8) This is the live-preview performance follow-up to merged #986. It preserves the previously delivered arc revolution geometry, partial angles, and cage display. Work started from current upstream main; no existing feature worktrees were overwritten.

9) Deploy the verified release to the existing per-user installation and the main workspace release location, without creating executable backups. The desktop and Start-menu shortcuts continue to target the updated per-user installation. The launched process and both deployed files have SHA-256 6401B3794ADB85C119E7CD244DCEDDD21076D3BA38D83DFAFF65662C56642086. The Windows application start screen was visually confirmed. User drawings were not saved.