### PR TITLE
Complete LOFT commands, surfaces and editable history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -878,7 +878,7 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 [[package]]
 name = "cadkernel"
 version = "0.1.0"
-source = "git+https://github.com/HakanSeven12/cadkernel.git?rev=36a2c56415f19c9e1be15d56592208e77bd73d0e#36a2c56415f19c9e1be15d56592208e77bd73d0e"
+source = "git+https://github.com/HakanSeven12/cadkernel.git?rev=3899c46e22e92d2e888f43405a36031365d6b1d5#3899c46e22e92d2e888f43405a36031365d6b1d5"
 dependencies = [
  "acadrust",
  "cavalier_contours",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,8 +71,8 @@ checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
 
 [[package]]
 name = "acadrust"
-version = "0.5.1"
-source = "git+https://git@github.com/HakanSeven12/cadcodec.git?rev=393d6c0857447f9ca678bed97a612707f0a842c6#393d6c0857447f9ca678bed97a612707f0a842c6"
+version = "0.5.3"
+source = "git+https://git@github.com/HakanSeven12/cadcodec.git?rev=305e93d4cf8ff70ce8449015edb201c2765fcc04#305e93d4cf8ff70ce8449015edb201c2765fcc04"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
@@ -878,7 +878,7 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 [[package]]
 name = "cadkernel"
 version = "0.1.0"
-source = "git+https://github.com/HakanSeven12/cadkernel.git?rev=1a1505c7bb8e26770f14b49859587660c7519a25#1a1505c7bb8e26770f14b49859587660c7519a25"
+source = "git+https://github.com/HakanSeven12/cadkernel.git?rev=209df414c9c0434af00edabc5529c6c774091f0e#209df414c9c0434af00edabc5529c6c774091f0e"
 dependencies = [
  "acadrust",
  "cavalier_contours",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,7 @@ checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
 [[package]]
 name = "acadrust"
 version = "0.5.4"
-source = "git+https://git@github.com/HakanSeven12/cadcodec.git?rev=41efc90be0dbf165a1a46213d0567b46664a22c3#41efc90be0dbf165a1a46213d0567b46664a22c3"
+source = "git+https://git@github.com/HakanSeven12/cadcodec.git?rev=580678d28f11ccbefbce3f9d3390d28ef4bbde80#580678d28f11ccbefbce3f9d3390d28ef4bbde80"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
@@ -878,7 +878,7 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 [[package]]
 name = "cadkernel"
 version = "0.1.0"
-source = "git+https://github.com/HakanSeven12/cadkernel.git?rev=3f3d715f3082852d0c76b9123f79283deb65d267#3f3d715f3082852d0c76b9123f79283deb65d267"
+source = "git+https://github.com/HakanSeven12/cadkernel.git?rev=5565ec3f23f6629974d2a5fed5215d2b92738a58#5565ec3f23f6629974d2a5fed5215d2b92738a58"
 dependencies = [
  "acadrust",
  "cavalier_contours",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,7 @@ checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
 [[package]]
 name = "acadrust"
 version = "0.5.4"
-source = "git+https://git@github.com/HakanSeven12/cadcodec.git?rev=0edbe8a945fa1de434d6ee88b2836dcaad459cbc#0edbe8a945fa1de434d6ee88b2836dcaad459cbc"
+source = "git+https://git@github.com/HakanSeven12/cadcodec.git?rev=41efc90be0dbf165a1a46213d0567b46664a22c3#41efc90be0dbf165a1a46213d0567b46664a22c3"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
@@ -878,7 +878,7 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 [[package]]
 name = "cadkernel"
 version = "0.1.0"
-source = "git+https://github.com/HakanSeven12/cadkernel.git?rev=0e7b97e4e6a22e4c46fb8b72e3bdd1dce3262052#0e7b97e4e6a22e4c46fb8b72e3bdd1dce3262052"
+source = "git+https://github.com/HakanSeven12/cadkernel.git?rev=3f3d715f3082852d0c76b9123f79283deb65d267#3f3d715f3082852d0c76b9123f79283deb65d267"
 dependencies = [
  "acadrust",
  "cavalier_contours",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -878,7 +878,7 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 [[package]]
 name = "cadkernel"
 version = "0.1.0"
-source = "git+https://github.com/HakanSeven12/cadkernel.git?rev=5fc881c0f6fbc7fb96d483cd3a4efe145ba6133f#5fc881c0f6fbc7fb96d483cd3a4efe145ba6133f"
+source = "git+https://github.com/HakanSeven12/cadkernel.git?rev=1a1505c7bb8e26770f14b49859587660c7519a25#1a1505c7bb8e26770f14b49859587660c7519a25"
 dependencies = [
  "acadrust",
  "cavalier_contours",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,7 @@ checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
 [[package]]
 name = "acadrust"
 version = "0.5.4"
-source = "git+https://git@github.com/HakanSeven12/cadcodec.git?rev=da65c079396eb6e48d0f5d411eb0f87477479ee2#da65c079396eb6e48d0f5d411eb0f87477479ee2"
+source = "git+https://git@github.com/HakanSeven12/cadcodec.git?rev=0edbe8a945fa1de434d6ee88b2836dcaad459cbc#0edbe8a945fa1de434d6ee88b2836dcaad459cbc"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
@@ -878,7 +878,7 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 [[package]]
 name = "cadkernel"
 version = "0.1.0"
-source = "git+https://github.com/HakanSeven12/cadkernel.git?rev=3899c46e22e92d2e888f43405a36031365d6b1d5#3899c46e22e92d2e888f43405a36031365d6b1d5"
+source = "git+https://github.com/HakanSeven12/cadkernel.git?rev=0e7b97e4e6a22e4c46fb8b72e3bdd1dce3262052#0e7b97e4e6a22e4c46fb8b72e3bdd1dce3262052"
 dependencies = [
  "acadrust",
  "cavalier_contours",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,8 +71,8 @@ checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
 
 [[package]]
 name = "acadrust"
-version = "0.5.3"
-source = "git+https://git@github.com/HakanSeven12/cadcodec.git?rev=305e93d4cf8ff70ce8449015edb201c2765fcc04#305e93d4cf8ff70ce8449015edb201c2765fcc04"
+version = "0.5.4"
+source = "git+https://git@github.com/HakanSeven12/cadcodec.git?rev=da65c079396eb6e48d0f5d411eb0f87477479ee2#da65c079396eb6e48d0f5d411eb0f87477479ee2"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
@@ -878,7 +878,7 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 [[package]]
 name = "cadkernel"
 version = "0.1.0"
-source = "git+https://github.com/HakanSeven12/cadkernel.git?rev=209df414c9c0434af00edabc5529c6c774091f0e#209df414c9c0434af00edabc5529c6c774091f0e"
+source = "git+https://github.com/HakanSeven12/cadkernel.git?rev=5dbd3dfb9a29af3112c082a8de2d0587ec1b7b16#5dbd3dfb9a29af3112c082a8de2d0587ec1b7b16"
 dependencies = [
  "acadrust",
  "cavalier_contours",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -878,7 +878,7 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 [[package]]
 name = "cadkernel"
 version = "0.1.0"
-source = "git+https://github.com/HakanSeven12/cadkernel.git?rev=5dbd3dfb9a29af3112c082a8de2d0587ec1b7b16#5dbd3dfb9a29af3112c082a8de2d0587ec1b7b16"
+source = "git+https://github.com/HakanSeven12/cadkernel.git?rev=36a2c56415f19c9e1be15d56592208e77bd73d0e#36a2c56415f19c9e1be15d56592208e77bd73d0e"
 dependencies = [
  "acadrust",
  "cavalier_contours",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ glam = { version = "0.33", features = ["bytemuck"] }
 rfd = "0.17"
 clap = { version = "4", features = ["derive"] }
 env_logger = "0.11"
-acadrust = { git = "https://github.com/HakanSeven12/cadcodec.git", rev = "393d6c0857447f9ca678bed97a612707f0a842c6", features = ["serde"] }
-cadkernel = { git = "https://github.com/HakanSeven12/cadkernel.git", rev = "1a1505c7bb8e26770f14b49859587660c7519a25", features = ["acis", "offset"] }
+acadrust = { git = "https://github.com/HakanSeven12/cadcodec.git", rev = "305e93d4cf8ff70ce8449015edb201c2765fcc04", features = ["serde"] }
+cadkernel = { git = "https://github.com/HakanSeven12/cadkernel.git", rev = "209df414c9c0434af00edabc5529c6c774091f0e", features = ["acis", "offset"] }
 dwg-thumbnailer = { path = "crates/dwg-thumbnailer" }
 flate2 = "1"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "bmp", "tiff"] }
@@ -61,7 +61,7 @@ iced_core = { git = "https://github.com/iced-rs/iced.git", rev = "23604ff22ab0aa
 iced_widget = { git = "https://github.com/iced-rs/iced.git", rev = "23604ff22ab0aad9e00b9327cb7b8546ed84db39" }
 
 [patch."https://github.com/HakanSeven12/cadcodec.git"]
-acadrust = { git = "https://git@github.com/HakanSeven12/cadcodec.git", rev = "393d6c0857447f9ca678bed97a612707f0a842c6" }
+acadrust = { git = "https://git@github.com/HakanSeven12/cadcodec.git", rev = "305e93d4cf8ff70ce8449015edb201c2765fcc04" }
 
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ glam = { version = "0.33", features = ["bytemuck"] }
 rfd = "0.17"
 clap = { version = "4", features = ["derive"] }
 env_logger = "0.11"
-acadrust = { git = "https://github.com/HakanSeven12/cadcodec.git", rev = "0edbe8a945fa1de434d6ee88b2836dcaad459cbc", features = ["serde"] }
-cadkernel = { git = "https://github.com/HakanSeven12/cadkernel.git", rev = "0e7b97e4e6a22e4c46fb8b72e3bdd1dce3262052", features = ["acis", "offset"] }
+acadrust = { git = "https://github.com/HakanSeven12/cadcodec.git", rev = "41efc90be0dbf165a1a46213d0567b46664a22c3", features = ["serde"] }
+cadkernel = { git = "https://github.com/HakanSeven12/cadkernel.git", rev = "3f3d715f3082852d0c76b9123f79283deb65d267", features = ["acis", "offset"] }
 dwg-thumbnailer = { path = "crates/dwg-thumbnailer" }
 flate2 = "1"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "bmp", "tiff"] }
@@ -61,7 +61,7 @@ iced_core = { git = "https://github.com/iced-rs/iced.git", rev = "23604ff22ab0aa
 iced_widget = { git = "https://github.com/iced-rs/iced.git", rev = "23604ff22ab0aad9e00b9327cb7b8546ed84db39" }
 
 [patch."https://github.com/HakanSeven12/cadcodec.git"]
-acadrust = { git = "https://git@github.com/HakanSeven12/cadcodec.git", rev = "0edbe8a945fa1de434d6ee88b2836dcaad459cbc" }
+acadrust = { git = "https://git@github.com/HakanSeven12/cadcodec.git", rev = "41efc90be0dbf165a1a46213d0567b46664a22c3" }
 
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ glam = { version = "0.33", features = ["bytemuck"] }
 rfd = "0.17"
 clap = { version = "4", features = ["derive"] }
 env_logger = "0.11"
-acadrust = { git = "https://github.com/HakanSeven12/cadcodec.git", rev = "41efc90be0dbf165a1a46213d0567b46664a22c3", features = ["serde"] }
-cadkernel = { git = "https://github.com/HakanSeven12/cadkernel.git", rev = "3f3d715f3082852d0c76b9123f79283deb65d267", features = ["acis", "offset"] }
+acadrust = { git = "https://github.com/HakanSeven12/cadcodec.git", rev = "580678d28f11ccbefbce3f9d3390d28ef4bbde80", features = ["serde"] }
+cadkernel = { git = "https://github.com/HakanSeven12/cadkernel.git", rev = "5565ec3f23f6629974d2a5fed5215d2b92738a58", features = ["acis", "offset"] }
 dwg-thumbnailer = { path = "crates/dwg-thumbnailer" }
 flate2 = "1"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "bmp", "tiff"] }
@@ -61,7 +61,7 @@ iced_core = { git = "https://github.com/iced-rs/iced.git", rev = "23604ff22ab0aa
 iced_widget = { git = "https://github.com/iced-rs/iced.git", rev = "23604ff22ab0aad9e00b9327cb7b8546ed84db39" }
 
 [patch."https://github.com/HakanSeven12/cadcodec.git"]
-acadrust = { git = "https://git@github.com/HakanSeven12/cadcodec.git", rev = "41efc90be0dbf165a1a46213d0567b46664a22c3" }
+acadrust = { git = "https://git@github.com/HakanSeven12/cadcodec.git", rev = "580678d28f11ccbefbce3f9d3390d28ef4bbde80" }
 
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ glam = { version = "0.33", features = ["bytemuck"] }
 rfd = "0.17"
 clap = { version = "4", features = ["derive"] }
 env_logger = "0.11"
-acadrust = { git = "https://github.com/HakanSeven12/cadcodec.git", rev = "da65c079396eb6e48d0f5d411eb0f87477479ee2", features = ["serde"] }
-cadkernel = { git = "https://github.com/HakanSeven12/cadkernel.git", rev = "3899c46e22e92d2e888f43405a36031365d6b1d5", features = ["acis", "offset"] }
+acadrust = { git = "https://github.com/HakanSeven12/cadcodec.git", rev = "0edbe8a945fa1de434d6ee88b2836dcaad459cbc", features = ["serde"] }
+cadkernel = { git = "https://github.com/HakanSeven12/cadkernel.git", rev = "0e7b97e4e6a22e4c46fb8b72e3bdd1dce3262052", features = ["acis", "offset"] }
 dwg-thumbnailer = { path = "crates/dwg-thumbnailer" }
 flate2 = "1"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "bmp", "tiff"] }
@@ -61,7 +61,7 @@ iced_core = { git = "https://github.com/iced-rs/iced.git", rev = "23604ff22ab0aa
 iced_widget = { git = "https://github.com/iced-rs/iced.git", rev = "23604ff22ab0aad9e00b9327cb7b8546ed84db39" }
 
 [patch."https://github.com/HakanSeven12/cadcodec.git"]
-acadrust = { git = "https://git@github.com/HakanSeven12/cadcodec.git", rev = "da65c079396eb6e48d0f5d411eb0f87477479ee2" }
+acadrust = { git = "https://git@github.com/HakanSeven12/cadcodec.git", rev = "0edbe8a945fa1de434d6ee88b2836dcaad459cbc" }
 
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ glam = { version = "0.33", features = ["bytemuck"] }
 rfd = "0.17"
 clap = { version = "4", features = ["derive"] }
 env_logger = "0.11"
-acadrust = { git = "https://github.com/HakanSeven12/cadcodec.git", rev = "305e93d4cf8ff70ce8449015edb201c2765fcc04", features = ["serde"] }
-cadkernel = { git = "https://github.com/HakanSeven12/cadkernel.git", rev = "209df414c9c0434af00edabc5529c6c774091f0e", features = ["acis", "offset"] }
+acadrust = { git = "https://github.com/HakanSeven12/cadcodec.git", rev = "da65c079396eb6e48d0f5d411eb0f87477479ee2", features = ["serde"] }
+cadkernel = { git = "https://github.com/HakanSeven12/cadkernel.git", rev = "5dbd3dfb9a29af3112c082a8de2d0587ec1b7b16", features = ["acis", "offset"] }
 dwg-thumbnailer = { path = "crates/dwg-thumbnailer" }
 flate2 = "1"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "bmp", "tiff"] }
@@ -61,7 +61,7 @@ iced_core = { git = "https://github.com/iced-rs/iced.git", rev = "23604ff22ab0aa
 iced_widget = { git = "https://github.com/iced-rs/iced.git", rev = "23604ff22ab0aad9e00b9327cb7b8546ed84db39" }
 
 [patch."https://github.com/HakanSeven12/cadcodec.git"]
-acadrust = { git = "https://git@github.com/HakanSeven12/cadcodec.git", rev = "305e93d4cf8ff70ce8449015edb201c2765fcc04" }
+acadrust = { git = "https://git@github.com/HakanSeven12/cadcodec.git", rev = "da65c079396eb6e48d0f5d411eb0f87477479ee2" }
 
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ rfd = "0.17"
 clap = { version = "4", features = ["derive"] }
 env_logger = "0.11"
 acadrust = { git = "https://github.com/HakanSeven12/cadcodec.git", rev = "393d6c0857447f9ca678bed97a612707f0a842c6", features = ["serde"] }
-cadkernel = { git = "https://github.com/HakanSeven12/cadkernel.git", rev = "5fc881c0f6fbc7fb96d483cd3a4efe145ba6133f", features = ["acis", "offset"] }
+cadkernel = { git = "https://github.com/HakanSeven12/cadkernel.git", rev = "1a1505c7bb8e26770f14b49859587660c7519a25", features = ["acis", "offset"] }
 dwg-thumbnailer = { path = "crates/dwg-thumbnailer" }
 flate2 = "1"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "bmp", "tiff"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ rfd = "0.17"
 clap = { version = "4", features = ["derive"] }
 env_logger = "0.11"
 acadrust = { git = "https://github.com/HakanSeven12/cadcodec.git", rev = "da65c079396eb6e48d0f5d411eb0f87477479ee2", features = ["serde"] }
-cadkernel = { git = "https://github.com/HakanSeven12/cadkernel.git", rev = "5dbd3dfb9a29af3112c082a8de2d0587ec1b7b16", features = ["acis", "offset"] }
+cadkernel = { git = "https://github.com/HakanSeven12/cadkernel.git", rev = "36a2c56415f19c9e1be15d56592208e77bd73d0e", features = ["acis", "offset"] }
 dwg-thumbnailer = { path = "crates/dwg-thumbnailer" }
 flate2 = "1"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "bmp", "tiff"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ rfd = "0.17"
 clap = { version = "4", features = ["derive"] }
 env_logger = "0.11"
 acadrust = { git = "https://github.com/HakanSeven12/cadcodec.git", rev = "da65c079396eb6e48d0f5d411eb0f87477479ee2", features = ["serde"] }
-cadkernel = { git = "https://github.com/HakanSeven12/cadkernel.git", rev = "36a2c56415f19c9e1be15d56592208e77bd73d0e", features = ["acis", "offset"] }
+cadkernel = { git = "https://github.com/HakanSeven12/cadkernel.git", rev = "3899c46e22e92d2e888f43405a36031365d6b1d5", features = ["acis", "offset"] }
 dwg-thumbnailer = { path = "crates/dwg-thumbnailer" }
 flate2 = "1"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "bmp", "tiff"] }

--- a/src/app/command_driver.rs
+++ b/src/app/command_driver.rs
@@ -4065,7 +4065,7 @@ impl OpenCADStudio {
                     }
                     self.tabs[i].dirty = true;
                     self.command_line.push_output(crate::tf!(
-                        "SWEEP: created %{created} object(s); %{failed} source(s) could not be swept.",
+                        "SWEEP: created {created} object(s); {failed} source(s) could not be swept.",
                         created = created_handles.len(), failed = failed
                     ).as_ref());
                 } else {

--- a/src/app/command_driver.rs
+++ b/src/app/command_driver.rs
@@ -4082,53 +4082,73 @@ impl OpenCADStudio {
             }
 
             // ── LOFT ──────────────────────────────────────────────────────
-            CmdResult::LoftEntities { handles, color: _ } => {
-                if let Some(handle) = handles
-                    .iter()
-                    .find(|handle| self.tabs[i].scene.is_layer_locked(**handle))
-                    .copied()
-                {
-                    self.reject_locked_edit(i, handle);
-                    self.tabs[i].active_cmd = None;
-                    return Task::none();
-                }
+            CmdResult::LoftEntities { sections, guides, path, mode, options, color: _ } => {
+                use crate::command::LoftSectionSelection;
                 use crate::modules::insert::solid3d_cmds::empty_solid3d;
-                use crate::scene::model::{solid_history, sweep_model};
-
-                let profiles: Vec<acadrust::EntityType> = handles
-                    .iter()
-                    .filter_map(|handle| self.tabs[i].scene.document.get_entity(*handle).cloned())
-                    .collect();
-                let result = sweep_model::loft_history(&profiles)
-                    .and_then(|history| {
-                        cadkernel::acis::rebuild_body(&history)
-                            .ok()
-                            .map(|solid| (solid, history))
-                    })
-                    .or_else(|| {
-                        sweep_model::lofted(&profiles).map(|solid| {
-                            let history = solid_history::brep_op(&solid);
-                            (solid, history)
-                        })
-                    });
-                if let Some((solid, history)) = result {
-                    let pending = self.begin_undo(i, "LOFT", 1, true);
-                    let created = self.add_solid_model(empty_solid3d(), solid, history);
-                    if !created.is_null() {
-                        self.tabs[i].dirty = true;
-                        self.command_line
-                            .push_output(crate::t!("LOFT: solid created.").as_ref());
-                        if let Some(pd) = pending {
-                            self.commit_undo_delta(i, pd);
-                        }
-                    }
+                use crate::scene::model::loft_command_model;
+                let mut sources = sections.iter().flat_map(|section| match section {
+                    LoftSectionSelection::Entity(handle) => vec![*handle],
+                    LoftSectionSelection::Join(handles) => handles.clone(),
+                    LoftSectionSelection::Point(_) => Vec::new(),
+                }).collect::<Vec<_>>();
+                sources.sort_unstable_by_key(|handle| handle.value());
+                sources.dedup();
+                let delete_sources = self.tabs[i].scene.document.header.delete_objects;
+                let locked = delete_sources && sources.iter().any(|handle| self.tabs[i].scene.is_layer_locked(*handle));
+                let available = sources.iter().chain(guides.iter()).copied().chain(path)
+                    .filter_map(|handle| self.tabs[i].scene.document.get_entity(handle)
+                        .cloned().map(|entity| (handle, entity))).collect::<Vec<_>>();
+                let result = if locked {
+                    Err("LOFT: a source is on a locked layer; disable source deletion or unlock it.".to_string())
                 } else {
-                    self.command_line.push_error(crate::t!("LOFT: select at least two closed profiles.").as_ref());
+                    loft_command_model::record(&sections, &guides, path, &available, mode, options)
+                        .and_then(|record| cadkernel::acis::rebuild_loft_with_options(&record).map(|body| (body, record)))
+                };
+                match result {
+                    Ok((body, record)) => {
+                        let surface = record.parameters.as_ref().is_some_and(|settings| settings.surface);
+                        let dirty_before = self.tabs[i].dirty;
+                        let pending = self.begin_undo(i, "LOFT", 1, true);
+                        let created = if surface {
+                            let handle = self.add_surface_model(loft_command_model::surface_entity(&record), body);
+                            if !handle.is_null() {
+                                self.tabs[i].scene.create_solid_history(handle,
+                                    acadrust::objects::SolidHistoryOperation::Loft(record));
+                            }
+                            handle
+                        } else {
+                            self.add_solid_model(empty_solid3d(), body,
+                                acadrust::objects::SolidHistoryOperation::Loft(record))
+                        };
+                        if created.is_null() {
+                            // The creation helper already removed its provisional
+                            // result. Discard its empty undo recording as well.
+                            self.tabs[i].scene.take_undo_recording();
+                            self.tabs[i].dirty = dirty_before;
+                            self.command_line.push_error(crate::t!("LOFT could not create a complete display. The source sections were preserved.").as_ref());
+                            return Task::none();
+                        } else {
+                            if delete_sources { self.tabs[i].scene.erase_entities(&sources); }
+                            self.tabs[i].scene.deselect_all();
+                            self.tabs[i].scene.select_entity(created, true);
+                            self.tabs[i].dirty = true;
+                            let message = if surface {
+                                crate::t!("LOFT: surface created.")
+                            } else { crate::t!("LOFT: solid created.") };
+                            self.command_line.push_output(message.as_ref());
+                        }
+                        if let Some(pending) = pending { self.commit_undo_delta(i, pending); }
+                    }
+                    Err(error) => {
+                        self.command_line.push_error(&error);
+                        return Task::none();
+                    }
                 }
                 self.tabs[i].active_cmd = None;
                 self.tabs[i].snap_result = None;
                 self.tabs[i].scene.clear_preview_wire();
                 self.restore_pre_cmd_tangent();
+                self.refresh_properties();
             }
 
             CmdResult::SolidEdgeBlend {

--- a/src/app/command_driver.rs
+++ b/src/app/command_driver.rs
@@ -353,6 +353,17 @@ impl OpenCADStudio {
             self.reset_tracking_after_point();
             self.push_ucs_to_cmd(i);
         }
+        if let StepInput::EntityPick(handle, _) = &input {
+            if self.tabs[i].active_cmd.as_ref()
+                .is_some_and(|command| command.inject_before_entity_pick())
+            {
+                if let Some(entity) = self.tabs[i].scene.document.get_entity(*handle).cloned() {
+                    if let Some(command) = self.tabs[i].active_cmd.as_mut() {
+                        command.inject_picked_entity(entity);
+                    }
+                }
+            }
+        }
         if let StepInput::SelectionComplete(handles) = &input {
             let entities = {
                 let scene = &self.tabs[i].scene;
@@ -3979,57 +3990,95 @@ impl OpenCADStudio {
                 self.refresh_properties();
             }
             // ── SWEEP ─────────────────────────────────────────────────────
-            CmdResult::SweepEntity {
-                profile_handle,
+            CmdResult::SweepEntities {
+                handles,
                 path_handle,
+                mode,
+                options,
                 color: _,
             } => {
-                if self.reject_locked_edit(i, profile_handle)
-                    || self.reject_locked_edit(i, path_handle)
-                {
-                    self.tabs[i].active_cmd = None;
-                    return Task::none();
-                }
+                use crate::command::ExtrudeMode;
                 use crate::modules::insert::solid3d_cmds::empty_solid3d;
-                use crate::scene::model::{solid_history, sweep_model};
-
-                let profile_ent = self.tabs[i]
-                    .scene
-                    .document
-                    .get_entity(profile_handle)
-                    .cloned();
-                let path_ent = self.tabs[i].scene.document.get_entity(path_handle).cloned();
-                let result = profile_ent.zip(path_ent).and_then(|(profile, path)| {
-                    let reference_point = sweep_model::profile_of(&profile)?.plane.origin;
-                    let solid = sweep_model::swept(&profile, &path)?;
-                    let history = sweep_model::sweep_history(
-                        &profile,
-                        &path,
-                        0.0,
-                        reference_point,
-                    )
-                    .unwrap_or_else(|| solid_history::brep_op(&solid));
-                    Some((solid, history))
-                });
-
-                if let Some((solid, history)) = result {
-                    let pending = self.begin_undo(i, "SWEEP", 1, true);
-                    let created = self.add_solid_model(empty_solid3d(), solid, history);
-                    if !created.is_null() {
-                        self.tabs[i].dirty = true;
-                        self.command_line
-                            .push_output(crate::t!("SWEEP: solid created.").as_ref());
-                        if let Some(pd) = pending {
-                            self.commit_undo_delta(i, pd);
+                use crate::scene::model::sweep_model;
+                let delete_sources = self.tabs[i].scene.document.header.delete_objects;
+                let path = self.tabs[i].scene.document.get_entity(path_handle).cloned();
+                let mut profiles = Vec::new();
+                let mut failed = 0usize;
+                for handle in handles {
+                    if handle == path_handle || self.reject_locked_edit(i, handle) {
+                        failed += 1;
+                        continue;
+                    }
+                    if let Some(entity) = self.tabs[i].scene.document.get_entity(handle).cloned() {
+                        profiles.push((handle, entity));
+                    } else {
+                        failed += 1;
+                    }
+                }
+                let selection = profiles.iter().map(|(_, entity)| entity.clone()).collect::<Vec<_>>();
+                let options = sweep_model::sweep_selection_options(&selection, options);
+                let pending = if profiles.is_empty() {
+                    None
+                } else {
+                    self.begin_undo(i, "SWEEP", profiles.len(), true)
+                };
+                let mut created_handles = Vec::new();
+                let mut consumed = Vec::new();
+                for (handle, profile) in profiles {
+                    let result = path.as_ref().zip(options).and_then(|(path, options)| {
+                        let record = sweep_model::sweep_record(&profile, path, options)?;
+                        let (_, _, closed) = cadkernel::acis::sweep_profile_geometry(
+                            record.sweep_entity.as_ref()?, record.sweep_entity_transform,
+                        ).ok()?;
+                        let surface = mode == ExtrudeMode::Surface || !closed;
+                        let body = cadkernel::acis::rebuild_sweep_with_mode(&record, surface).ok()?;
+                        Some((body, record, surface))
+                    });
+                    let Some((body, record, surface)) = result else {
+                        failed += 1;
+                        continue;
+                    };
+                    let created = if surface {
+                        self.add_surface_model(sweep_model::swept_surface_entity(&record), body)
+                    } else {
+                        self.add_solid_model(
+                            empty_solid3d(), body,
+                            acadrust::objects::SolidHistoryOperation::Sweep(record),
+                        )
+                    };
+                    if created.is_null() {
+                        failed += 1;
+                    } else {
+                        created_handles.push(created);
+                        if delete_sources {
+                            consumed.push(handle);
                         }
                     }
+                }
+                if !created_handles.is_empty() {
+                    consumed.sort_unstable_by_key(|handle| handle.value());
+                    consumed.dedup();
+                    self.tabs[i].scene.erase_entities(&consumed);
+                    self.tabs[i].scene.deselect_all();
+                    for handle in &created_handles {
+                        self.tabs[i].scene.select_entity(*handle, true);
+                    }
+                    self.tabs[i].dirty = true;
+                    self.command_line.push_output(crate::tf!(
+                        "SWEEP: created %{created} object(s); %{failed} source(s) could not be swept.",
+                        created = created_handles.len(), failed = failed
+                    ).as_ref());
                 } else {
                     self.command_line.push_error(crate::t!("SWEEP: could not sweep the profile along the path.").as_ref());
+                }
+                if let Some(pending) = pending {
+                    self.commit_undo_delta(i, pending);
                 }
                 self.tabs[i].active_cmd = None;
                 self.tabs[i].snap_result = None;
                 self.tabs[i].scene.clear_preview_wire();
                 self.restore_pre_cmd_tangent();
+                self.refresh_properties();
             }
 
             // ── LOFT ──────────────────────────────────────────────────────

--- a/src/app/commands/display.rs
+++ b/src/app/commands/display.rs
@@ -832,7 +832,13 @@ impl OpenCADStudio {
             "LOFT" => {
                 use crate::modules::insert::solid3d_cmds::LoftCommand;
                 let color = self.tabs[i].scene.layer_color(&self.tabs[i].active_layer);
-                let cmd = LoftCommand::new(color);
+                let isolines = self.tabs[i].scene.document.header.isolines.max(0) as usize;
+                let selected = self.tabs[i].scene.selected_handles_in_order().into_iter()
+                    .filter_map(|handle| self.tabs[i].scene.document.get_entity(handle)
+                        .cloned().map(|entity| (handle, entity))).collect();
+                let available = self.tabs[i].scene.document.entities()
+                    .map(|entity| (entity.common().handle, entity.clone())).collect();
+                let cmd = LoftCommand::new(color, isolines, crate::command::ExtrudeMode::Solid, selected, available);
                 self.command_line.push_info(&cmd.prompt());
                 self.tabs[i].active_cmd = Some(Box::new(cmd));
             }

--- a/src/app/commands/display.rs
+++ b/src/app/commands/display.rs
@@ -814,7 +814,16 @@ impl OpenCADStudio {
             "SWEEP" => {
                 use crate::modules::insert::solid3d_cmds::SweepCommand;
                 let color = self.tabs[i].scene.layer_color(&self.tabs[i].active_layer);
-                let cmd = SweepCommand::new(color);
+                let isolines = self.tabs[i].scene.document.header.isolines.max(0) as usize;
+                let mut cmd = SweepCommand::new(color, isolines);
+                let selected = self.tabs[i].scene.selected_handles_in_order()
+                    .into_iter()
+                    .filter_map(|handle| self.tabs[i].scene.document.get_entity(handle)
+                        .cloned().map(|entity| (handle, entity)))
+                    .collect::<Vec<_>>();
+                if !selected.is_empty() {
+                    cmd.set_preselection(selected);
+                }
                 self.command_line.push_info(&cmd.prompt());
                 self.tabs[i].active_cmd = Some(Box::new(cmd));
             }

--- a/src/app/commands/styleprops.rs
+++ b/src/app/commands/styleprops.rs
@@ -830,6 +830,8 @@ impl OpenCADStudio {
                     | "BLIPMODE"
                     | "SPLFRAME"
                     | "DELOBJ"
+                    | "SOLIDHIST"
+                    | "SHOWHIST"
                     | "PLINEGEN"
                     | "PSLTSCALE"
                     | "DISPSILH"
@@ -926,6 +928,37 @@ impl OpenCADStudio {
                         "SETVAR: LTSCALE CELTSCALE PDMODE PDSIZE TEXTSIZE ORTHOMODE FILLMODE MIRRTEXT FRAME IMAGEFRAME PDFFRAME WIPEOUTFRAME XCLIPFRAME POINTCLOUDCLIPFRAME ZOOMWHEEL ZOOMFACTOR CURSORSIZE PICKBOX CURSORTYPE SNAPANG TEXTFILL CLIPROMPTLINES ATTREQ ATTDIA DIMASSOC DIMCONTINUEMODE ANGBASE ANGDIR SKETCHINC SKPOLY SKTOLERANCE DONUTID DONUTOD CENTEREXE CENTERLAYER CENTERLTYPE CENTERLTSCALE CENTERLTYPEFILE CENTERCROSSSIZE CENTERCROSSGAP CENTERMARKEXE COLORTHEME SELECTIONAREA SELECTIONAREAOPACITY SELECTIONEFFECT SELECTIONEFFECTCOLOR WINDOWSAREACOLOR CROSSINGAREACOLOR SELECTIONPREVIEW GRIPSIZE GRIPCOLOR GRIPHOT GRIPHOVER | CLAYER CELTYPE TEXTSTYLE (read-only)",
                     );
                 } else {
+                    if matches!(name.as_str(), "SHOWHIST" | "SOLIDHIST") {
+                        let current = if name == "SHOWHIST" {
+                            self.tabs[i].scene.document.header.show_solid_history.clamp(0, 2)
+                        } else {
+                            i16::from(self.tabs[i].scene.document.header.record_solid_history)
+                        };
+                        if let Some(value) = &value {
+                            let maximum = if name == "SHOWHIST" { 2 } else { 1 };
+                            match value.parse::<i16>().ok().filter(|value| (0..=maximum).contains(value)) {
+                                Some(mode) => {
+                                    if current != mode {
+                                        self.push_undo_snapshot(i, &name);
+                                        if name == "SHOWHIST" {
+                                            self.tabs[i].scene.document.header.show_solid_history = mode;
+                                            self.tabs[i].scene.bump_geometry();
+                                        } else {
+                                            self.tabs[i].scene.document.header.record_solid_history = mode != 0;
+                                        }
+                                        self.tabs[i].dirty = true;
+                                        self.refresh_properties();
+                                    }
+                                    self.command_line.push_output(&format!("{name} = {mode}"));
+                                }
+                                None => self.command_line.push_error(&format!("{name}: expected an integer from 0 to {maximum}.")),
+                            }
+                        } else {
+                            self.command_line.push_output(&format!("Enter new value for {name} <{current}>:"));
+                            self.pending_setvar = Some(name.clone());
+                        }
+                        return Some(self.finish_dispatch(cmd));
+                    }
                     let frame_kind = crate::scene::frame::kind_for_name(&name);
                     if name == "FRAME" || frame_kind.is_some() {
                         let current = frame_kind.map_or_else(

--- a/src/app/model_ops.rs
+++ b/src/app/model_ops.rs
@@ -35,8 +35,10 @@ impl super::OpenCADStudio {
         let Some(handle) = self.commit_entity_handle(entity) else {
             return Handle::NULL;
         };
+        let require_complete = matches!(history, SolidHistoryOperation::Loft(_));
         self.tabs[i].scene.create_solid_history(handle, history);
-        if !self.tabs[i].scene.register_solid_model(handle, solid) {
+        if !self.tabs[i].scene.register_solid_model(handle, solid)
+            || (require_complete && self.tabs[i].scene.meshes.get(&handle).is_none_or(|mesh| !mesh.complete)) {
             // A command result is not successful until it has renderable
             // geometry. Roll the new entity back so DELOBJ cannot consume a
             // visible source in exchange for an invisible result.
@@ -69,7 +71,10 @@ impl super::OpenCADStudio {
         let Some(handle) = self.commit_entity_handle(entity) else {
             return Handle::NULL;
         };
-        if !self.tabs[i].scene.register_solid_model(handle, surface) {
+        let require_complete = self.tabs[i].scene.document.get_entity(handle).is_some_and(|entity|
+            matches!(entity, EntityType::Surface(value) if value.kind == acadrust::entities::SurfaceKind::Lofted));
+        if !self.tabs[i].scene.register_solid_model(handle, surface)
+            || (require_complete && self.tabs[i].scene.meshes.get(&handle).is_none_or(|mesh| !mesh.complete)) {
             self.tabs[i].scene.rollback_new_entities(&[handle]);
             return Handle::NULL;
         }

--- a/src/app/update/command.rs
+++ b/src/app/update/command.rs
@@ -2001,7 +2001,18 @@ pub(super) fn on_tab_close(&mut self, idx: usize) -> Task<Message> {
             }
             self.push_undo_snapshot(i, "CHPROP");
 
-            if crate::scene::model::solid_history::is_history_choice(field) {
+            if crate::scene::model::solid_history::is_loft_geometry_choice(field) {
+                // These choices change the generated body, not just history
+                // flags. Use the same transactional rebuild as numeric edits.
+                for &handle in &handles {
+                    if self.tabs[i].scene.is_layer_locked(handle) {
+                        continue;
+                    }
+                    self.tabs[i]
+                        .scene
+                        .apply_solid_history_property(handle, field, &value);
+                }
+            } else if crate::scene::model::solid_history::is_history_choice(field) {
                 for &handle in &handles {
                     if self.tabs[i].scene.is_layer_locked(handle) {
                         continue;

--- a/src/app/update/viewport.rs
+++ b/src/app/update/viewport.rs
@@ -3152,6 +3152,19 @@ impl OpenCADStudio {
                 is_added_polyline_vertex(original, current, target.grip_id)
                     .then_some(target.grip_id)
             });
+            // Keep originals available until every history shape has a valid
+            // final display. A rejected rebuild cancels the entire gesture.
+            let history_handles: Vec<_> = self.grip_preview_handles.iter().copied()
+                .filter(|handle| self.tabs[i].scene.document.solid_history_operation(*handle).is_some())
+                .collect();
+            for handle in history_handles {
+                if !self.tabs[i].scene.finalize_solid_history(handle) {
+                    self.cancel_active_grip_edit();
+                    self.command_line.push_error(crate::t!("The edited shape could not be displayed; the original geometry was restored.").as_ref());
+                    self.refresh_properties();
+                    return Task::none();
+                }
+            }
             self.tabs[i].active_grip = None;
             // Commit the grip drag as one undoable group, then put every
             // edited entity back into the resident tessellation.
@@ -3160,9 +3173,6 @@ impl OpenCADStudio {
             let history_originals = std::mem::take(&mut self.grip_history_originals);
             let dirty_before = self.grip_dirty_before.take().unwrap_or(self.tabs[i].dirty);
             if !handles.is_empty() {
-                for &handle in &handles {
-                    let _ = self.tabs[i].scene.finalize_solid_history(handle);
-                }
                 if !originals.is_empty() {
                     self.push_entity_group_history(
                         i,

--- a/src/app/update/viewport.rs
+++ b/src/app/update/viewport.rs
@@ -2298,6 +2298,15 @@ impl OpenCADStudio {
                     self.tabs[i].scene.set_hover_highlight(None);
                 }
                 let hover_handle = hovered.unwrap_or(acadrust::Handle::NULL);
+                let wants_entity = self.tabs[i].active_cmd.as_ref()
+                    .is_some_and(|command| command.wants_hover_entity(hover_handle));
+                if wants_entity {
+                    if let Some(entity) = self.tabs[i].scene.document.get_entity(hover_handle).cloned() {
+                        if let Some(command) = self.tabs[i].active_cmd.as_mut() {
+                            command.inject_hover_entity(hover_handle, entity);
+                        }
+                    }
+                }
                 let shift = self.shift_down;
                 let mut p = self.tabs[i]
                     .active_cmd

--- a/src/command.rs
+++ b/src/command.rs
@@ -1142,6 +1142,29 @@ pub enum ExtrudeExtent {
     Path(Handle),
 }
 
+/// Construction options shared by SWEEP creation and its live preview.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct SweepOptions {
+    pub align: bool,
+    pub bank: bool,
+    pub base_point: Option<DVec3>,
+    pub scale: f64,
+    /// Total twist along the path, in radians.
+    pub twist_angle: f64,
+}
+
+impl Default for SweepOptions {
+    fn default() -> Self {
+        Self {
+            align: true,
+            bank: false,
+            base_point: None,
+            scale: 1.0,
+            twist_angle: 0.0,
+        }
+    }
+}
+
 /// Returned by every `CadCommand` method to tell main.rs what to do.
 #[allow(dead_code)]
 pub enum CmdResult {
@@ -1453,10 +1476,12 @@ pub enum CmdResult {
         mode: ExtrudeMode,
         color: [f32; 4],
     },
-    /// Sweep the profile entity `profile_handle` along `path_handle`.
-    SweepEntity {
-        profile_handle: Handle,
+    /// Sweep the selected profiles along one path in a single undo step.
+    SweepEntities {
+        handles: Vec<Handle>,
         path_handle: Handle,
+        mode: ExtrudeMode,
+        options: SweepOptions,
         color: [f32; 4],
     },
     /// Loft through a series of profile entities.
@@ -1950,6 +1975,14 @@ pub trait CadCommand: Send {
     fn on_hover_entity(&mut self, _handle: Handle, _pt: DVec3) -> Vec<WireModel> {
         vec![]
     }
+
+    /// Request a source snapshot only when the hovered entity changes.
+    /// Commands can cache geometry across mouse moves without holding a scene.
+    fn wants_hover_entity(&self, _handle: Handle) -> bool {
+        false
+    }
+
+    fn inject_hover_entity(&mut self, _handle: Handle, _entity: EntityType) {}
 
     /// Called on every mouse-move in the viewport.
     /// Return `Some(WireModel)` to update the rubber-band preview, `None` to skip.

--- a/src/command.rs
+++ b/src/command.rs
@@ -1165,6 +1165,55 @@ impl Default for SweepOptions {
     }
 }
 
+/// Ordered cross-sections used by LOFT creation, validation and preview.
+#[derive(Clone, Debug, PartialEq)]
+pub enum LoftSectionSelection {
+    Entity(Handle),
+    Point(DVec3),
+    /// Connected source edges forming one exact cross-section.
+    Join(Vec<Handle>),
+}
+
+/// Construction parameters shared by the LOFT command and its history.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct LoftOptions {
+    /// Ruled, Smooth, First normal, Last normal, Ends normal, All normal,
+    /// or Use draft angles, respectively.
+    pub normals: i32,
+    pub start_draft_angle: f64,
+    pub end_draft_angle: f64,
+    pub start_magnitude: f64,
+    pub end_magnitude: f64,
+    /// Point-end continuity: G0 (0) or G1 (1).
+    pub start_continuity: i32,
+    pub end_continuity: i32,
+    /// Positive point-end bulge factors; independent of draft magnitudes.
+    pub start_bulge: f64,
+    pub end_bulge: f64,
+    pub closed: bool,
+    pub periodic: bool,
+    pub align_direction: bool,
+}
+
+impl Default for LoftOptions {
+    fn default() -> Self {
+        Self {
+            normals: 1,
+            start_draft_angle: std::f64::consts::FRAC_PI_2,
+            end_draft_angle: std::f64::consts::FRAC_PI_2,
+            start_magnitude: 0.0,
+            end_magnitude: 0.0,
+            start_continuity: 1,
+            end_continuity: 1,
+            start_bulge: 0.5,
+            end_bulge: 0.5,
+            closed: false,
+            periodic: true,
+            align_direction: true,
+        }
+    }
+}
+
 /// Returned by every `CadCommand` method to tell main.rs what to do.
 #[allow(dead_code)]
 pub enum CmdResult {
@@ -1484,9 +1533,13 @@ pub enum CmdResult {
         options: SweepOptions,
         color: [f32; 4],
     },
-    /// Loft through a series of profile entities.
+    /// Loft through ordered cross-sections, with optional guides or a path.
     LoftEntities {
-        handles: Vec<Handle>,
+        sections: Vec<LoftSectionSelection>,
+        guides: Vec<Handle>,
+        path: Option<Handle>,
+        mode: ExtrudeMode,
+        options: LoftOptions,
         color: [f32; 4],
     },
     /// Round or bevel the straight edge nearest `pick` on a solid.

--- a/src/entities/object_data.rs
+++ b/src/entities/object_data.rs
@@ -204,6 +204,7 @@ fn embedded_name(value: Option<&acadrust::entities::EmbeddedEntity>) -> &'static
         Some(acadrust::entities::EmbeddedEntity::Ellipse(_)) => "Ellipse",
         Some(acadrust::entities::EmbeddedEntity::Spline(_)) => "Spline",
         Some(acadrust::entities::EmbeddedEntity::LwPolyline(_)) => "Polyline",
+        Some(acadrust::entities::EmbeddedEntity::Region(_)) => "Region",
         Some(acadrust::entities::EmbeddedEntity::Ray(_)) => "Ray",
         Some(acadrust::entities::EmbeddedEntity::XLine(_)) => "XLine",
         Some(acadrust::entities::EmbeddedEntity::Unknown { .. }) => "Unknown",

--- a/src/entities/solid3d.rs
+++ b/src/entities/solid3d.rs
@@ -371,6 +371,7 @@ fn embedded_name(entity: Option<&acadrust::entities::EmbeddedEntity>) -> &'stati
         Some(acadrust::entities::EmbeddedEntity::Ellipse(_)) => "Ellipse",
         Some(acadrust::entities::EmbeddedEntity::Spline(_)) => "Spline",
         Some(acadrust::entities::EmbeddedEntity::LwPolyline(_)) => "Polyline",
+        Some(acadrust::entities::EmbeddedEntity::Region(_)) => "Region",
         Some(acadrust::entities::EmbeddedEntity::Ray(_)) => "Ray",
         Some(acadrust::entities::EmbeddedEntity::XLine(_)) => "XLine",
         Some(acadrust::entities::EmbeddedEntity::Unknown { .. }) => "Unknown",

--- a/src/modules/insert/solid3d_cmds.rs
+++ b/src/modules/insert/solid3d_cmds.rs
@@ -1809,7 +1809,8 @@ impl LoftCommand {
             ) {
                 Ok(body) => {
                     // Only edges/isolines: do not triangulate faces on mouse movement.
-                    self.preview_cache = preview_body_wires(&body, self.color, self.isolines);
+                    // Keep the transient cage blue without changing the result's layer color.
+                    self.preview_cache = preview_body_wires(&body, WireModel::SELECTED, self.isolines);
                 }
                 Err(error) => self.preview_error = Some(error),
             }

--- a/src/modules/insert/solid3d_cmds.rs
+++ b/src/modules/insert/solid3d_cmds.rs
@@ -6,7 +6,8 @@ use acadrust::{entities::Solid3D, EntityType, Handle};
 use glam::DVec3;
 
 use crate::command::{
-    CadCommand, CmdOption, CmdResult, ExtrudeExtent, ExtrudeMode, SelectionEntity, WorkingPlane,
+    CadCommand, CmdOption, CmdResult, ExtrudeExtent, ExtrudeMode, SelectionEntity, SweepOptions,
+    WorkingPlane,
 };
 use crate::scene::WireModel;
 use crate::t;
@@ -1184,23 +1185,117 @@ impl CadCommand for RevolveCommand {
 
 pub struct SweepCommand {
     step: SweepStep,
-    profile_handle: acadrust::Handle,
+    profiles: Vec<(Handle, EntityType)>,
+    injected_path: Option<EntityType>,
+    hover_path: Option<(Handle, EntityType)>,
+    preview_key: Option<(Handle, ExtrudeMode, SweepOptions)>,
+    preview_cache: Vec<WireModel>,
+    mode: ExtrudeMode,
+    options: SweepOptions,
+    reference_start: Option<DVec3>,
+    reference_length: f64,
+    new_length_start: Option<DVec3>,
+    isolines: usize,
     color: [f32; 4],
 }
 
-#[derive(PartialEq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 enum SweepStep {
-    PickProfile,
+    PickProfiles,
+    Mode,
     PickPath,
+    Alignment,
+    BasePoint,
+    Scale,
+    ReferenceLength,
+    ReferenceEnd,
+    NewLength,
+    NewLengthStart,
+    NewLengthEnd,
+    Twist,
 }
 
 impl SweepCommand {
-    pub fn new(color: [f32; 4]) -> Self {
+    pub fn new(color: [f32; 4], isolines: usize) -> Self {
         Self {
-            step: SweepStep::PickProfile,
-            profile_handle: acadrust::Handle::NULL,
+            step: SweepStep::PickProfiles,
+            profiles: Vec::new(),
+            injected_path: None,
+            hover_path: None,
+            preview_key: None,
+            preview_cache: Vec::new(),
+            mode: ExtrudeMode::Solid,
+            options: SweepOptions::default(),
+            reference_start: None,
+            reference_length: 1.0,
+            new_length_start: None,
+            isolines,
             color,
         }
+    }
+
+    pub fn set_preselection(&mut self, profiles: Vec<(Handle, EntityType)>) {
+        self.set_profiles(profiles);
+        if !self.profiles.is_empty() {
+            self.step = SweepStep::PickPath;
+        }
+    }
+
+    fn set_profiles(&mut self, profiles: Vec<(Handle, EntityType)>) {
+        self.profiles.clear();
+        for (handle, entity) in profiles {
+            if !handle.is_null()
+                && !self.profiles.iter().any(|(selected, _)| *selected == handle)
+                && crate::scene::model::sweep_model::is_sweep_profile(&entity)
+            {
+                self.profiles.push((handle, entity));
+            }
+        }
+        self.preview_key = None;
+        self.preview_cache.clear();
+    }
+
+    fn contains_profile(&self, handle: Handle) -> bool {
+        self.profiles.iter().any(|(selected, _)| *selected == handle)
+    }
+
+    fn selection_options(&self) -> Option<SweepOptions> {
+        let profiles = self.profiles.iter().map(|(_, entity)| entity.clone()).collect::<Vec<_>>();
+        crate::scene::model::sweep_model::sweep_selection_options(&profiles, self.options)
+    }
+
+    fn finish(&self, path_handle: Handle) -> CmdResult {
+        CmdResult::SweepEntities {
+            handles: self.profiles.iter().map(|(handle, _)| *handle).collect(),
+            path_handle,
+            mode: self.mode,
+            options: self.options,
+            color: self.color,
+        }
+    }
+
+    fn set_scale(&mut self, scale: f64) -> bool {
+        if !scale.is_finite() || scale <= 0.0 {
+            return false;
+        }
+        self.options.scale = scale;
+        self.step = SweepStep::PickPath;
+        true
+    }
+
+    fn set_reference_length(&mut self, length: f64) -> bool {
+        if !length.is_finite() || length <= 1e-12 {
+            return false;
+        }
+        self.reference_length = length;
+        self.step = SweepStep::NewLength;
+        true
+    }
+
+    fn length_anchor(&self) -> DVec3 {
+        self.reference_start
+            .or_else(|| self.selection_options().and_then(|options| options.base_point))
+            .unwrap_or(DVec3::ZERO)
     }
 }
 
@@ -1210,37 +1305,301 @@ impl CadCommand for SweepCommand {
     }
     fn prompt(&self) -> String {
         match self.step {
-            SweepStep::PickProfile => t!("SWEEP  Select profile to sweep:").into_owned(),
-            SweepStep::PickPath => {
-                t!("SWEEP  Select path (Line, Arc, LwPolyline):").into_owned()
-            }
+            SweepStep::PickProfiles => t!("SWEEP  Select objects to sweep or [Mode] (Enter to finish):").into_owned(),
+            SweepStep::Mode => format!(
+                "{} <{}>:",
+                t!("SWEEP  Creation mode [Solid/Surface]"),
+                if self.mode == ExtrudeMode::Solid { "Solid" } else { "Surface" },
+            ),
+            SweepStep::PickPath => t!("SWEEP  Select sweep path or [Alignment/Base point/Scale/Twist]:").into_owned(),
+            SweepStep::Alignment => format!(
+                "{} <{}>:",
+                t!("SWEEP  Align sweep object perpendicular to path [Yes/No]"),
+                if self.options.align { "Yes" } else { "No" },
+            ),
+            SweepStep::BasePoint => t!("SWEEP  Specify base point:").into_owned(),
+            SweepStep::Scale => format!(
+                "{} <{}>:", t!("SWEEP  Enter scale factor or [Reference]"), self.options.scale,
+            ),
+            SweepStep::ReferenceLength => format!(
+                "{} <{}>:",
+                t!("SWEEP  Specify reference length or first point"),
+                crate::entities::common::format_length(self.reference_length),
+            ),
+            SweepStep::ReferenceEnd => t!("SWEEP  Specify second reference point:").into_owned(),
+            SweepStep::NewLength => format!(
+                "{} <{}>:",
+                t!("SWEEP  Specify new length or [Points]"),
+                crate::entities::common::format_length(self.reference_length * self.options.scale),
+            ),
+            SweepStep::NewLengthStart => t!("SWEEP  Specify first point of new length:").into_owned(),
+            SweepStep::NewLengthEnd => t!("SWEEP  Specify second point of new length:").into_owned(),
+            SweepStep::Twist => format!(
+                "{} <{}>:",
+                t!("SWEEP  Specify twist angle or [Bank]"),
+                crate::entities::common::format_angle(self.options.twist_angle),
+            ),
         }
     }
-    fn needs_entity_pick(&self) -> bool {
-        true
+
+    fn options(&self) -> Vec<CmdOption> {
+        match self.step {
+            SweepStep::PickProfiles => vec![CmdOption::new("Mode", "MODE"), CmdOption::enter("Done")],
+            SweepStep::Mode => vec![CmdOption::new("Solid", "SOLID"), CmdOption::new("Surface", "SURFACE")],
+            SweepStep::PickPath => vec![
+                CmdOption::new("Alignment", "ALIGNMENT"),
+                CmdOption::new("Base point", "BASE"),
+                CmdOption::new("Scale", "SCALE"),
+                CmdOption::new("Twist", "TWIST"),
+            ],
+            SweepStep::Alignment => vec![CmdOption::new("Yes", "YES"), CmdOption::new("No", "NO")],
+            SweepStep::Scale => vec![CmdOption::new("Reference", "REFERENCE")],
+            SweepStep::NewLength => vec![CmdOption::new("Points", "POINTS")],
+            SweepStep::Twist => vec![CmdOption::new("Bank", "BANK")],
+            _ => Vec::new(),
+        }
     }
-    fn on_entity_pick(&mut self, handle: acadrust::Handle, _pt: DVec3) -> CmdResult {
-        if handle.is_null() {
+
+    fn needs_entity_pick(&self) -> bool {
+        self.step == SweepStep::PickPath
+    }
+
+    fn entity_pick_highlights_hover(&self) -> bool {
+        self.step == SweepStep::PickPath
+    }
+
+    fn on_entity_pick(&mut self, handle: Handle, _pt: DVec3) -> CmdResult {
+        if self.step != SweepStep::PickPath || handle.is_null() || self.contains_profile(handle) {
+            self.injected_path = None;
+            return CmdResult::NeedPoint;
+        }
+        let path = self.injected_path.take().or_else(|| {
+            self.hover_path.as_ref()
+                .filter(|(hovered, _)| *hovered == handle)
+                .map(|(_, entity)| entity.clone())
+        });
+        if path.as_ref().is_some_and(crate::scene::model::sweep_model::is_sweep_path) {
+            self.finish(handle)
+        } else {
+            CmdResult::NeedPoint
+        }
+    }
+
+    fn on_point(&mut self, point: DVec3) -> CmdResult {
+        if !point.is_finite() {
             return CmdResult::NeedPoint;
         }
         match self.step {
-            SweepStep::PickProfile => {
-                self.profile_handle = handle;
+            SweepStep::BasePoint => {
+                self.options.base_point = Some(point);
                 self.step = SweepStep::PickPath;
-                CmdResult::NeedPoint
             }
-            SweepStep::PickPath => CmdResult::SweepEntity {
-                profile_handle: self.profile_handle,
-                path_handle: handle,
-                color: self.color,
-            },
+            SweepStep::ReferenceLength => {
+                self.reference_start = Some(point);
+                self.step = SweepStep::ReferenceEnd;
+            }
+            SweepStep::ReferenceEnd => {
+                if let Some(start) = self.reference_start {
+                    self.set_reference_length(point.distance(start));
+                }
+            }
+            SweepStep::NewLength => {
+                self.set_scale(point.distance(self.length_anchor()) / self.reference_length);
+            }
+            SweepStep::NewLengthStart => {
+                self.new_length_start = Some(point);
+                self.step = SweepStep::NewLengthEnd;
+            }
+            SweepStep::NewLengthEnd => {
+                if let Some(start) = self.new_length_start {
+                    self.set_scale(point.distance(start) / self.reference_length);
+                }
+            }
+            _ => {}
         }
-    }
-    fn on_point(&mut self, _pt: DVec3) -> CmdResult {
         CmdResult::NeedPoint
     }
+
+    fn wants_text_input(&self) -> bool {
+        matches!(self.step,
+            SweepStep::PickProfiles | SweepStep::Mode | SweepStep::PickPath
+                | SweepStep::Alignment | SweepStep::Scale | SweepStep::ReferenceLength
+                | SweepStep::NewLength | SweepStep::Twist
+        )
+    }
+
+    fn point_step_accepts_keywords(&self) -> bool {
+        matches!(self.step, SweepStep::PickPath | SweepStep::ReferenceLength | SweepStep::NewLength)
+    }
+
+    fn on_text_input(&mut self, text: &str) -> Option<CmdResult> {
+        let value = text.trim();
+        if value.is_empty() {
+            return None;
+        }
+        let keyword = value.to_ascii_uppercase();
+        match self.step {
+            SweepStep::PickProfiles if "MODE".starts_with(&keyword) => {
+                self.step = SweepStep::Mode;
+            }
+            SweepStep::Mode => {
+                if "SOLID".starts_with(&keyword) {
+                    self.mode = ExtrudeMode::Solid;
+                } else if "SURFACE".starts_with(&keyword) {
+                    self.mode = ExtrudeMode::Surface;
+                } else {
+                    return Some(CmdResult::NeedPoint);
+                }
+                self.step = SweepStep::PickProfiles;
+            }
+            SweepStep::PickPath => {
+                self.step = if "ALIGNMENT".starts_with(&keyword) {
+                    SweepStep::Alignment
+                } else if "BASE".starts_with(&keyword) || "BASE POINT".starts_with(&keyword) {
+                    SweepStep::BasePoint
+                } else if "SCALE".starts_with(&keyword) {
+                    SweepStep::Scale
+                } else if "TWIST".starts_with(&keyword) {
+                    SweepStep::Twist
+                } else {
+                    // Unconsumed text can be an object handle from automation.
+                    return None;
+                };
+            }
+            SweepStep::Alignment => {
+                if "YES".starts_with(&keyword) {
+                    self.options.align = true;
+                } else if "NO".starts_with(&keyword) {
+                    self.options.align = false;
+                } else {
+                    return Some(CmdResult::NeedPoint);
+                }
+                self.step = SweepStep::PickPath;
+            }
+            SweepStep::Scale => {
+                if "REFERENCE".starts_with(&keyword) {
+                    self.reference_start = None;
+                    self.new_length_start = None;
+                    self.step = SweepStep::ReferenceLength;
+                } else if let Ok(scale) = value.parse::<f64>() {
+                    self.set_scale(scale);
+                }
+            }
+            SweepStep::ReferenceLength => {
+                if let Some(length) = crate::entities::common::parse_typed_length(value) {
+                    self.set_reference_length(length);
+                } else {
+                    return None;
+                }
+            }
+            SweepStep::NewLength => {
+                if "POINTS".starts_with(&keyword) {
+                    self.step = SweepStep::NewLengthStart;
+                } else if let Some(length) = crate::entities::common::parse_typed_length(value) {
+                    self.set_scale(length / self.reference_length);
+                } else {
+                    return None;
+                }
+            }
+            SweepStep::Twist => {
+                if "BANK".starts_with(&keyword) {
+                    self.options.bank = true;
+                    self.step = SweepStep::PickPath;
+                } else if let Some(angle) = crate::entities::common::parse_angle(value) {
+                    if angle.is_finite() {
+                        self.options.twist_angle = angle;
+                        self.options.bank = false;
+                        self.step = SweepStep::PickPath;
+                    }
+                }
+            }
+            _ => return None,
+        }
+        Some(CmdResult::NeedPoint)
+    }
+
     fn on_enter(&mut self) -> CmdResult {
-        CmdResult::Cancel
+        match self.step {
+            SweepStep::PickProfiles if !self.profiles.is_empty() => {
+                self.step = SweepStep::PickPath;
+            }
+            SweepStep::Mode => self.step = SweepStep::PickProfiles,
+            SweepStep::Alignment | SweepStep::Scale | SweepStep::Twist
+                | SweepStep::NewLength => self.step = SweepStep::PickPath,
+            SweepStep::ReferenceLength => self.step = SweepStep::NewLength,
+            _ => return CmdResult::Cancel,
+        }
+        CmdResult::NeedPoint
+    }
+
+    fn is_selection_gathering(&self) -> bool {
+        self.step == SweepStep::PickProfiles
+    }
+
+    fn selection_forces_add(&self) -> bool {
+        self.step == SweepStep::PickProfiles
+    }
+
+    fn inject_selection_entities(&mut self, entities: Vec<SelectionEntity>) {
+        if self.step == SweepStep::PickProfiles {
+            self.set_profiles(entities.into_iter().map(|entry| (entry.handle, entry.entity)).collect());
+        }
+    }
+
+    fn on_selection_complete(&mut self, _handles: Vec<Handle>) -> CmdResult {
+        CmdResult::NeedPoint
+    }
+
+    fn inject_before_entity_pick(&self) -> bool {
+        self.step == SweepStep::PickPath
+    }
+
+    fn inject_picked_entity(&mut self, entity: EntityType) {
+        if self.step == SweepStep::PickPath {
+            self.injected_path = Some(entity);
+        }
+    }
+
+    fn wants_hover_entity(&self, handle: Handle) -> bool {
+        self.step == SweepStep::PickPath
+            && !handle.is_null()
+            && !self.contains_profile(handle)
+            && self.hover_path.as_ref().is_none_or(|(hovered, _)| *hovered != handle)
+    }
+
+    fn inject_hover_entity(&mut self, handle: Handle, entity: EntityType) {
+        self.hover_path = Some((handle, entity));
+        self.preview_key = None;
+    }
+
+    fn on_hover_entity(&mut self, handle: Handle, _point: DVec3) -> Vec<WireModel> {
+        if self.step != SweepStep::PickPath || handle.is_null() || self.contains_profile(handle) {
+            return Vec::new();
+        }
+        let key = (handle, self.mode, self.options);
+        if self.preview_key == Some(key) {
+            return self.preview_cache.clone();
+        }
+        self.preview_cache.clear();
+        let Some((hovered, path)) = self.hover_path.as_ref() else {
+            return Vec::new();
+        };
+        if *hovered != handle {
+            return Vec::new();
+        }
+        self.preview_key = Some(key);
+        if !crate::scene::model::sweep_model::is_sweep_path(path) {
+            return Vec::new();
+        }
+        let Some(options) = self.selection_options() else {
+            return Vec::new();
+        };
+        self.preview_cache = self.profiles.iter().flat_map(|(_, profile)| {
+            crate::scene::model::sweep_model::swept_with_options(profile, path, self.mode, options)
+                .map(|body| preview_body_wires(&body, self.color, self.isolines))
+                .unwrap_or_default()
+        }).collect();
+        self.preview_cache.clone()
     }
 }
 

--- a/src/modules/insert/solid3d_cmds.rs
+++ b/src/modules/insert/solid3d_cmds.rs
@@ -6,8 +6,8 @@ use acadrust::{entities::Solid3D, EntityType, Handle};
 use glam::DVec3;
 
 use crate::command::{
-    CadCommand, CmdOption, CmdResult, ExtrudeExtent, ExtrudeMode, SelectionEntity, SweepOptions,
-    WorkingPlane,
+    CadCommand, CmdOption, CmdResult, ExtrudeExtent, ExtrudeMode, LoftOptions,
+    LoftSectionSelection, SelectionEntity, SweepOptions, WorkingPlane,
 };
 use crate::scene::WireModel;
 use crate::t;
@@ -1606,15 +1606,400 @@ impl CadCommand for SweepCommand {
 // ── LOFT command ───────────────────────────────────────────────────────────
 
 pub struct LoftCommand {
-    profiles: Vec<acadrust::Handle>,
+    state: LoftState,
+    undo: Vec<LoftState>,
+    available: Vec<(Handle, EntityType)>,
+    injected_entity: Option<EntityType>,
+    entity_revision: u64,
+    preview_key: Option<LoftPreviewKey>,
+    preview_cache: Vec<WireModel>,
+    preview_error: Option<String>,
+    notice: Option<String>,
+    isolines: usize,
     color: [f32; 4],
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum LoftStep {
+    Sections,
+    Join,
+    Point,
+    Mode,
+    Options,
+    Guides,
+    Path,
+    Settings,
+    Normals,
+    StartDraft,
+    EndDraft,
+    StartMagnitude,
+    EndMagnitude,
+    StartContinuity,
+    EndContinuity,
+    StartBulge,
+    EndBulge,
+    Closed,
+    AlignDirection,
+}
+
+#[derive(Clone)]
+struct LoftState {
+    step: LoftStep,
+    return_step: LoftStep,
+    sections: Vec<LoftSectionSelection>,
+    join: Vec<Handle>,
+    guides: Vec<Handle>,
+    path: Option<Handle>,
+    mode: ExtrudeMode,
+    options: LoftOptions,
+}
+
+#[derive(Clone, PartialEq)]
+struct LoftPreviewKey {
+    sections: Vec<LoftSectionSelection>,
+    guides: Vec<Handle>,
+    path: Option<Handle>,
+    mode: ExtrudeMode,
+    options: LoftOptions,
+    entity_revision: u64,
+}
+
 impl LoftCommand {
-    pub fn new(color: [f32; 4]) -> Self {
-        Self {
-            profiles: Vec::new(),
+    pub fn new(
+        color: [f32; 4],
+        isolines: usize,
+        mode: ExtrudeMode,
+        seed: Vec<(Handle, EntityType)>,
+        available: Vec<(Handle, EntityType)>,
+    ) -> Self {
+        let mut command = Self {
+            state: LoftState {
+                step: LoftStep::Sections,
+                return_step: LoftStep::Sections,
+                sections: Vec::new(),
+                join: Vec::new(),
+                guides: Vec::new(),
+                path: None,
+                mode,
+                options: LoftOptions::default(),
+            },
+            undo: Vec::new(),
+            available,
+            injected_entity: None,
+            entity_revision: 0,
+            preview_key: None,
+            preview_cache: Vec::new(),
+            preview_error: None,
+            notice: None,
+            isolines,
             color,
+        };
+        // Preserve supplied selection order; a loft is not an unordered set.
+        for (handle, entity) in seed {
+            if !handle.is_null()
+                && !command.contains_section(handle)
+                && crate::scene::model::loft_command_model::is_section(&entity)
+            {
+                command.store_entity(handle, entity);
+                command.state.sections.push(LoftSectionSelection::Entity(handle));
+            }
+        }
+        let invalid_point = command.state.sections.iter().enumerate().find_map(|(index, section)| {
+            (command.is_point_section(section)
+                && ((index > 0 && index + 1 < command.state.sections.len())
+                    || (index > 0 && command.is_point_section(&command.state.sections[index - 1]))))
+                .then_some(index)
+        });
+        if let Some(index) = invalid_point {
+            command.state.sections.truncate(index);
+            command.notice = Some(t!("Point cross-sections are allowed only at the first or last end, with a curve between point ends.").into_owned());
+        } else if command.state.sections.len() >= 2 {
+            command.state.step = LoftStep::Options;
+        }
+        command
+    }
+
+    fn store_entity(&mut self, handle: Handle, entity: EntityType) {
+        if let Some((_, stored)) = self.available.iter_mut().find(|(id, _)| *id == handle) {
+            *stored = entity;
+        } else {
+            self.available.push((handle, entity));
+        }
+        self.entity_revision = self.entity_revision.wrapping_add(1);
+    }
+
+    fn contains_section(&self, handle: Handle) -> bool {
+        self.state.sections.iter().any(|section| match section {
+            LoftSectionSelection::Entity(id) => *id == handle,
+            LoftSectionSelection::Join(handles) => handles.contains(&handle),
+            LoftSectionSelection::Point(_) => false,
+        })
+    }
+
+    fn is_point_section(&self, section: &LoftSectionSelection) -> bool {
+        match section {
+            LoftSectionSelection::Point(_) => true,
+            LoftSectionSelection::Entity(handle) => self.available.iter().any(|(id, entity)| {
+                id == handle && matches!(entity, EntityType::Point(_))
+            }),
+            LoftSectionSelection::Join(_) => false,
+        }
+    }
+
+    fn point_ends(&self) -> (bool, bool) {
+        (
+            self.state.sections.first().is_some_and(|section| self.is_point_section(section)),
+            self.state.sections.last().is_some_and(|section| self.is_point_section(section)),
+        )
+    }
+
+    fn point_setting_next(&self, step: LoftStep) -> LoftStep {
+        match step {
+            LoftStep::StartContinuity if self.point_ends().1 => LoftStep::EndContinuity,
+            LoftStep::StartBulge if self.point_ends().1 => LoftStep::EndBulge,
+            _ => LoftStep::Options,
+        }
+    }
+
+    fn remember(&mut self) {
+        self.undo.push(self.state.clone());
+        self.notice = None;
+    }
+
+    fn enter_step(&mut self, step: LoftStep) {
+        self.remember();
+        self.state.step = step;
+    }
+
+    fn invalid(&mut self, message: String) -> CmdResult {
+        self.notice = Some(message);
+        CmdResult::NeedPoint
+    }
+
+    fn can_close(&self) -> bool {
+        self.state.sections.len() >= 3
+            && !self.state.sections.iter().any(|section| self.is_point_section(section))
+    }
+
+    fn key(&self) -> LoftPreviewKey {
+        LoftPreviewKey {
+            sections: self.state.sections.clone(),
+            guides: self.state.guides.clone(),
+            path: self.state.path,
+            mode: self.state.mode,
+            options: self.state.options,
+            entity_revision: self.entity_revision,
+        }
+    }
+
+    fn cached_preview(&mut self, key: LoftPreviewKey) -> Vec<WireModel> {
+        if self.preview_key.as_ref() == Some(&key) {
+            return self.preview_cache.clone();
+        }
+        self.preview_cache.clear();
+        self.preview_error = None;
+        if key.sections.len() >= 2 {
+            match crate::scene::model::loft_command_model::build_body(
+                &key.sections,
+                &key.guides,
+                key.path,
+                &self.available,
+                key.mode,
+                key.options,
+            ) {
+                Ok(body) => {
+                    // Only edges/isolines: do not triangulate faces on mouse movement.
+                    self.preview_cache = preview_body_wires(&body, self.color, self.isolines);
+                }
+                Err(error) => self.preview_error = Some(error),
+            }
+        }
+        self.preview_key = Some(key);
+        self.preview_cache.clone()
+    }
+
+    fn finish(&mut self) -> CmdResult {
+        if self.state.sections.len() < 2 {
+            return self.invalid(t!("LOFT requires at least two cross-sections.").into_owned());
+        }
+        if self.state.sections.iter().enumerate().any(|(index, section)| {
+            self.is_point_section(section)
+                && ((index > 0 && index + 1 < self.state.sections.len())
+                    || (index > 0 && self.is_point_section(&self.state.sections[index - 1])))
+        }) {
+            return self.invalid(t!("Point cross-sections are allowed only at the first or last end, with a curve between point ends.").into_owned());
+        }
+        if self.state.options.closed && !self.can_close() {
+            return self.invalid(t!("A closed loft requires at least three curve cross-sections and no point ends.").into_owned());
+        }
+        let key = self.key();
+        self.cached_preview(key);
+        if let Some(error) = self.preview_error.clone() {
+            return self.invalid(error);
+        }
+        CmdResult::LoftEntities {
+            sections: self.state.sections.clone(),
+            guides: self.state.guides.clone(),
+            path: self.state.path,
+            mode: self.state.mode,
+            options: self.state.options,
+            color: self.color,
+        }
+    }
+
+    fn undo_selection(&mut self) -> CmdResult {
+        if let Some(state) = self.undo.pop() {
+            self.state = state;
+        } else if !self.state.sections.is_empty() {
+            self.state.sections.pop();
+            self.state.step = LoftStep::Sections;
+            self.state.options.closed = false;
+        }
+        self.notice = None;
+        CmdResult::NeedPoint
+    }
+
+    fn add_section(&mut self, handle: Handle) -> CmdResult {
+        if self.state.sections.len() >= 2 && self.point_ends().1 {
+            return self.invalid(t!("A point must remain the last cross-section; use Undo to change the end.").into_owned());
+        }
+        if self.contains_section(handle) {
+            return self.invalid(t!("That cross-section is already selected.").into_owned());
+        }
+        if self.available.iter().find(|(id, _)| *id == handle)
+            .is_none_or(|(_, entity)| !crate::scene::model::loft_command_model::is_section(entity))
+        {
+            return self.invalid(t!("Select a supported planar curve or region cross-section.").into_owned());
+        }
+        let section = LoftSectionSelection::Entity(handle);
+        let point = self.is_point_section(&section);
+        if point && self.point_ends().1 {
+            return self.invalid(t!("Add a curve cross-section between point ends.").into_owned());
+        }
+        self.remember();
+        self.state.sections.push(section);
+        if point {
+            self.state.options.closed = false;
+            if self.state.sections.len() >= 2 {
+                self.state.step = LoftStep::Options;
+            }
+        }
+        CmdResult::NeedPoint
+    }
+
+    fn set_numeric_setting(&mut self, text: &str) -> bool {
+        let angle = matches!(self.state.step, LoftStep::StartDraft | LoftStep::EndDraft);
+        let bulge = matches!(self.state.step, LoftStep::StartBulge | LoftStep::EndBulge);
+        let number = if angle {
+            crate::entities::common::parse_angle(text)
+        } else {
+            text.trim().replace(',', ".").parse::<f64>().ok()
+        };
+        let Some(number) = number.filter(|number| number.is_finite()) else {
+            return false;
+        };
+        if (angle && !(0.0..=std::f64::consts::PI).contains(&number))
+            || (!angle && number < 0.0)
+            || (bulge && number < 0.0)
+        {
+            return false;
+        }
+        self.remember();
+        self.state.step = match self.state.step {
+            LoftStep::StartDraft => {
+                self.state.options.start_draft_angle = number;
+                LoftStep::EndDraft
+            }
+            LoftStep::EndDraft => {
+                self.state.options.end_draft_angle = number;
+                LoftStep::Settings
+            }
+            LoftStep::StartMagnitude => {
+                self.state.options.start_magnitude = number;
+                LoftStep::EndMagnitude
+            }
+            LoftStep::EndMagnitude => {
+                self.state.options.end_magnitude = number;
+                LoftStep::Settings
+            }
+            LoftStep::StartBulge => {
+                self.state.options.start_bulge = number;
+                self.point_setting_next(LoftStep::StartBulge)
+            }
+            LoftStep::EndBulge => {
+                self.state.options.end_bulge = number;
+                LoftStep::Options
+            }
+            _ => return false,
+        };
+        true
+    }
+
+    fn keyword(text: &str, choices: &[&str]) -> Option<usize> {
+        let keyword = text.trim().trim_start_matches('_').replace([' ', '-'], "").to_ascii_uppercase();
+        let keyword = match keyword.as_str() {
+            "CROSSSECTIONSONLY" => "CROSSSECTIONS",
+            "BULGEMAGNITUDE" => "BULGE",
+            _ => keyword.as_str(),
+        };
+        if keyword.is_empty() {
+            return None;
+        }
+        if let Some(index) = choices.iter().position(|choice| *choice == keyword) {
+            return Some(index);
+        }
+        let mut matches = choices.iter().enumerate().filter(|(_, choice)| choice.starts_with(keyword));
+        let index = matches.next()?.0;
+        matches.next().is_none().then_some(index)
+    }
+
+    fn option_prompt(&self) -> String {
+        match self.state.step {
+            LoftStep::Sections => format!(
+                "{} ({}):", t!("LOFT  Select cross-sections in order or [Point/Join/Mode/Undo] (Enter to finish)"),
+                self.state.sections.len(),
+            ),
+            LoftStep::Join => format!(
+                "{} ({}):", t!("LOFT  Select connected edges for one cross-section or [Undo] (Enter to finish)"),
+                self.state.join.len(),
+            ),
+            LoftStep::Point => t!("LOFT  Specify point end:").into_owned(),
+            LoftStep::Mode => format!("{} <{}>:", t!("LOFT  Creation mode [Solid/Surface]"),
+                if self.state.mode == ExtrudeMode::Solid { "Solid" } else { "Surface" }),
+            LoftStep::Options => {
+                let (start, end) = self.point_ends();
+                if start || end {
+                    t!("LOFT  Enter an option [Guides/Path/Cross sections only/Settings/Continuity/Bulge magnitude/Mode/Undo] <Cross sections only>:").into_owned()
+                } else {
+                    t!("LOFT  Enter an option [Guides/Path/Cross sections only/Settings/Mode/Undo] <Cross sections only>:").into_owned()
+                }
+            }
+            LoftStep::Guides => format!("{} ({}):", t!("LOFT  Select guide curves or [Undo] (Enter to finish)"), self.state.guides.len()),
+            LoftStep::Path => t!("LOFT  Select path or [Undo]:").into_owned(),
+            LoftStep::Settings => {
+                let mut choices = vec![t!("Normals").into_owned()];
+                if self.state.options.normals == 6 {
+                    choices.push(t!("Draft angles").into_owned());
+                    choices.push(t!("Magnitudes").into_owned());
+                }
+                if self.can_close() {
+                    choices.push(t!("Closed").into_owned());
+                }
+                choices.push(t!("Align direction").into_owned());
+                choices.push(t!("Done").into_owned());
+                format!("{} [{}]:", t!("LOFT  Settings"), choices.join("/"))
+            }
+            LoftStep::Normals => t!("LOFT  Surface normals [Ruled/Smooth/First normal/Last normal/Ends normal/All normal/Use draft angles]:").into_owned(),
+            LoftStep::StartDraft => format!("{} <{}>:", t!("LOFT  Start draft angle"), crate::entities::common::format_angle(self.state.options.start_draft_angle)),
+            LoftStep::EndDraft => format!("{} <{}>:", t!("LOFT  End draft angle"), crate::entities::common::format_angle(self.state.options.end_draft_angle)),
+            LoftStep::StartMagnitude => format!("{} <{}>:", t!("LOFT  Start magnitude"), self.state.options.start_magnitude),
+            LoftStep::EndMagnitude => format!("{} <{}>:", t!("LOFT  End magnitude"), self.state.options.end_magnitude),
+            LoftStep::StartContinuity => format!("{} <G{}>:", t!("LOFT  Start point continuity [G0/G1]"), self.state.options.start_continuity),
+            LoftStep::EndContinuity => format!("{} <G{}>:", t!("LOFT  End point continuity [G0/G1]"), self.state.options.end_continuity),
+            LoftStep::StartBulge => format!("{} <{:.4}>:", t!("LOFT  Start point bulge magnitude"), self.state.options.start_bulge),
+            LoftStep::EndBulge => format!("{} <{:.4}>:", t!("LOFT  End point bulge magnitude"), self.state.options.end_bulge),
+            LoftStep::Closed => format!("{} <{}>:", t!("LOFT  Closed [Yes/No]"), if self.state.options.closed { "Yes" } else { "No" }),
+            LoftStep::AlignDirection => format!("{} <{}>:", t!("LOFT  Align cross-section directions [Yes/No]"), if self.state.options.align_direction { "Yes" } else { "No" }),
         }
     }
 }
@@ -1624,47 +2009,331 @@ impl CadCommand for LoftCommand {
         "LOFT"
     }
     fn prompt(&self) -> String {
-        if self.profiles.is_empty() {
-            t!("LOFT  Select first cross-section:").into_owned()
-        } else {
-            t!(
-                "LOFT  Select next cross-section (%{count} selected, Enter to finish):",
-                count = self.profiles.len()
-            )
-            .into_owned()
+        let prompt = self.option_prompt();
+        match &self.notice {
+            Some(notice) => format!("{notice}\n{prompt}"),
+            None => prompt,
         }
+    }
+    fn options(&self) -> Vec<CmdOption> {
+        let mut options = match self.state.step {
+            LoftStep::Sections => vec![CmdOption::new("Point", "POINT"), CmdOption::new("Join", "JOIN"), CmdOption::new("Mode", "MODE"), CmdOption::enter("Done")],
+            LoftStep::Join | LoftStep::Guides => vec![CmdOption::enter("Done")],
+            LoftStep::Mode => vec![CmdOption::new("Solid", "SOLID"), CmdOption::new("Surface", "SURFACE")],
+            LoftStep::Options => {
+                let mut choices = vec![CmdOption::new("Guides", "GUIDES"), CmdOption::new("Path", "PATH"), CmdOption::new("Cross sections only", "CROSSSECTIONS"), CmdOption::new("Settings", "SETTINGS")];
+                let (start, end) = self.point_ends();
+                if start || end {
+                    choices.push(CmdOption::new("Continuity", "CONTINUITY"));
+                    choices.push(CmdOption::new("Bulge magnitude", "BULGE"));
+                }
+                choices.push(CmdOption::new("Mode", "MODE"));
+                choices
+            }
+            LoftStep::Settings => {
+                let mut choices = vec![CmdOption::new("Normals", "NORMALS")];
+                if self.state.options.normals == 6 {
+                    choices.push(CmdOption::new("Draft angles", "DRAFTANGLES"));
+                    choices.push(CmdOption::new("Magnitudes", "MAGNITUDES"));
+                }
+                if self.can_close() {
+                    choices.push(CmdOption::new("Closed", "CLOSED"));
+                }
+                choices.push(CmdOption::new("Align direction", "ALIGNDIRECTION"));
+                choices.push(CmdOption::enter("Done"));
+                choices
+            }
+            LoftStep::Normals => vec![
+                CmdOption::new("Ruled", "RULED"), CmdOption::new("Smooth", "SMOOTH"),
+                CmdOption::new("First normal", "FIRSTNORMAL"), CmdOption::new("Last normal", "LASTNORMAL"),
+                CmdOption::new("Ends normal", "ENDSNORMAL"), CmdOption::new("All normal", "ALLNORMAL"),
+                CmdOption::new("Use draft angles", "USEDRAFTANGLES"),
+            ],
+            LoftStep::Closed | LoftStep::AlignDirection => vec![CmdOption::new("Yes", "YES"), CmdOption::new("No", "NO")],
+            LoftStep::StartContinuity | LoftStep::EndContinuity => vec![CmdOption::new("G0", "G0"), CmdOption::new("G1", "G1")],
+            _ => Vec::new(),
+        };
+        options.push(CmdOption::new("Undo", "UNDO"));
+        options
     }
     fn needs_entity_pick(&self) -> bool {
-        true
+        matches!(self.state.step, LoftStep::Sections | LoftStep::Join | LoftStep::Guides | LoftStep::Path)
     }
-    fn on_entity_pick(&mut self, handle: acadrust::Handle, _pt: DVec3) -> CmdResult {
-        if handle.is_null() {
+    fn entity_pick_highlights_hover(&self) -> bool {
+        self.needs_entity_pick()
+    }
+    fn inject_before_entity_pick(&self) -> bool {
+        self.needs_entity_pick()
+    }
+    fn inject_picked_entity(&mut self, entity: EntityType) {
+        self.injected_entity = Some(entity);
+    }
+    fn on_entity_pick(&mut self, handle: Handle, _pt: DVec3) -> CmdResult {
+        if !self.needs_entity_pick() || handle.is_null() {
+            self.injected_entity = None;
             return CmdResult::NeedPoint;
         }
-        // Avoid duplicate picks.
-        if !self.profiles.contains(&handle) {
-            self.profiles.push(handle);
+        if let Some(entity) = self.injected_entity.take() {
+            self.store_entity(handle, entity);
         }
-        CmdResult::NeedPoint
-    }
-    fn on_point(&mut self, _pt: DVec3) -> CmdResult {
+        if self.state.step == LoftStep::Sections {
+            return self.add_section(handle);
+        }
+        if self.contains_section(handle) {
+            return self.invalid(t!("A cross-section cannot also be a guide, path, or joined edge.").into_owned());
+        }
+        if self.available.iter().find(|(id, _)| *id == handle)
+            .is_none_or(|(_, entity)| !crate::scene::model::loft_command_model::is_guide_or_path(entity))
+        {
+            return self.invalid(t!("Select a supported guide or path curve.").into_owned());
+        }
+        match self.state.step {
+            LoftStep::Join => {
+                if self.state.join.contains(&handle) {
+                    return self.invalid(t!("That edge is already selected.").into_owned());
+                }
+                self.remember();
+                self.state.join.push(handle);
+            }
+            LoftStep::Guides => {
+                if self.state.guides.contains(&handle) {
+                    return self.invalid(t!("That guide is already selected.").into_owned());
+                }
+                self.remember();
+                self.state.guides.push(handle);
+            }
+            LoftStep::Path => {
+                self.remember();
+                self.state.path = Some(handle);
+                self.state.guides.clear();
+                return self.finish();
+            }
+            _ => {}
+        }
         CmdResult::NeedPoint
     }
     fn wants_text_input(&self) -> bool {
-        self.profiles.len() >= 2
+        true
     }
-    fn on_text_input(&mut self, _text: &str) -> Option<CmdResult> {
-        None
+    fn point_step_accepts_keywords(&self) -> bool {
+        self.state.step == LoftStep::Point
     }
-    fn on_enter(&mut self) -> CmdResult {
-        if self.profiles.len() < 2 {
-            CmdResult::Cancel
-        } else {
-            CmdResult::LoftEntities {
-                handles: self.profiles.clone(),
-                color: self.color,
+    fn on_point(&mut self, point: DVec3) -> CmdResult {
+        if self.state.step != LoftStep::Point || !point.is_finite() {
+            return CmdResult::NeedPoint;
+        }
+        if self.point_ends().1 {
+            return self.invalid(t!("Add a curve cross-section between point ends.").into_owned());
+        }
+        self.remember();
+        self.state.sections.push(LoftSectionSelection::Point(point));
+        self.state.options.closed = false;
+        self.state.step = if self.state.sections.len() >= 2 { LoftStep::Options } else { LoftStep::Sections };
+        CmdResult::NeedPoint
+    }
+    fn on_text_input(&mut self, text: &str) -> Option<CmdResult> {
+        if text.trim().is_empty() {
+            return Some(self.on_enter());
+        }
+        if Self::keyword(text, &["UNDO"]).is_some() {
+            return Some(self.undo_selection());
+        }
+        match self.state.step {
+            LoftStep::Sections => match Self::keyword(text, &["POINT", "JOIN", "MODE"]) {
+                Some(0) => {
+                    if self.point_ends().1 {
+                        return Some(self.invalid(t!("Select a curve cross-section before another point end.").into_owned()));
+                    }
+                    self.enter_step(LoftStep::Point);
+                }
+                Some(1) => {
+                    if self.state.sections.len() >= 2 && self.point_ends().1 {
+                        return Some(self.invalid(t!("A point must remain the last cross-section; use Undo to change the end.").into_owned()));
+                    }
+                    self.enter_step(LoftStep::Join);
+                    self.state.join.clear();
+                }
+                Some(2) => {
+                    self.enter_step(LoftStep::Mode);
+                    self.state.return_step = LoftStep::Sections;
+                }
+                _ => return Some(self.invalid(t!("Select a cross-section or enter Point, Join, Mode, or Undo.").into_owned())),
+            },
+            LoftStep::Mode => match Self::keyword(text, &["SOLID", "SURFACE"]) {
+                Some(mode) => {
+                    self.remember();
+                    self.state.mode = if mode == 0 { ExtrudeMode::Solid } else { ExtrudeMode::Surface };
+                    self.state.step = self.state.return_step;
+                }
+                _ => return Some(self.invalid(t!("Enter Solid or Surface.").into_owned())),
+            },
+            LoftStep::Options => match Self::keyword(text, &["GUIDES", "PATH", "CROSSSECTIONS", "SETTINGS", "MODE", "CONTINUITY", "BULGE"]) {
+                Some(0) => {
+                    self.enter_step(LoftStep::Guides);
+                    self.state.path = None;
+                }
+                Some(1) => {
+                    self.enter_step(LoftStep::Path);
+                    self.state.guides.clear();
+                }
+                Some(2) => {
+                    self.remember();
+                    self.state.guides.clear();
+                    self.state.path = None;
+                    return Some(self.finish());
+                }
+                Some(3) => self.enter_step(LoftStep::Settings),
+                Some(4) => {
+                    self.enter_step(LoftStep::Mode);
+                    self.state.return_step = LoftStep::Options;
+                }
+                Some(5) | Some(6) if !self.point_ends().0 && !self.point_ends().1 => {
+                    return Some(self.invalid(t!("Continuity and bulge magnitude require a point cross-section at an end.").into_owned()));
+                }
+                Some(5) => self.enter_step(if self.point_ends().0 { LoftStep::StartContinuity } else { LoftStep::EndContinuity }),
+                Some(6) => self.enter_step(if self.point_ends().0 { LoftStep::StartBulge } else { LoftStep::EndBulge }),
+                _ => return Some(self.invalid(t!("Enter one of the listed loft options.").into_owned())),
+            },
+            LoftStep::Settings => match Self::keyword(text, &["NORMALS", "DRAFTANGLES", "MAGNITUDES", "CLOSED", "ALIGNDIRECTION", "DONE"]) {
+                Some(0) => self.enter_step(LoftStep::Normals),
+                Some(1) | Some(2) if self.state.options.normals != 6 => {
+                    return Some(self.invalid(t!("Choose Use draft angles under Normals before editing draft angles or magnitudes.").into_owned()));
+                }
+                Some(1) => self.enter_step(LoftStep::StartDraft),
+                Some(2) => self.enter_step(LoftStep::StartMagnitude),
+                Some(3) if self.can_close() => self.enter_step(LoftStep::Closed),
+                Some(3) => return Some(self.invalid(t!("Closed is available for at least three curve cross-sections without point ends.").into_owned())),
+                Some(4) => self.enter_step(LoftStep::AlignDirection),
+                Some(5) => self.enter_step(LoftStep::Options),
+                _ => return Some(self.invalid(t!("Enter a listed loft setting.").into_owned())),
+            },
+            LoftStep::Normals => {
+                let selected = Self::keyword(text, &["RULED", "SMOOTH", "FIRSTNORMAL", "LASTNORMAL", "ENDSNORMAL", "ALLNORMAL", "USEDRAFTANGLES"])
+                    .or_else(|| text.trim().parse::<usize>().ok().filter(|value| *value <= 6));
+                let Some(selected) = selected else {
+                    return Some(self.invalid(t!("Select one of the seven surface normal options.").into_owned()));
+                };
+                self.remember();
+                self.state.options.normals = selected as i32;
+                self.state.step = LoftStep::Settings;
+            }
+            LoftStep::StartDraft | LoftStep::EndDraft | LoftStep::StartMagnitude | LoftStep::EndMagnitude => {
+                if !self.set_numeric_setting(text) {
+                    return Some(self.invalid(t!("Enter a finite draft angle from 0 to 180 degrees or a non-negative magnitude.").into_owned()));
+                }
+            }
+            LoftStep::StartContinuity | LoftStep::EndContinuity => {
+                let continuity = match text.trim().trim_start_matches('_').to_ascii_uppercase().as_str() {
+                    "G0" => 0,
+                    "G1" => 1,
+                    _ => return Some(self.invalid(t!("Enter G0 or G1.").into_owned())),
+                };
+                let step = self.state.step;
+                self.remember();
+                if step == LoftStep::StartContinuity {
+                    self.state.options.start_continuity = continuity;
+                } else {
+                    self.state.options.end_continuity = continuity;
+                }
+                self.state.step = self.point_setting_next(step);
+            }
+            LoftStep::StartBulge | LoftStep::EndBulge => {
+                if !self.set_numeric_setting(text) {
+                    return Some(self.invalid(t!("Enter a finite bulge magnitude greater than zero.").into_owned()));
+                }
+            }
+            LoftStep::Closed | LoftStep::AlignDirection => {
+                let Some(selected) = Self::keyword(text, &["YES", "NO"]) else {
+                    return Some(self.invalid(t!("Enter Yes or No.").into_owned()));
+                };
+                if self.state.step == LoftStep::Closed && selected == 0 && !self.can_close() {
+                    return Some(self.invalid(t!("A closed loft requires at least three curve cross-sections and no point ends.").into_owned()));
+                }
+                self.remember();
+                if self.state.step == LoftStep::Closed {
+                    self.state.options.closed = selected == 0;
+                } else {
+                    self.state.options.align_direction = selected == 0;
+                }
+                self.state.step = LoftStep::Settings;
+            }
+            LoftStep::Point => return None,
+            LoftStep::Join | LoftStep::Guides | LoftStep::Path => {
+                return Some(self.invalid(t!("Select a curve or use Undo.").into_owned()));
             }
         }
+        Some(CmdResult::NeedPoint)
+    }
+    fn on_enter(&mut self) -> CmdResult {
+        match self.state.step {
+            LoftStep::Sections if self.state.sections.len() >= 2 => self.enter_step(LoftStep::Options),
+            LoftStep::Sections => return self.invalid(t!("LOFT requires at least two cross-sections; select another section or a point end.").into_owned()),
+            LoftStep::Join if !self.state.join.is_empty() => {
+                self.remember();
+                self.state.sections.push(LoftSectionSelection::Join(std::mem::take(&mut self.state.join)));
+                self.state.step = LoftStep::Sections;
+            }
+            LoftStep::Join => return self.invalid(t!("Select connected edges for the cross-section.").into_owned()),
+            LoftStep::Options => return self.finish(),
+            LoftStep::Guides if !self.state.guides.is_empty() => return self.finish(),
+            LoftStep::Guides => return self.invalid(t!("Select at least one guide curve.").into_owned()),
+            LoftStep::Mode => self.enter_step(self.state.return_step),
+            LoftStep::Settings => self.enter_step(LoftStep::Options),
+            LoftStep::Normals | LoftStep::Closed | LoftStep::AlignDirection | LoftStep::EndDraft | LoftStep::EndMagnitude => self.enter_step(LoftStep::Settings),
+            LoftStep::StartDraft => self.enter_step(LoftStep::EndDraft),
+            LoftStep::StartMagnitude => self.enter_step(LoftStep::EndMagnitude),
+            LoftStep::StartContinuity | LoftStep::EndContinuity | LoftStep::StartBulge | LoftStep::EndBulge => self.enter_step(self.point_setting_next(self.state.step)),
+            LoftStep::Path | LoftStep::Point => return self.invalid(t!("Specify the requested path or point, or use Undo.").into_owned()),
+        }
+        CmdResult::NeedPoint
+    }
+    fn on_undo_step(&mut self) -> Option<CmdResult> {
+        Some(self.undo_selection())
+    }
+    fn wants_hover_entity(&self, handle: Handle) -> bool {
+        self.needs_entity_pick() && !handle.is_null()
+            && !self.available.iter().any(|(id, _)| *id == handle)
+    }
+    fn inject_hover_entity(&mut self, handle: Handle, entity: EntityType) {
+        self.store_entity(handle, entity);
+    }
+    fn on_hover_entity(&mut self, handle: Handle, _point: DVec3) -> Vec<WireModel> {
+        let mut key = self.key();
+        if !handle.is_null() && !self.contains_section(handle) {
+            if let Some((_, entity)) = self.available.iter().find(|(id, _)| *id == handle) {
+                match self.state.step {
+                    LoftStep::Sections if crate::scene::model::loft_command_model::is_section(entity) => {
+                        let section = LoftSectionSelection::Entity(handle);
+                        let point = self.is_point_section(&section);
+                        if !(self.point_ends().1 && (point || self.state.sections.len() >= 2)) {
+                            key.sections.push(section);
+                            if point {
+                                key.options.closed = false;
+                            }
+                        }
+                    }
+                    LoftStep::Guides if !key.guides.contains(&handle)
+                        && crate::scene::model::loft_command_model::is_guide_or_path(entity) => key.guides.push(handle),
+                    LoftStep::Path if crate::scene::model::loft_command_model::is_guide_or_path(entity) => {
+                        key.path = Some(handle);
+                        key.guides.clear();
+                    }
+                    _ => {}
+                }
+            }
+        }
+        self.cached_preview(key)
+    }
+    fn on_preview_wires(&mut self, point: DVec3) -> Vec<WireModel> {
+        let mut key = self.key();
+        if self.state.step == LoftStep::Point && point.is_finite()
+            && !key.sections.is_empty()
+            && !self.point_ends().1
+        {
+            key.sections.push(LoftSectionSelection::Point(point));
+            key.options.closed = false;
+        }
+        self.cached_preview(key)
     }
 }
 

--- a/src/modules/insert/solid3d_cmds.rs
+++ b/src/modules/insert/solid3d_cmds.rs
@@ -168,7 +168,9 @@ fn preview_body_wires(
     color: [f32; 4],
     isolines: usize,
 ) -> Vec<WireModel> {
-    let mesh = cadkernel::brep::mesh::tessellate(
+    // This overlay only consumes curves. Do not triangulate the body's faces
+    // on every cursor event just to discard the resulting surface mesh.
+    let wireframe = cadkernel::brep::mesh::tessellate_wireframe(
         body,
         cadkernel::brep::mesh::TessellationTolerance::new(
             cadkernel::tessellation::DEFAULT_ANGLE,
@@ -176,7 +178,7 @@ fn preview_body_wires(
         )
         .with_isolines(isolines),
     );
-    let mut wires = mesh
+    let mut wires = wireframe
         .edges
         .into_iter()
         .filter(|edge| edge.positions.len() >= 2)
@@ -190,7 +192,7 @@ fn preview_body_wires(
         })
         .collect::<Vec<_>>();
     wires.extend(
-        mesh.isolines
+        wireframe.isolines
             .into_iter()
             .filter(|line| line.positions.len() >= 2)
             .map(|line| {

--- a/src/modules/insert/solid3d_cmds.rs
+++ b/src/modules/insert/solid3d_cmds.rs
@@ -2138,6 +2138,14 @@ impl CadCommand for LoftCommand {
         if Self::keyword(text, &["UNDO"]).is_some() {
             return Some(self.undo_selection());
         }
+        // Leave hexadecimal object identifiers to the shared pick-input router.
+        // Treating them as unknown options would consume scripted section,
+        // guide and path selections before on_entity_pick can receive them.
+        if self.needs_entity_pick()
+            && u64::from_str_radix(text.trim().trim_start_matches("0x"), 16).is_ok()
+        {
+            return None;
+        }
         match self.state.step {
             LoftStep::Sections => match Self::keyword(text, &["POINT", "JOIN", "MODE"]) {
                 Some(0) => {
@@ -2239,7 +2247,7 @@ impl CadCommand for LoftCommand {
             }
             LoftStep::StartBulge | LoftStep::EndBulge => {
                 if !self.set_numeric_setting(text) {
-                    return Some(self.invalid(t!("Enter a finite bulge magnitude greater than zero.").into_owned()));
+                    return Some(self.invalid(t!("Enter a finite, non-negative bulge magnitude.").into_owned()));
                 }
             }
             LoftStep::Closed | LoftStep::AlignDirection => {

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -54,9 +54,83 @@ pub(crate) use boundary::{
 // other tessellation code); re-exported here so this root and sibling topic
 // modules (each does `use super::*`) keep referencing them unqualified.
 pub(crate) use convert::tess::{
-    entity_aabb, entity_world_aabb_f64, is_unindexable_entity, tessellate_entity,
+    entity_aabb, entity_world_aabb_f64, is_unindexable_entity,
     tessellate_entity_dim_text,
 };
+
+/// Keep construction-history curves in the same per-entity tessellation memo
+/// as their parent, so navigation never rebuilds them on every frame.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn tessellate_entity(
+    document: &CadDocument,
+    selected: &HashSet<Handle>,
+    active_viewport: Option<Handle>,
+    bg_color: [f32; 4],
+    anno_scale: f32,
+    annotation_scale_handle: Option<Handle>,
+    entity: &EntityType,
+    block_cache: Option<&cache::block_cache::BlockCache>,
+    view_aabb: Option<[f32; 4]>,
+    world_per_pixel: Option<f32>,
+    paper_space: bool,
+) -> Vec<WireModel> {
+    let mut wires = convert::tess::tessellate_entity(
+        document, selected, active_viewport, bg_color, anno_scale,
+        annotation_scale_handle, entity, block_cache, view_aabb,
+        world_per_pixel, paper_space,
+    );
+    if matches!(entity, EntityType::Solid3D(_) | EntityType::Surface(_)) {
+        let handle = entity.common().handle;
+        for source in model::solid_history::loft_visible_history_entities(document, handle) {
+            // Call the raw converter, not this wrapper: sources must not expand
+            // the parent's history again through their shared selection handle.
+            let mut construction = if let EntityType::Region(region) = &source {
+                // Regions normally render through the mesh layer, so the raw
+                // wire converter emits nothing. Decode every exact boundary,
+                // including holes, then sample only for this cached display.
+                let mut boundaries = Vec::new();
+                if let Ok(cadkernel::brep::LoftSection::Profile { plane, wires, .. }) =
+                    cadkernel::acis::loft_section_geometry(&[
+                        acadrust::entities::EmbeddedEntity::Region(region.clone()),
+                    ])
+                {
+                    let (color, _, _, line_weight_px, _) =
+                        view::render::render_style_for_viewport(document, &source, active_viewport);
+                    for boundary in wires {
+                        for curve in boundary {
+                            let points = curve.tessellate(64.0 / std::f64::consts::TAU)
+                                .into_iter().map(|point| plane.point_at(point));
+                            let (points, points_low) = convert::tessellate::points_to_ds(points);
+                            let mut wire = WireModel::solid(
+                                handle.value().to_string(), points, color, selected.contains(&handle),
+                            );
+                            wire.points_low = points_low;
+                            wire.line_weight_px = line_weight_px;
+                            boundaries.push(wire);
+                        }
+                    }
+                }
+                boundaries
+            } else {
+                convert::tess::tessellate_entity(
+                    document, selected, active_viewport, bg_color, anno_scale,
+                    annotation_scale_handle, &source, block_cache, view_aabb,
+                    world_per_pixel, paper_space,
+                )
+            };
+            for wire in &mut construction {
+                wire.name = handle.value().to_string();
+                if !wire.selected {
+                    wire.color = [1.0, 0.25, 0.25, wire.color[3]];
+                }
+                wire.fill_tris.clear();
+                wire.fill_tris_low.clear();
+            }
+            wires.extend(construction);
+        }
+    }
+    wires
+}
 
 /// Result of `Scene::entity_index()`. The wire path queries `tree` for
 /// view-rect candidates and also always emits `unbounded_handles`
@@ -2731,12 +2805,12 @@ impl Scene {
         })
     }
 
-    /// Cache and display a Model-tab kernel solid.
-    pub fn register_solid_model(
-        &mut self,
+    /// Prepare display geometry without changing the entity or resident caches.
+    pub(crate) fn prepare_solid_model_display(
+        &self,
         handle: Handle,
-        solid: cadkernel::brep::Body,
-    ) -> bool {
+        solid: &cadkernel::brep::Body,
+    ) -> Option<(MeshLodSet, Vec<acadrust::entities::Wire>, [f64; 3])> {
         let color = self
             .document
             .get_entity(handle)
@@ -2746,67 +2820,88 @@ impl Scene {
         let chordal_deflection =
             crate::entities::solid3d::display_deflection(&self.document.header, facet_resolution);
         let isolines = self.document.header.isolines.max(0) as usize;
-        let displayed = if let Some((mut set, wires, center)) =
+        let (mut set, wires, center) =
             crate::scene::model::solid_model::display_from_solid(
-                &solid,
+                solid,
                 color,
                 facet_resolution,
                 chordal_deflection,
                 isolines,
+            )?;
+        let name = handle.value().to_string();
+        for mesh in &mut set.lods {
+            mesh.name = name.clone();
+        }
+        if let Some(entity) = self.document.get_entity(handle) {
+            crate::scene::model::material_model::resolve_material_with_base(
+                &self.document,
+                entity,
+                color,
+                None,
+                self.material_base_dir.as_deref(),
             )
-        {
-            if let Some(entity) = self.document.get_entity_mut(handle) {
-                let reference = acadrust::types::Vector3::new(center[0], center[1], center[2]);
-                match entity {
-                    EntityType::Solid3D(entity) => {
-                        entity.point_of_reference = reference;
-                        entity.wires = wires;
-                        entity.silhouettes.clear();
-                    }
-                    EntityType::Surface(entity) => {
-                        entity.point_of_reference = reference;
-                        entity.wires = wires;
-                        entity.silhouettes.clear();
-                    }
-                    _ => {}
+            .apply_to_with_face_overrides(
+                &mut set,
+                &self.document,
+                self.material_base_dir.as_deref(),
+            );
+            crate::scene::model::visual_style_model::apply_mesh_visual_style(
+                &mut set,
+                &self.document,
+                entity,
+            );
+        }
+        Some((set, wires, center))
+    }
+
+    /// Commit a prepared display without tessellating the body a second time.
+    pub(crate) fn register_prepared_solid_model(
+        &mut self,
+        handle: Handle,
+        solid: cadkernel::brep::Body,
+        display: (MeshLodSet, Vec<acadrust::entities::Wire>, [f64; 3]),
+    ) -> bool {
+        let (set, wires, center) = display;
+        if let Some(entity) = self.document.get_entity_mut(handle) {
+            let reference = acadrust::types::Vector3::new(center[0], center[1], center[2]);
+            match entity {
+                EntityType::Solid3D(entity) => {
+                    entity.point_of_reference = reference;
+                    entity.wires = wires;
+                    entity.silhouettes.clear();
                 }
+                EntityType::Surface(entity) => {
+                    entity.point_of_reference = reference;
+                    entity.wires = wires;
+                    entity.silhouettes.clear();
+                }
+                _ => {}
             }
-            let name = handle.value().to_string();
-            for mesh in &mut set.lods {
-                mesh.name = name.clone();
-            }
-            if let Some(entity) = self.document.get_entity(handle) {
-                crate::scene::model::material_model::resolve_material_with_base(
-                    &self.document,
-                    entity,
-                    color,
-                    None,
-                    self.material_base_dir.as_deref(),
-                )
-                .apply_to_with_face_overrides(
-                    &mut set,
-                    &self.document,
-                    self.material_base_dir.as_deref(),
-                );
-                crate::scene::model::visual_style_model::apply_mesh_visual_style(
-                    &mut set,
-                    &self.document,
-                    entity,
-                );
-            }
-            self.meshes.insert(handle, set);
-            true
-        } else {
-            self.meshes.remove(&handle);
-            false
-        };
+        }
+        self.meshes.insert(handle, set);
         self.solid_models.insert(handle, solid);
         self.sync_solid_reference_point(handle);
-        // Only this solid's mesh changed — report just its handle so the mesh /
-        // wire caches patch it in rather than rebuilding the whole drawing (and
-        // so a bulk register loop stays O(n), not O(n²)).
         self.bump_entities(&[(handle, ChangeKind::Modified)]);
-        displayed
+        true
+    }
+
+    /// Cache and display a Model-tab kernel solid. A failed preparation leaves
+    /// the previous entity, body and mesh untouched.
+    pub fn register_solid_model(
+        &mut self,
+        handle: Handle,
+        solid: cadkernel::brep::Body,
+    ) -> bool {
+        let Some(display) = self.prepare_solid_model_display(handle, &solid) else {
+            return false;
+        };
+        if !display.0.complete && matches!(
+            self.document.solid_history_operation(handle),
+            Some(acadrust::objects::SolidHistoryOperation::Loft(_))
+        ) {
+            return false;
+        }
+        self.register_prepared_solid_model(handle, solid, display)
     }
 
     /// `BACKGROUND` change picks up the new `adapt_to_bg` result without

--- a/src/scene/model/loft_command_model.rs
+++ b/src/scene/model/loft_command_model.rs
@@ -1,0 +1,95 @@
+//! LOFT command/history integration. Geometry and validation live in the kernel.
+
+use acadrust::entities::{EmbeddedEntity, Point, Surface, SurfaceData, SurfaceKind};
+use acadrust::objects::{SolidHistoryLoft, SolidHistoryLoftParameters, SolidHistoryNodeBase};
+use acadrust::{EntityType, Handle};
+use cadkernel::brep::Body;
+use crate::command::{ExtrudeMode, LoftOptions, LoftSectionSelection};
+use super::sweep_model::embedded_path;
+
+fn embedded_section(entity: &EntityType) -> Option<EmbeddedEntity> {
+    match entity {
+        EntityType::Region(region) => Some(EmbeddedEntity::Region(region.clone())),
+        EntityType::Point(point) => Some(EmbeddedEntity::Point(point.clone())),
+        _ => embedded_path(entity),
+    }
+}
+
+pub fn is_section(entity: &EntityType) -> bool {
+    embedded_section(entity).is_some_and(|entity|
+        cadkernel::acis::loft_section_geometry(&[entity]).is_ok())
+}
+
+pub fn is_guide_or_path(entity: &EntityType) -> bool {
+    embedded_path(entity).is_some_and(|entity| cadkernel::acis::loft_path_geometry(&entity).is_ok())
+}
+
+pub fn record(
+    sections: &[LoftSectionSelection], guides: &[Handle], path: Option<Handle>,
+    available: &[(Handle, EntityType)], mode: ExtrudeMode, options: LoftOptions,
+) -> Result<SolidHistoryLoft, String> {
+    let find = |handle| available.iter().find(|(candidate, _)| *candidate == handle)
+        .map(|(_, entity)| entity).ok_or_else(|| "A selected loft source no longer exists.".to_string());
+    let mut cross_sections = Vec::new();
+    let mut section_counts = Vec::new();
+    let mut surface = mode == ExtrudeMode::Surface;
+    for section in sections {
+        let members = match section {
+            LoftSectionSelection::Entity(handle) => vec![embedded_section(find(*handle)?)
+                .ok_or("Unsupported loft section.")?],
+            LoftSectionSelection::Point(point) => vec![EmbeddedEntity::Point(Point::from_coords(point.x, point.y, point.z))],
+            LoftSectionSelection::Join(handles) => handles.iter().map(|handle| {
+                embedded_section(find(*handle)?).ok_or_else(|| "Unsupported joined loft edge.".to_string())
+            }).collect::<Result<Vec<_>, _>>()?,
+        };
+        if let cadkernel::brep::LoftSection::Profile { closed, .. } = cadkernel::acis::loft_section_geometry(&members)? {
+            surface |= !closed;
+        }
+        section_counts.push(members.len());
+        cross_sections.extend(members);
+    }
+    let guides = guides.iter().map(|handle| embedded_path(find(*handle)?)
+        .ok_or_else(|| "Unsupported loft guide.".to_string())).collect::<Result<Vec<_>, _>>()?;
+    let path_entity = path.map(|handle| embedded_path(find(handle)?)
+        .ok_or_else(|| "Unsupported loft path.".to_string())).transpose()?;
+    Ok(SolidHistoryLoft {
+        base: SolidHistoryNodeBase::new(1), operation_major: 1,
+        cross_sections, guides,
+        parameters: Some(SolidHistoryLoftParameters {
+            path_entity, normals: options.normals,
+            start_draft_angle: options.start_draft_angle, end_draft_angle: options.end_draft_angle,
+            start_magnitude: options.start_magnitude, end_magnitude: options.end_magnitude,
+            start_continuity: options.start_continuity, end_continuity: options.end_continuity,
+            start_bulge: options.start_bulge, end_bulge: options.end_bulge,
+            closed: options.closed, periodic: options.periodic, surface, align_direction: options.align_direction, section_counts,
+        }),
+        ..SolidHistoryLoft::default()
+    })
+}
+
+pub fn build_body(
+    sections: &[LoftSectionSelection], guides: &[Handle], path: Option<Handle>,
+    available: &[(Handle, EntityType)], mode: ExtrudeMode, options: LoftOptions,
+) -> Result<Body, String> {
+    cadkernel::acis::rebuild_loft_with_options(&record(sections, guides, path, available, mode, options)?)
+}
+
+pub fn surface_entity(record: &SolidHistoryLoft) -> EntityType {
+    let settings = record.parameters.clone().unwrap_or_else(|| SolidHistoryLoftParameters {
+        normals: 0, ..Default::default()
+    });
+    let mut surface = Surface::new(SurfaceKind::Lofted);
+    surface.surface_data = SurfaceData::Lofted {
+        loft_transform: record.base.transform,
+        cross_section_entities: record.cross_sections.clone(), guide_entities: record.guides.clone(),
+        path_entity: settings.path_entity,
+        plane_normal_lofting_type: settings.normals,
+        start_draft_angle: settings.start_draft_angle, end_draft_angle: settings.end_draft_angle,
+        start_draft_magnitude: settings.start_magnitude, end_draft_magnitude: settings.end_magnitude,
+        arc_length_parameterization: true, no_twist: true, align_direction: settings.align_direction,
+        simple_surfaces: true, closed_surfaces: settings.closed, solid: false,
+        ruled_surface: settings.normals == 0, virtual_guide: false,
+        cross_sections: Vec::new(), guide_curves: Vec::new(), path_curve: None,
+    };
+    EntityType::Surface(surface)
+}

--- a/src/scene/model/mod.rs
+++ b/src/scene/model/mod.rs
@@ -11,5 +11,6 @@ pub mod mesh_model;
 pub mod solid_model;
 pub mod solid_history;
 pub mod sweep_model;
+mod sweep_command_model;
 pub mod visual_style_model;
 pub mod object;

--- a/src/scene/model/mod.rs
+++ b/src/scene/model/mod.rs
@@ -11,6 +11,7 @@ pub mod mesh_model;
 pub mod solid_model;
 pub mod solid_history;
 pub mod sweep_model;
+pub mod loft_command_model;
 mod sweep_command_model;
 pub mod visual_style_model;
 pub mod object;

--- a/src/scene/model/solid_history.rs
+++ b/src/scene/model/solid_history.rs
@@ -212,7 +212,9 @@ pub fn reference_point(operation: &SolidHistoryOperation) -> Option<glam::DVec3>
         }
         SolidHistoryOperation::Cone(value) => world_point(value.base.transform, [0.0; 3]),
         SolidHistoryOperation::Cylinder(value) => world_point(value.base.transform, [0.0; 3]),
-        SolidHistoryOperation::Sweep(value) | SolidHistoryOperation::Extrusion(value) => world_point(
+        SolidHistoryOperation::Sweep(value) => cadkernel::acis::sweep_history_reference_point(value)
+            .ok().map(glam::DVec3::from_array),
+        SolidHistoryOperation::Extrusion(value) => world_point(
             value.base.transform,
             [
                 value.reference_point.x,
@@ -444,7 +446,7 @@ fn sweep_properties(
     let (show_history, show_history_editable) =
         displayed_history_state(object_show_history, show_history_mode);
     let show_value = if show_history { "Yes" } else { "No" };
-    let length = sweep_path_length(value)
+    let length = cadkernel::acis::sweep_history_path_length(value).ok()
         .map(crate::entities::common::format_length)
         .unwrap_or_default();
     vec![
@@ -497,7 +499,7 @@ fn sweep_properties(
                     field: PROP_HISTORY,
                     value: PropValue::Choice {
                         selected: if record_history { "Record" } else { "None" }.to_string(),
-                        options: vec!["None".to_string(), "Record".to_string()],
+                        options: vec!["Record".to_string(), "None".to_string()],
                     },
                 },
                 Property {
@@ -506,7 +508,7 @@ fn sweep_properties(
                     value: if show_history_editable {
                         PropValue::Choice {
                             selected: show_value.to_string(),
-                            options: vec!["No".to_string(), "Yes".to_string()],
+                            options: vec!["Yes".to_string(), "No".to_string()],
                         }
                     } else {
                         PropValue::ReadOnly(show_value.to_string())
@@ -2179,6 +2181,7 @@ fn embedded_entity(value: &EmbeddedEntity) -> Option<EntityType> {
         EmbeddedEntity::Ellipse(value) => EntityType::Ellipse(value.clone()),
         EmbeddedEntity::Spline(value) => EntityType::Spline(value.clone()),
         EmbeddedEntity::LwPolyline(value) => EntityType::LwPolyline(value.clone()),
+        EmbeddedEntity::Region(value) => EntityType::Region(value.clone()),
         EmbeddedEntity::Ray(value) => EntityType::Ray(value.clone()),
         EmbeddedEntity::XLine(value) => EntityType::XLine(value.clone()),
         EmbeddedEntity::Unknown { .. } => return None,
@@ -2194,6 +2197,7 @@ fn into_embedded_entity(value: EntityType) -> Option<EmbeddedEntity> {
         EntityType::Ellipse(value) => EmbeddedEntity::Ellipse(value),
         EntityType::Spline(value) => EmbeddedEntity::Spline(value),
         EntityType::LwPolyline(value) => EmbeddedEntity::LwPolyline(value),
+        EntityType::Region(value) => EmbeddedEntity::Region(value),
         EntityType::Ray(value) => EmbeddedEntity::Ray(value),
         EntityType::XLine(value) => EmbeddedEntity::XLine(value),
         _ => return None,
@@ -2288,21 +2292,27 @@ fn apply_extrusion_profile_grip(
     true
 }
 
+fn sweep_placement_matrices(value: &SolidHistorySweep) -> Option<(glam::DMat4, glam::DMat4)> {
+    let (profile, path) = cadkernel::acis::sweep_history_placements(value).ok()?;
+    let matrix = |place: cadkernel::brep::Placement| {
+        glam::DMat4::from_cols(
+            glam::DVec3::from_array(place.x_axis).extend(0.0),
+            glam::DVec3::from_array(place.y_axis).extend(0.0),
+            glam::DVec3::from_array(place.z_axis).extend(0.0),
+            glam::DVec3::from_array(place.origin).extend(1.0),
+        )
+    };
+    Some((matrix(profile), matrix(path)))
+}
+
 fn sweep_embedded_grips(
     value: Option<&EmbeddedEntity>,
-    base_transform: [f64; 16],
-    entity_transform: [f64; 16],
+    transform: glam::DMat4,
     first_id: usize,
 ) -> Vec<GripDef> {
     let Some(entity) = value.and_then(embedded_entity) else {
         return Vec::new();
     };
-    let (Some(base), Some(entity_placement)) =
-        (matrix(base_transform), matrix(entity_transform))
-    else {
-        return Vec::new();
-    };
-    let transform = base * entity_placement;
     entity
         .grips()
         .into_iter()
@@ -2330,8 +2340,7 @@ fn sweep_embedded_grips(
 
 fn apply_sweep_embedded_grip(
     value: &mut Option<EmbeddedEntity>,
-    base_transform: [f64; 16],
-    entity_transform: [f64; 16],
+    transform: glam::DMat4,
     index: usize,
     apply: GripApply,
 ) -> bool {
@@ -2341,12 +2350,7 @@ fn apply_sweep_embedded_grip(
     let Some(source_grip) = entity.grips().get(index).cloned() else {
         return false;
     };
-    let (Some(base), Some(entity_placement)) =
-        (matrix(base_transform), matrix(entity_transform))
-    else {
-        return false;
-    };
-    let inverse = (base * entity_placement).inverse();
+    let inverse = transform.inverse();
     if !inverse.is_finite() {
         return false;
     }
@@ -2891,18 +2895,14 @@ pub fn primitive_grips(
             );
         }
         SolidHistoryOperation::Sweep(value) => {
-            grips.extend(sweep_embedded_grips(
-                value.sweep_entity.as_ref(),
-                value.base.transform,
-                value.sweep_entity_transform,
-                GRIP_SWEEP_PROFILE_FIRST,
-            ));
-            grips.extend(sweep_embedded_grips(
-                value.path_entity.as_ref(),
-                value.base.transform,
-                value.path_entity_transform,
-                GRIP_SWEEP_PATH_FIRST,
-            ));
+            if let Some((profile, path)) = sweep_placement_matrices(value) {
+                grips.extend(sweep_embedded_grips(
+                    value.sweep_entity.as_ref(), profile, GRIP_SWEEP_PROFILE_FIRST,
+                ));
+                grips.extend(sweep_embedded_grips(
+                    value.path_entity.as_ref(), path, GRIP_SWEEP_PATH_FIRST,
+                ));
+            }
         }
         SolidHistoryOperation::Loft(value) => grips.extend(loft_section_grips(value)),
         SolidHistoryOperation::Revolve(value) => {
@@ -2962,11 +2962,13 @@ pub fn apply_primitive_grip(
         }
     }
     if let SolidHistoryOperation::Sweep(value) = operation {
+        let Some((profile, path)) = sweep_placement_matrices(value) else {
+            return false;
+        };
         if let Some(index) = grip_id.checked_sub(GRIP_SWEEP_PATH_FIRST) {
             return apply_sweep_embedded_grip(
                 &mut value.path_entity,
-                value.base.transform,
-                value.path_entity_transform,
+                path,
                 index,
                 apply,
             );
@@ -2977,8 +2979,7 @@ pub fn apply_primitive_grip(
         {
             return apply_sweep_embedded_grip(
                 &mut value.sweep_entity,
-                value.base.transform,
-                value.sweep_entity_transform,
+                profile,
                 index,
                 apply,
             );

--- a/src/scene/model/solid_history.rs
+++ b/src/scene/model/solid_history.rs
@@ -1,7 +1,7 @@
 use acadrust::entities::{EmbeddedEntity, Solid3D};
 use acadrust::objects::{
     DynamicBlockData, ObjectType, SolidHistoryBox, SolidHistoryBrep, SolidHistoryCone,
-    SolidHistoryCylinder, SolidHistoryLoft, SolidHistoryNodeBase, SolidHistoryOperation,
+    SolidHistoryCylinder, SolidHistoryLoft, SolidHistoryLoftParameters, SolidHistoryNodeBase, SolidHistoryOperation,
     SolidHistoryPyramid, SolidHistoryRevolve, SolidHistorySphere, SolidHistorySweep,
     SolidHistoryTorus,
 };
@@ -76,6 +76,15 @@ pub const PROP_AXIS_DIRECTION_X: &str = "solid_history_axis_direction_x";
 pub const PROP_AXIS_DIRECTION_Y: &str = "solid_history_axis_direction_y";
 pub const PROP_AXIS_DIRECTION_Z: &str = "solid_history_axis_direction_z";
 pub const PROP_PYRAMID_TYPE: &str = "solid_history_pyramid_type";
+pub const PROP_LOFT_TYPE: &str = "solid_history_loft_type";
+pub const PROP_LOFT_SECTION_COUNT: &str = "solid_history_loft_section_count";
+pub const PROP_LOFT_NORMALS: &str = "solid_history_loft_normals";
+pub const PROP_LOFT_START_DRAFT_ANGLE: &str = "solid_history_loft_start_draft_angle";
+pub const PROP_LOFT_END_DRAFT_ANGLE: &str = "solid_history_loft_end_draft_angle";
+pub const PROP_LOFT_START_MAGNITUDE: &str = "solid_history_loft_start_magnitude";
+pub const PROP_LOFT_END_MAGNITUDE: &str = "solid_history_loft_end_magnitude";
+pub const PROP_LOFT_CLOSED: &str = "solid_history_loft_closed";
+pub const PROP_LOFT_PERIODIC: &str = "solid_history_loft_periodic";
 pub const PROP_HISTORY: &str = "solid_history_record";
 pub const PROP_SHOW_HISTORY: &str = "solid_history_show";
 
@@ -195,6 +204,7 @@ pub fn has_specialized_primitive_properties(
                 | SolidHistoryOperation::Torus(_)
                 | SolidHistoryOperation::Pyramid(_)
                 | SolidHistoryOperation::Sweep(_)
+                | SolidHistoryOperation::Loft(_)
                 | SolidHistoryOperation::Extrusion(_)
                 | SolidHistoryOperation::Revolve(_)
         )
@@ -517,6 +527,161 @@ fn sweep_properties(
             ],
         },
     ]
+}
+
+const LOFT_NORMAL_CHOICES: [&str; 7] = [
+    "Ruled",
+    "Smooth",
+    "First normal",
+    "Last normal",
+    "Ends normal",
+    "All normal",
+    "Use draft angles",
+];
+
+fn loft_parameters(value: &SolidHistoryLoft) -> SolidHistoryLoftParameters {
+    value.parameters.clone().unwrap_or_else(|| SolidHistoryLoftParameters {
+        // Older history predates the options extension and rebuilds as ruled.
+        // Displaying or editing it must not silently change it to smooth.
+        normals: 0,
+        ..SolidHistoryLoftParameters::default()
+    })
+}
+
+pub fn loft_section_count(value: &SolidHistoryLoft) -> usize {
+    value.parameters.as_ref()
+        .filter(|parameters| !parameters.section_counts.is_empty())
+        .map_or(value.cross_sections.len(), |parameters| parameters.section_counts.len())
+}
+
+pub fn loft_closed_editable(value: &SolidHistoryLoft) -> bool {
+    loft_section_count(value) >= 3
+        && !value.cross_sections.iter().any(|section| matches!(section, EmbeddedEntity::Point(_)))
+}
+
+fn loft_properties(
+    document: &acadrust::CadDocument,
+    handle: acadrust::Handle,
+    value: &SolidHistoryLoft,
+) -> Vec<PropSection> {
+    let parameters = loft_parameters(value);
+    let kind = if parameters.path_entity.is_some() {
+        t!("Loft with path").into_owned()
+    } else if !value.guides.is_empty() {
+        t!("Loft with guides").into_owned()
+    } else {
+        t!("Loft with cross sections only").into_owned()
+    };
+    let mut geometry = vec![
+        Property {
+            label: t!("Solid type").into_owned(),
+            field: PROP_LOFT_TYPE,
+            value: PropValue::ReadOnly(kind),
+        },
+        Property {
+            label: t!("Number of Cross sections").into_owned(),
+            field: PROP_LOFT_SECTION_COUNT,
+            value: PropValue::ReadOnly(loft_section_count(value).to_string()),
+        },
+        Property {
+            label: t!("Surface Normals").into_owned(),
+            field: PROP_LOFT_NORMALS,
+            value: PropValue::Choice {
+                selected: LOFT_NORMAL_CHOICES.get(parameters.normals as usize)
+                    .map_or_else(|| parameters.normals.to_string(), |name| (*name).to_string()),
+                options: LOFT_NORMAL_CHOICES.iter().map(|name| (*name).to_string()).collect(),
+            },
+        },
+    ];
+    if parameters.normals == 6 {
+        geometry.extend([
+            Property {
+                label: t!("Start draft angle").into_owned(),
+                field: PROP_LOFT_START_DRAFT_ANGLE,
+                value: PropValue::EditText(crate::entities::common::format_angle(parameters.start_draft_angle)),
+            },
+            Property {
+                label: t!("End draft angle").into_owned(),
+                field: PROP_LOFT_END_DRAFT_ANGLE,
+                value: PropValue::EditText(crate::entities::common::format_angle(parameters.end_draft_angle)),
+            },
+            Property {
+                label: t!("Start magnitude").into_owned(),
+                field: PROP_LOFT_START_MAGNITUDE,
+                value: PropValue::EditText(parameters.start_magnitude.to_string()),
+            },
+            Property {
+                label: t!("End magnitude").into_owned(),
+                field: PROP_LOFT_END_MAGNITUDE,
+                value: PropValue::EditText(parameters.end_magnitude.to_string()),
+            },
+        ]);
+    }
+    let (record_history, object_show_history, show_history_mode) =
+        history_flags(document, handle).unwrap_or((false, false, 1));
+    let (show_history, show_history_editable) =
+        displayed_history_state(object_show_history, show_history_mode);
+    let show_value = if show_history { "Yes" } else { "No" }.to_string();
+    let closed_value = if parameters.closed { "Yes" } else { "No" }.to_string();
+    let mut sections = vec![
+        PropSection {
+            title: t!("Geometry").into_owned(),
+            props: geometry,
+        },
+        PropSection {
+            title: t!("Solid History").into_owned(),
+            props: vec![
+                Property {
+                    label: t!("History").into_owned(),
+                    field: PROP_HISTORY,
+                    value: PropValue::Choice {
+                        selected: if record_history { "Record" } else { "None" }.to_string(),
+                        options: vec!["Record".to_string(), "None".to_string()],
+                    },
+                },
+                Property {
+                    label: t!("Show History").into_owned(),
+                    field: PROP_SHOW_HISTORY,
+                    value: if show_history_editable {
+                        PropValue::Choice {
+                            selected: show_value,
+                            options: vec!["Yes".to_string(), "No".to_string()],
+                        }
+                    } else {
+                        PropValue::ReadOnly(show_value)
+                    },
+                },
+            ],
+        },
+        PropSection {
+            title: t!("Misc").into_owned(),
+            props: vec![
+                Property {
+                    label: t!("Closed").into_owned(),
+                    field: PROP_LOFT_CLOSED,
+                    value: if loft_closed_editable(value) {
+                        PropValue::Choice {
+                            selected: closed_value,
+                            options: vec!["Yes".to_string(), "No".to_string()],
+                        }
+                    } else {
+                        PropValue::ReadOnly(closed_value)
+                    },
+                },
+            ],
+        },
+    ];
+    if parameters.closed {
+        sections[2].props.push(Property {
+            label: t!("Periodic").into_owned(),
+            field: PROP_LOFT_PERIODIC,
+            value: PropValue::Choice {
+                selected: if parameters.periodic { "Yes" } else { "No" }.to_string(),
+                options: vec!["Yes".to_string(), "No".to_string()],
+            },
+        });
+    }
+    sections
 }
 
 fn sweep_path_length(value: &SolidHistorySweep) -> Option<f64> {
@@ -1209,6 +1374,7 @@ pub fn primitive_properties(
         SolidHistoryOperation::Pyramid(value) => pyramid_properties(document, handle, value),
         SolidHistoryOperation::Torus(value) => torus_properties(document, handle, value),
         SolidHistoryOperation::Sweep(value) => sweep_properties(document, handle, value),
+        SolidHistoryOperation::Loft(value) => loft_properties(document, handle, value),
         SolidHistoryOperation::Extrusion(value) => {
             extrusion_properties(document, handle, value)
         }
@@ -1253,6 +1419,13 @@ pub fn is_primitive_property(field: &str) -> bool {
             | PROP_AXIS_DIRECTION_Y
             | PROP_AXIS_DIRECTION_Z
             | PROP_PYRAMID_TYPE
+            | PROP_LOFT_NORMALS
+            | PROP_LOFT_START_DRAFT_ANGLE
+            | PROP_LOFT_END_DRAFT_ANGLE
+            | PROP_LOFT_START_MAGNITUDE
+            | PROP_LOFT_END_MAGNITUDE
+            | PROP_LOFT_CLOSED
+            | PROP_LOFT_PERIODIC
     )
 }
 
@@ -1260,8 +1433,13 @@ pub fn is_history_choice(field: &str) -> bool {
     matches!(field, PROP_HISTORY | PROP_SHOW_HISTORY)
 }
 
+pub fn is_loft_geometry_choice(field: &str) -> bool {
+    matches!(field, PROP_LOFT_NORMALS | PROP_LOFT_CLOSED | PROP_LOFT_PERIODIC)
+}
+
 pub fn is_specialized_property(field: &str) -> bool {
-    matches!(field, "solid_history_type" | PROP_BANK | PROP_SWEEP_LENGTH)
+    matches!(field, "solid_history_type" | PROP_BANK | PROP_SWEEP_LENGTH
+        | PROP_LOFT_TYPE | PROP_LOFT_SECTION_COUNT)
         || is_primitive_property(field)
         || is_history_choice(field)
 }
@@ -1688,6 +1866,85 @@ fn apply_sweep_geometry_property(
     }
 }
 
+fn apply_loft_geometry_property(
+    value: &mut SolidHistoryLoft,
+    field: &str,
+    text: &str,
+) -> Option<bool> {
+    let current = loft_parameters(value);
+    let mut parameters = current.clone();
+    match field {
+        PROP_LOFT_NORMALS => {
+            let Some(index) = LOFT_NORMAL_CHOICES.iter()
+                .position(|name| name.eq_ignore_ascii_case(text.trim()))
+            else {
+                return Some(false);
+            };
+            parameters.normals = index as i32;
+        }
+        PROP_LOFT_START_DRAFT_ANGLE | PROP_LOFT_END_DRAFT_ANGLE => {
+            if parameters.normals != 6 {
+                return Some(false);
+            }
+            let Some(angle) = crate::entities::common::parse_angle(text)
+                .filter(|angle| angle.is_finite() && (0.0..=std::f64::consts::PI).contains(angle))
+            else {
+                return Some(false);
+            };
+            if field == PROP_LOFT_START_DRAFT_ANGLE {
+                parameters.start_draft_angle = angle;
+            } else {
+                parameters.end_draft_angle = angle;
+            }
+        }
+        PROP_LOFT_START_MAGNITUDE | PROP_LOFT_END_MAGNITUDE => {
+            if parameters.normals != 6 {
+                return Some(false);
+            }
+            let Some(magnitude) = text.trim().replace(',', ".").parse::<f64>().ok()
+                .filter(|magnitude| magnitude.is_finite() && *magnitude >= 0.0)
+            else {
+                return Some(false);
+            };
+            if field == PROP_LOFT_START_MAGNITUDE {
+                parameters.start_magnitude = magnitude;
+            } else {
+                parameters.end_magnitude = magnitude;
+            }
+        }
+        PROP_LOFT_CLOSED => {
+            if !loft_closed_editable(value) {
+                return Some(false);
+            }
+            parameters.closed = if text.trim().eq_ignore_ascii_case("Yes") {
+                true
+            } else if text.trim().eq_ignore_ascii_case("No") {
+                false
+            } else {
+                return Some(false);
+            };
+        }
+        PROP_LOFT_PERIODIC => {
+            if !parameters.closed {
+                return Some(false);
+            }
+            parameters.periodic = if text.trim().eq_ignore_ascii_case("Yes") {
+                true
+            } else if text.trim().eq_ignore_ascii_case("No") {
+                false
+            } else {
+                return Some(false);
+            };
+        }
+        _ => return None,
+    }
+    if parameters == current {
+        return Some(false);
+    }
+    value.parameters = Some(parameters);
+    Some(true)
+}
+
 fn apply_torus_position_property(
     value: &mut SolidHistoryTorus,
     field: &str,
@@ -1878,6 +2135,11 @@ pub fn apply_primitive_property(
     }
     if let SolidHistoryOperation::Sweep(sweep_value) = operation {
         if let Some(applied) = apply_sweep_geometry_property(sweep_value, field, value) {
+            return applied;
+        }
+    }
+    if let SolidHistoryOperation::Loft(loft_value) = operation {
+        if let Some(applied) = apply_loft_geometry_property(loft_value, field, value) {
             return applied;
         }
     }
@@ -2186,6 +2448,51 @@ fn embedded_entity(value: &EmbeddedEntity) -> Option<EntityType> {
         EmbeddedEntity::XLine(value) => EntityType::XLine(value.clone()),
         EmbeddedEntity::Unknown { .. } => return None,
     })
+}
+
+/// Visible LOFT construction curves, owned by the parent display entity.
+/// Copies are transformed to WCS and never inserted into the document.
+pub fn loft_visible_history_entities(
+    document: &acadrust::CadDocument,
+    handle: acadrust::Handle,
+) -> Vec<EntityType> {
+    let Some((_, object_show_history, show_history_mode)) = history_flags(document, handle) else {
+        return Vec::new();
+    };
+    if !displayed_history_state(object_show_history, show_history_mode).0 {
+        return Vec::new();
+    }
+    let Some(SolidHistoryOperation::Loft(value)) = document.solid_history_operation(handle) else {
+        return Vec::new();
+    };
+    let Some(parent) = document.get_entity(handle) else {
+        return Vec::new();
+    };
+    let Some(transform) = matrix(value.base.transform) else {
+        return Vec::new();
+    };
+    let columns = transform.to_cols_array_2d();
+    let affine = acadrust::types::Transform::from_matrix(
+        acadrust::types::Matrix4 {
+            m: std::array::from_fn(|row| std::array::from_fn(|column| columns[column][row])),
+        },
+    );
+    value.cross_sections.iter()
+        .chain(&value.guides)
+        .chain(value.parameters.as_ref().and_then(|parameters| parameters.path_entity.as_ref()))
+        .filter_map(|source| {
+            let mut entity = embedded_entity(source)?;
+            entity.apply_transform(&affine);
+            // Construction sources belong to the visible parent's layer and
+            // selection identity, not a deleted source or hidden source layer.
+            let common = entity.common_mut();
+            common.handle = handle;
+            common.owner_handle = parent.common().owner_handle;
+            common.layer = parent.common().layer.clone();
+            common.invisible = parent.common().invisible;
+            Some(entity)
+        })
+        .collect()
 }
 
 fn into_embedded_entity(value: EntityType) -> Option<EmbeddedEntity> {

--- a/src/scene/model/sweep_command_model.rs
+++ b/src/scene/model/sweep_command_model.rs
@@ -1,0 +1,113 @@
+//! SWEEP command data mapped to the shared kernel history reconstruction.
+
+use acadrust::entities::{Surface, SurfaceData, SurfaceKind, SurfaceSweepOptions};
+use acadrust::objects::{SolidHistoryNodeBase, SolidHistorySweep};
+use acadrust::types::Vector3;
+use acadrust::EntityType;
+use cadkernel::brep::Body;
+
+use crate::command::{ExtrudeMode, SweepOptions};
+use super::sweep_model::{embedded_path, embedded_revolve_profile};
+
+fn embedded_sweep_profile(entity: &EntityType) -> Option<(acadrust::entities::EmbeddedEntity, [f64; 16])> {
+    if let EntityType::Region(region) = entity {
+        Some((acadrust::entities::EmbeddedEntity::Region(region.clone()), glam::DMat4::IDENTITY.to_cols_array()))
+    } else {
+        embedded_revolve_profile(entity)
+    }
+}
+
+pub fn is_sweep_profile(entity: &EntityType) -> bool {
+    embedded_sweep_profile(entity).is_some_and(|(profile, transform)| {
+        cadkernel::acis::sweep_profile_geometry(&profile, transform).is_ok()
+    })
+}
+
+pub fn is_sweep_path(entity: &EntityType) -> bool {
+    match embedded_path(entity) {
+        Some(acadrust::entities::EmbeddedEntity::Spline(value)) => {
+            value.degree > 0 && (value.control_points.len() > value.degree as usize
+                || value.fit_points.len() >= 2)
+        }
+        Some(_) => crate::entities::curve::entity_curve(entity)
+            .is_some_and(|curve| curve.curve.length().is_finite() && curve.curve.length() > 1e-9),
+        None => false,
+    }
+}
+
+/// All selected profiles use one base point, preserving their relative offsets.
+pub fn sweep_selection_options(profiles: &[EntityType], mut options: SweepOptions) -> Option<SweepOptions> {
+    if options.base_point.is_some() {
+        return Some(options);
+    }
+    let geometry = profiles.iter().map(|profile| {
+        let (entity, transform) = embedded_sweep_profile(profile)?;
+        let (plane, wires, _) = cadkernel::acis::sweep_profile_geometry(&entity, transform).ok()?;
+        Some((plane, wires))
+    }).collect::<Option<Vec<_>>>()?;
+    options.base_point = Some(glam::DVec3::from_array(
+        cadkernel::brep::sweep_profile_group_base(&geometry)?,
+    ));
+    Some(options)
+}
+
+pub fn sweep_record(profile: &EntityType, path: &EntityType, options: SweepOptions) -> Option<SolidHistorySweep> {
+    let (sweep_entity, sweep_entity_transform) = embedded_sweep_profile(profile)?;
+    let (plane, wires, _) = cadkernel::acis::sweep_profile_geometry(&sweep_entity, sweep_entity_transform).ok()?;
+    let base_point = match options.base_point {
+        Some(point) => point.to_array(),
+        None => cadkernel::brep::sweep_profile_base(plane, &wires)?,
+    };
+    let mut base = SolidHistoryNodeBase::new(1);
+    base.transform = glam::DMat4::IDENTITY.to_cols_array();
+    Some(SolidHistorySweep {
+        base,
+        operation_major: 1,
+        sweep_entity: Some(sweep_entity),
+        path_entity: Some(embedded_path(path)?),
+        scale_factor: options.scale,
+        twist_angle: options.twist_angle,
+        align_option: u8::from(options.align),
+        has_align_start: true,
+        bank: options.bank,
+        sweep_entity_transform,
+        path_entity_transform: glam::DMat4::IDENTITY.to_cols_array(),
+        reference_point: Vector3::new(base_point[0], base_point[1], base_point[2]),
+        ..SolidHistorySweep::default()
+    })
+}
+
+pub fn swept_with_options(profile: &EntityType, path: &EntityType, mode: ExtrudeMode, options: SweepOptions) -> Option<Body> {
+    let record = sweep_record(profile, path, options)?;
+    cadkernel::acis::rebuild_sweep_with_mode(&record, mode == ExtrudeMode::Surface).ok()
+}
+
+/// Preserve native construction parameters alongside the sheet's saved B-rep.
+pub fn swept_surface_entity(record: &SolidHistorySweep) -> EntityType {
+    let mut surface = Surface::new(SurfaceKind::Swept);
+    if let Ok(point) = cadkernel::acis::sweep_history_reference_point(record) {
+        surface.point_of_reference = Vector3::new(point[0], point[1], point[2]);
+    }
+    surface.surface_data = SurfaceData::Swept {
+        class_version: 0,
+        sweep_entity: record.sweep_entity.clone(),
+        path_entity: record.path_entity.clone(),
+        sweep_transform: glam::DMat4::IDENTITY.to_cols_array(),
+        path_transform: glam::DMat4::IDENTITY.to_cols_array(),
+        options: SurfaceSweepOptions {
+            draft_angle: record.draft_angle,
+            twist_angle: record.twist_angle,
+            scale_factor: record.scale_factor,
+            align_angle: record.align_angle,
+            sweep_entity_transform: record.sweep_entity_transform,
+            path_entity_transform: record.path_entity_transform,
+            sweep_alignment_flags: record.align_option as i16,
+            align_start: record.has_align_start,
+            bank: record.bank,
+            base_point_set: true,
+            reference_vector: record.reference_point,
+            ..SurfaceSweepOptions::default()
+        },
+    };
+    EntityType::Surface(surface)
+}

--- a/src/scene/model/sweep_model.rs
+++ b/src/scene/model/sweep_model.rs
@@ -12,6 +12,9 @@ use acadrust::types::{Vector2, Vector3};
 use acadrust::EntityType;
 
 use crate::entities::curve::entity_curve;
+pub use super::sweep_command_model::{
+    is_sweep_path, is_sweep_profile, sweep_record, sweep_selection_options, swept_surface_entity, swept_with_options,
+};
 
 /// A drawn profile, as the kernel wants it: the plane it lies in and the
 /// chain of pieces closing a loop in that plane.
@@ -591,18 +594,32 @@ pub fn embedded_path(entity: &EntityType) -> Option<EmbeddedEntity> {
         EntityType::Circle(value) => Some(EmbeddedEntity::Circle(value.clone())),
         EntityType::Ellipse(value) => Some(EmbeddedEntity::Ellipse(value.clone())),
         EntityType::LwPolyline(value) => Some(EmbeddedEntity::LwPolyline(value.clone())),
+        EntityType::Polyline2D(value) => {
+            let mut polyline = LwPolyline::new();
+            polyline.elevation = value.elevation;
+            polyline.normal = value.normal;
+            polyline.is_closed = value.is_closed();
+            polyline.vertices = value.vertices.iter().map(|vertex| {
+                let mut converted = LwVertex::new(Vector2::new(vertex.location.x, vertex.location.y));
+                converted.bulge = vertex.bulge;
+                converted
+            }).collect();
+            Some(EmbeddedEntity::LwPolyline(polyline))
+        }
         EntityType::Spline(value) => Some(EmbeddedEntity::Spline(value.clone())),
-        EntityType::Polyline3D(value) if !value.is_closed() && value.vertices.len() >= 2 => {
+        EntityType::Helix(value) => Some(EmbeddedEntity::Spline(value.spline.clone())),
+        EntityType::Polyline3D(value) if value.vertices.len() >= 2 => {
+            let mut points = value.vertices.iter().map(|vertex| vertex.position).collect::<Vec<_>>();
+            if value.is_closed() && points.first() != points.last() {
+                points.push(*points.first()?);
+            }
             let mut spline = Spline::from_control_points(
                 1,
-                value
-                    .vertices
-                    .iter()
-                    .map(|vertex| vertex.position)
-                    .collect(),
+                points,
             );
             spline.flags.linear = true;
             spline.flags.planar = false;
+            spline.flags.closed = value.is_closed();
             Some(EmbeddedEntity::Spline(spline))
         }
         _ => None,

--- a/src/scene/modify.rs
+++ b/src/scene/modify.rs
@@ -841,13 +841,29 @@ impl Scene {
         handle: Handle,
         operation: acadrust::objects::SolidHistoryOperation,
     ) -> bool {
-        self.solid_history_preview_wires.remove(&handle);
         let Ok(body) = cadkernel::acis::rebuild_body(&operation) else {
             return false;
         };
         let Some(document) = crate::scene::convert::acis_export::solid_to_sat(&body) else {
             return false;
         };
+        let loft_surface_data = match (&operation, self.document.get_entity(handle)) {
+            (acadrust::objects::SolidHistoryOperation::Loft(record), Some(EntityType::Surface(_))) => {
+                let EntityType::Surface(surface) = crate::scene::model::loft_command_model::surface_entity(record)
+                    else { return false; };
+                Some(surface.surface_data)
+            }
+            (_, Some(EntityType::Solid3D(_))) => None,
+            _ => return false,
+        };
+        let Some(display) = self.prepare_solid_model_display(handle, &body) else {
+            return false;
+        };
+        if matches!(&operation, acadrust::objects::SolidHistoryOperation::Loft(_))
+            && !display.0.complete
+        {
+            return false;
+        }
         self.record_solid_history_before(handle);
         if self
             .document
@@ -856,12 +872,16 @@ impl Scene {
         {
             return false;
         }
-        let Some(EntityType::Solid3D(entity)) = self.document.get_entity_mut(handle) else {
-            return false;
-        };
-        entity.set_sat_document(&document);
-        self.sync_solid_reference_point(handle);
-        self.register_solid_model(handle, body);
+        match self.document.get_entity_mut(handle) {
+            Some(EntityType::Solid3D(entity)) => entity.set_sat_document(&document),
+            Some(EntityType::Surface(entity)) => {
+                entity.acis_data = acadrust::entities::AcisData::from_sat(&document.to_sat_string());
+                if let Some(data) = loft_surface_data { entity.surface_data = data; }
+            }
+            _ => return false,
+        }
+        self.register_prepared_solid_model(handle, body, display);
+        self.solid_history_preview_wires.remove(&handle);
         true
     }
 
@@ -875,13 +895,28 @@ impl Scene {
         let Some(document) = crate::scene::convert::acis_export::solid_to_sat(&body) else {
             return false;
         };
-        let Some(EntityType::Solid3D(entity)) = self.document.get_entity_mut(handle) else {
+        let Some(display) = self.prepare_solid_model_display(handle, &body) else {
             return false;
         };
-        entity.set_sat_document(&document);
-        self.sync_solid_reference_point(handle);
+        if matches!(&operation, acadrust::objects::SolidHistoryOperation::Loft(_))
+            && !display.0.complete
+        {
+            return false;
+        }
+        match self.document.get_entity_mut(handle) {
+            Some(EntityType::Solid3D(entity)) => entity.set_sat_document(&document),
+            Some(EntityType::Surface(entity)) => {
+                entity.acis_data = acadrust::entities::AcisData::from_sat(&document.to_sat_string());
+                if let acadrust::objects::SolidHistoryOperation::Loft(record) = &operation {
+                    if let EntityType::Surface(updated) = crate::scene::model::loft_command_model::surface_entity(record) {
+                        entity.surface_data = updated.surface_data;
+                    }
+                }
+            }
+            _ => return false,
+        }
+        self.register_prepared_solid_model(handle, body, display);
         self.solid_history_preview_wires.remove(&handle);
-        self.register_solid_model(handle, body);
         true
     }
 
@@ -900,9 +935,9 @@ impl Scene {
         {
             return false;
         }
-        let Some(EntityType::Solid3D(_)) = self.document.get_entity(handle) else {
+        if !matches!(self.document.get_entity(handle), Some(EntityType::Solid3D(_) | EntityType::Surface(_))) {
             return false;
-        };
+        }
         self.solid_history_preview_wires.insert(
             handle,
             crate::scene::model::solid_model::grip_preview_wires(&body, handle),
@@ -945,12 +980,16 @@ impl Scene {
         value: &str,
     ) -> bool {
         self.record_solid_history_before(handle);
-        crate::scene::model::solid_history::apply_history_choice(
+        let applied = crate::scene::model::solid_history::apply_history_choice(
             &mut self.document,
             handle,
             field,
             value,
-        )
+        );
+        if applied {
+            self.bump_entities(&[(handle, ChangeKind::Modified)]);
+        }
+        applied
     }
 
     fn apply_solid_history_grip(


### PR DESCRIPTION
1) LOFT komutu, sıralı kesit toplama aşaması ile Guides, Path, Cross sections only ve Settings aşamalarını ayırır. Komut seçenekleri hem metin girdisinden hem seçenek düğmelerinden kullanılabilir.

2) LOFT önseçili nesneleri seçim sırasıyla alır; yeterli geçerli kesit bulunduğunda doğrudan seçenek aşamasına geçer. Yinelenen nesneler ve desteklenmeyen kesitler ayıklanır.

3) Join, bağlantılı açık kenarları tek LOFT kesiti olarak gruplar. History kaydı, grubun kaynak kenarlarını ve kesit başına kenar sayılarını ayrı tutar; gruplama bir çokgen kopyasına indirgenmez.

4) LOFT, koordinatla girilen Point uçlarını ve mevcut Point nesnelerini kesit olarak kabul eder. Nokta yalnız ilk veya son kesitte bulunabilir; arada nokta ve aralarında eğri bulunmayan iki nokta reddedilir. Son noktanın seçilmesi kesit toplamayı bitirir; geçersiz önseçim komutu açık tutar.

5) Nokta uçlu LOFT için Continuity seçeneği eklenir. Başlangıç ve bitiş uçlarının G0/G1 değerleri ayrı saklanır; varsayılan G1'dir. İki nokta ucu varsa başlangıç ve bitiş değerleri sırayla sorulur.

6) Nokta uçlu LOFT için Bulge magnitude seçeneği eklenir. Başlangıç ve bitiş büyüklükleri ayrı saklanır; varsayılan 0.5'tir. Sıfır ve sonlu pozitif değerler kabul edilir; negatif veya sonlu olmayan değerler reddedilir. Bu parametreler draft büyüklüklerinden bağımsızdır.

7) LOFT Mode, Solid ve Surface üretimini seçtirir. Açık kesitlerden Solid seçilmiş olsa da yüzey oluşturulur; kapalı kesitler Surface modunda LoftedSurface olarak üretilir.

8) LOFT Guides, birden fazla kılavuz eğri toplar. Kesitlerin kılavuz olarak tekrar seçilmesi ve aynı kılavuzun yinelenmesi engellenir; kılavuzların geometrik koşulları çekirdeğe iletilir.

9) LOFT Path, tek bir yol eğrisiyle üretimi destekler. Guides ve Path birbirini dışlar; kullanıcı yol seçerken önceki kılavuzlar, kılavuz seçerken önceki yol kaldırılır.

10) Cross sections only, kılavuz ve yol seçimlerini temizleyerek yalnız sıralı kesitlerle LOFT üretir.

11) LOFT Settings içindeki Normals, Ruled, Smooth, First normal, Last normal, Ends normal, All normal ve Use draft angles seçeneklerini taşır. Yeni LOFT için varsayılan Smooth'tur.

12) Use draft angles seçildiğinde başlangıç/bitiş draft açıları ve büyüklükleri komuttan değiştirilebilir. Açılar 0–180 derece aralığında alınarak radyan saklanır; varsayılan iki açı 90 derece, iki büyüklük sıfırdır. Büyüklükler sonlu ve negatif olmayan değerlerle sınırlandırılır.

13) LOFT Settings içindeki Closed, en az üç eğri kesitinde kullanılabilir; nokta uçlarında kapalı üretim engellenir. Align direction, kesit yönlerinin çekirdek tarafından hizalanmasını açıp kapatır.

14) LOFT yerel Undo, kesit/kılavuz/yol seçimlerini ve komut ayarlarını geri alır. Boş veya geçersiz girdiler ve çekirdeğin reddettiği şekiller, mevcut seçimleri kaybetmeden ilgili istemde kalır.

15) LOFT canlı önizlemesi kesit, kılavuz, yol, mod, parametreler ve kaynak nesne sürümünden oluşan bir anahtarla önbelleğe alınır. Aynı kaynak üzerinde fare hareketi aynı gövdeyi tekrar üretmez; yeni kesit, yol ve Point konumu tel görünümünde gösterilir.

16) LOFT, DELOBJ etkinse yalnız başarılı sonucun kaynak kesitlerini tüketir. Silinmesi gereken kilitli katman kaynakları işlemi durdurur. Başarı tek Undo/Redo adımıdır; başarısız geçici sonuç kaldırılır, boş geri alma kaydı bırakılmaz ve komut seçimleri korunur.

17) LOFT Properties için özel Geometry bölümü eklenir. Solid type satırı, Loft with cross sections only, Loft with guides veya Loft with path değerini salt okunur gösterir.

18) Number of Cross sections salt okunur gösterilir. Join ile gruplanmış kenarlar ayrı kesit sayılmaz; sayı, history'deki kesit gruplarından hesaplanır.

19) Surface Normals satırı düzenlenebilir açılır listedir; yedi seçenek komutla aynı sırada sunulur. Seçim, yalnız metadata değiştirmek yerine gövdenin yeniden üretilmesini tetikler.

20) Start draft angle satırı yalnız Use draft angles seçildiğinde görünür. Düzenlenen derece değeri radyana çevrilir ve başlangıç geometrisine uygulanır.

21) End draft angle satırı yalnız Use draft angles seçildiğinde görünür. Bitiş açısı başlangıç açısından bağımsız düzenlenir ve gövdeye uygulanır.

22) Start magnitude satırı yalnız Use draft angles seçildiğinde görünür; başlangıç büyüklüğü düzenlenebilir ve negatif olmayan sonlu değerlerle geometriyi yeniden üretir.

23) End magnitude satırı aynı koşulda görünür; bitiş büyüklüğü başlangıç büyüklüğünden bağımsız düzenlenir ve geometriyi yeniden üretir.

24) Solid History bölümündeki History satırı, Record ve None sıralı seçenekleriyle nesnenin history kayıt bayrağını değiştirir.

25) Show History satırı Yes ve No sıralı seçeneklerini kullanır. SHOWHIST=0 iken salt okunur No, SHOWHIST=2 iken salt okunur Yes gösterilir; SHOWHIST=1 iken nesneye özel görünürlük düzenlenebilir. Bayrak değişikliği nesnenin görüntü önbelleğini yeniler.

26) Misc bölümündeki Closed satırı, iki kesitli veya nokta uçlu LOFT için salt okunurdur. En az üç nokta olmayan kesitte Yes/No seçimi açılır ve değişiklik gerçek geometriye uygulanır.

27) Periodic satırı yalnız Closed=Yes iken, Closed satırının hemen altında görünür. Varsayılan Yes'tir; Yes/No değişikliği kapatma birleşiminin periyodik davranışıyla gövdeyi yeniden üretir.

28) SOLIDHIST ve SHOWHIST, doğrudan komut ve SETVAR üzerinden okunup yazılabilir. SOLIDHIST yeni nesnelerin history kayıt tercihini belirler; SHOWHIST değişikliği görüntüyü ve koşullu Properties denetimlerini yeniler.

29) LOFT Show History, gömülü kesitleri, kılavuzları ve yolu WCS konumlarında görünür tel geometri olarak çizer. Kaynaklar belgeye tekrar eklenmez; ana nesnenin katmanı, seçim kimliği ve sahipliği kullanılır. Seçilmemiş kaynak çizgileri ayırt edilebilir renkte gösterilir.

30) Region kesitlerinin history görünümü, çekirdeğin çözdüğü bütün sınır eğrilerini ve delikleri kapsar. Örnekleme yalnız görüntü içindir; kaynak Region ve tam eğri verileri korunur. Çizgiler ana nesnenin önbelleğinde tutulur ve yüksek koordinat hassasiyeti korunur.

31) Katı/yüzey görüntüsü hazırlama ile sonucu sahneye uygulama ayrılır. Gövde başına mesh bir kez hazırlanır; görüntü üretilemezse önceki entity, gövde ve mesh değiştirilmez. Malzeme, yüz malzemeleri, görsel stil, tel geometri ve referans noktası hazır sonuçla birlikte aktarılır.

32) LOFT ilk üretimi ve history yeniden üretimi, bütün yüzlerin görüntüye aktarılmış olmasını gerektirir. Eksik görüntü history veya SAT verisi değiştirilmeden reddedilir; geçici yeni nesne kaldırılır ve kaynak kesitleri tüketilmez. Başarılı yeniden üretimden sonra önizleme temizlenir.

33) LOFT katılarıyla birlikte yüzeylerin kesit gripleri de history üzerinden önizlenip kesinleştirilir. Grip hareketinde bütün sonuçlar uygulanabilir olana kadar orijinal nesneler ve history kayıtları tutulur; başarısız kesinleştirme bütün hareketi geri alır.

34) LOFT uygulama veri modeli, sıralı Entity/Point/Join kesitleri ile kılavuz, yol, üretim modu ve bütün LOFT parametrelerini tek sonuç sözleşmesinde taşır. İlk üretim, önizleme ve history yeniden üretimi aynı çekirdek çağrılarını kullanır.

35) LOFT history kaydı; kaynak kesitleri, kılavuzları, yol nesnesini, kesit gruplamasını, normal/draft seçeneklerini, büyüklükleri, nokta uçlarının continuity/bulge değerlerini, Closed, Periodic, Surface ve Align direction tercihlerini güncellenen cadcodec veri modeline aktarır.

36) LoftedSurface nesneleri, ACIS gövdelerine ek olarak yerel SurfaceData::Lofted üretim verilerini taşır. History veya grip düzenlemesi kesinleştiğinde kesit/kılavuz/yol, dönüşüm ve ilgili yüzey ayarları aynı kayıtla eşitlenir. Parametre uzantısı olmayan eski LOFT history kayıtları Ruled olarak yorumlanır; ilk düzenleme onları sessizce Smooth'a dönüştürmez.

37) cadcodec ve cadkernel bağımlılıkları, genişletilmiş LOFT/SWEEP veri modeli ve geometrik API'lerini sağlayan sürümlere taşınır. Gömülü Region nesneleri uygulamanın nesne verisi ve yüzey kaynak türü gösteriminde de tanınır.

38) Uygulama; açık/kapalı kesitler, Region delikleri, farklı kenar sayıları, rasyonel eğriler, nokta uçları, kılavuz/yol kısıtları ve normal/draft/kapalı üretim için cadkernel'in genel LOFT API'sini kullanır. Kesit eşleştirme, yüzey oluşturma, topoloji ve tolerans işlemleri uygulamada ayrı algoritmalarla çoğaltılmaz.

39) [SWEEP kapsamı](https://github.com/HakanSeven12/OpenCADStudio/pull/994): SWEEP birden fazla profili ve önseçimi destekler. Geçerli profiller tek yolda işlenir; profilin aynı zamanda yol seçilmesi ve yinelenen profiller engellenir. Kilitli profiller atlanır; değiştirilmeden kullanılan yolun kilitli olması üretimi engellemez.

40) SWEEP Mode, Solid/Surface seçimini ekler. Açık profiller yüzey oluşturur; kapalı profiller için katı veya yüzey üretimi seçilebilir.

41) SWEEP Alignment, profilin yola dik hizalanmasını açıp kapatır. Base point kullanıcı tarafından seçilebilir; çoklu profiller için çekirdeğin ortak taban noktası kullanılarak profillerin birbirine göre konumu korunur.

42) SWEEP Scale, doğrudan ölçek katsayısını ve Reference akışını destekler. Referans uzunluğu sayı veya iki noktadan, yeni uzunluk sayı veya Points seçeneğiyle iki noktadan alınır; sıfır veya geçersiz uzunluklar reddedilir.

43) SWEEP Twist, açı girdisini radyan parametresine aktarır. Bank seçeneği yol boyunca yönlenme davranışını etkinleştirir; yeniden açı girilmesi Bank durumunu kapatır.

44) SWEEP üretim ve önizlemesi, ortak cadkernel history yeniden üretimini kullanır. Region profilleri, delikleri ve tam sınır eğrileriyle çekirdeğe iletilir. Katılar gömülü profil/yol history'sini, yüzeyler ACIS verisine ek olarak yerel SweptSurface üretim parametrelerini taşır.

45) Paylaşılan kaynak dönüşümü, ağır 2D polyline'ın normal, yükseklik, kapalılık ve bulge bilgilerini korur; Helix eğrisini spline olarak aktarır. Açık/kapalı 3D polyline yolları doğrusal spline biçiminde taşınır ve kapalı yolun son bağlantısı korunur.

46) SWEEP, DELOBJ etkin olduğunda yalnız başarıyla üretilmiş profilleri siler; başarısız profiller ve yol korunur. Çoklu üretim tek Undo/Redo grubunda toplanır; sonuç mesajı oluşan nesne ve başarısız kaynak sayılarını ayrı gösterir.

47) SWEEP Properties içindeki yol uzunluğu ve referans noktası, çekirdeğin gerçek yol ve yerleşim verilerinden alınır. History seçenek sırası Record/None, Show History seçenek sırası Yes/No olarak düzenlenir.

48) SWEEP profil ve yol griplerinin görüntü konumları ve düzenleme dönüşümleri, çekirdeğin hesapladığı yerleşimlerle eşleştirilir. Hizalama ve taban noktası uygulandıktan sonra gripler kaynak nesnenin eski konumunda kalmaz.

49) SWEEP yol üzerinde gezinirken bütün seçili profillerin tel önizlemesini üretir. Yol, mod ve seçenekler değişmedikçe önbellek tekrar kullanılır. Komut altyapısı, gereken nesne kopyasını seçimden önce ve yeni hover nesnesinde iletir.

50) [REVOLVE önizleme kapsamı](https://github.com/HakanSeven12/OpenCADStudio/pull/993): ortak canlı gövde önizlemesi, yüzey mesh'i üretmek yerine cadkernel'in yalnız tel geometri üreten API'sini kullanır. REVOLVE, SWEEP ve LOFT önizlemelerinde kenarlar ile ISOLINES kafesi korunurken fare hareketi başına gereksiz yüz üçgenlemesi kaldırılır.

51) LOFT nesne seçiminde yazılan hexadecimal handle değerleri ortak nesne-seçim işleyicisine bırakılır. Kesit, Join kenarı, kılavuz ve yol kimliklerinin bilinmeyen seçenek olarak tüketilmesi önlenir; tek satırlı komut ve script girdileri fare seçimiyle aynı üretim akışına ulaşır.

52) Bulge magnitude hata mesajı sıfır değerinin kabul edildiğini doğru belirtir; mesaj ile sayısal doğrulama aynı negatif olmayan aralığı kullanır.

53) LOFT canlı önizlemesindeki bütün sınır kenarları ve ISOLINES kafesi, aktif katman renginden bağımsız olarak uygulamanın sabit mavi rengiyle gösterilir. İkinci kesit üzerinde gezinme ve seçim sonrası kesit, kılavuz, yol, Point ve ayar önizlemeleri aynı rengi kullanır. Önizleme rengi kalıcı LOFT nesnesine aktarılmaz; sonuç nesnesinin mevcut renk davranışı korunur.

54) LOFT kesit toplama aşamasındaki görünür düğmeler Point, Join ve Mode ile; kesit seçimi sonrasındaki görünür düğmeler Guides, Path, Cross sections only, Settings ve yalnız nokta uçlarında Continuity/Bulge magnitude ile sınırlandırılır. Done düğmesinin işlevini Enter sürdürür. Gizli Mode, Undo ve Ctrl+Z komut yolları korunurken görünür istem listeleri aynı aşama düzenine uyarlanır.
