### PR TITLE
perf: stop rescanning every entity to fill the selection-filter menu

### DIFF
--- a/src/app/update/mod.rs
+++ b/src/app/update/mod.rs
@@ -3687,8 +3687,8 @@ impl OpenCADStudio {
                 let i = self.active_tab;
                 let types = self.tabs[i].scene.entity_type_names_in_layout();
                 let f = &mut self.tabs[i].scene.selection_filter;
-                for t in types {
-                    f.insert(t.to_string());
+                for t in types.iter() {
+                    f.insert(t.clone());
                 }
                 Task::none()
             }

--- a/src/app/view/mod.rs
+++ b/src/app/view/mod.rs
@@ -1948,9 +1948,8 @@ impl OpenCADStudio {
                         selection_types: tab
                             .scene
                             .entity_type_names_in_layout()
-                            .into_iter()
-                            .map(|name| name.to_string())
-                            .collect(),
+                            .as_ref()
+                            .clone(),
                         selection_filter: &tab.scene.selection_filter,
                         tooltip_hidden: self.status_menu_tooltip_hidden,
                     };

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -1715,6 +1715,11 @@ pub struct Scene {
     /// Reverse map: entity_handle → block_record_handle, built from entity_handles lists.
     /// Keyed by geometry_epoch. Eliminates the O(B) fallback scan in belongs_to_visible_block.
     entity_block_map_cache: RefCell<Option<(u64, HashMap<Handle, Handle>)>>,
+    /// Distinct entity type names present in a layout, keyed by
+    /// (geometry_epoch, layout block). The status bar asks for this on every
+    /// frame to populate the selection-filter menu, but the answer only
+    /// changes when entities are added or removed.
+    layout_type_names_cache: RefCell<Option<(u64, Handle, std::sync::Arc<Vec<String>>)>>,
     /// Reverse dependencies from layer/style/block definitions to the top-level
     /// entities whose resident wire runs actually change. Kept independent from
     /// `geometry_epoch`: a layer colour toggle can reuse the index, invalidate
@@ -1950,6 +1955,7 @@ impl Scene {
             annotation_affects_wires: std::cell::Cell::new(None),
             model_extents_cache: RefCell::new(None),
             entity_block_map_cache: RefCell::new(None),
+            layout_type_names_cache: RefCell::new(None),
             dependency_index_cache: RefCell::new(None),
             associative_hatch_source_cache: RefCell::new(None),
             block_defn_cache: RefCell::new(HashMap::default()),

--- a/src/scene/selection.rs
+++ b/src/scene/selection.rs
@@ -363,16 +363,50 @@ impl Scene {
     /// Returns the sorted set of entity-type names present in the active
     /// layout. Used to populate the Quick Select "Object type" dropdown
     /// with only the types that actually exist in the drawing.
-    pub fn entity_type_names_in_layout(&self) -> Vec<String> {
+    /// Distinct entity type names in the current layout, for the
+    /// selection-filter menu.
+    ///
+    /// The status bar rebuilds on every frame, so this used to run once per
+    /// mouse move over the canvas: a full clone of the layout's handle list
+    /// (1.16 M handles, ~9 MB, on the reproducer), then a lookup, a `String`
+    /// allocation and a `BTreeSet` insert for each one — about 107 ms of a
+    /// 110 ms frame, to produce roughly twenty names.
+    ///
+    /// The answer only changes when entities are added or removed, so it is
+    /// cached against `geometry_epoch` and the layout block. The scan itself
+    /// now borrows the handle list instead of cloning it and collects
+    /// `&str`, allocating only for the names it actually returns.
+    pub fn entity_type_names_in_layout(&self) -> std::sync::Arc<Vec<String>> {
         use crate::entities::traits::entity_type_name;
-        let mut names: std::collections::BTreeSet<String> =
-            std::collections::BTreeSet::new();
-        for h in self.current_layout_entity_handles() {
-            if let Some(e) = self.document.get_entity(h) {
-                names.insert(entity_type_name(e).to_string());
+        let block = self.current_layout_block_handle();
+        {
+            let cache = self.layout_type_names_cache.borrow();
+            if let Some((epoch, cached_block, names)) = cache.as_ref() {
+                if *epoch == self.geometry_epoch && *cached_block == block {
+                    return std::sync::Arc::clone(names);
+                }
             }
         }
-        names.into_iter().collect()
+        let mut names: std::collections::BTreeSet<&str> =
+            std::collections::BTreeSet::new();
+        if let Some(record) = self
+            .document
+            .block_records
+            .iter()
+            .find(|record| record.handle == block)
+        {
+            for &handle in &record.entity_handles {
+                if let Some(entity) = self.document.get_entity(handle) {
+                    names.insert(entity_type_name(entity));
+                }
+            }
+        }
+        let names: std::sync::Arc<Vec<String>> = std::sync::Arc::new(
+            names.into_iter().map(str::to_string).collect(),
+        );
+        *self.layout_type_names_cache.borrow_mut() =
+            Some((self.geometry_epoch, block, std::sync::Arc::clone(&names)));
+        names
     }
 
     /// True when `handle`'s entity type is allowed by the selection filter.


### PR DESCRIPTION
<p style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px 0px 16px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility; color: rgb(240, 239, 236); font-family: anthropic-sans, system-ui, &quot;Segoe UI&quot;, Roboto, Helvetica, Arial, sans-serif, ui-sans-serif, system-ui, -apple-system, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(17, 17, 17); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">On a large drawing (1.17 M entities), pan, zoom and even plain cursor movement over the canvas ran at roughly 8 fps. Movement over menus and palettes stayed smooth.</p><p style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px 0px 16px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility; color: rgb(240, 239, 236); font-family: anthropic-sans, system-ui, &quot;Segoe UI&quot;, Roboto, Helvetica, Arial, sans-serif, ui-sans-serif, system-ui, -apple-system, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(17, 17, 17); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Nothing being rendered was responsible. Measured on the slow frames:</p><div class="overflow-x-auto" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px 0px 16px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); overflow-x: auto; text-rendering: optimizelegibility; color: rgb(240, 239, 236); font-family: anthropic-sans, system-ui, &quot;Segoe UI&quot;, Roboto, Helvetica, Arial, sans-serif, ui-sans-serif, system-ui, -apple-system, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(17, 17, 17); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">
  | large drawing | small drawing
-- | -- | --
view() | 110–135 ms | 3–6 ms
Primitive::prepare | 0.45 ms | 0.2 ms
Primitive::render (encode) | 0.50 ms | —
GPU utilisation | 0–8 % | —

</div><p style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px 0px 16px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility; color: rgb(240, 239, 236); font-family: anthropic-sans, system-ui, &quot;Segoe UI&quot;, Roboto, Helvetica, Arial, sans-serif, ui-sans-serif, system-ui, -apple-system, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(17, 17, 17); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The frame was<span> </span><code data-epitaxy-inline-code="" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); font-family: anthropic-mono, ui-monospace, monospace, &quot;SF Mono&quot;, ui-monospace, Menlo, Consolas, monospace; font-feature-settings: &quot;calt&quot; 0, &quot;liga&quot; 0; font-variation-settings: normal; font-size: 12px; font-variant-ligatures: none; text-rendering: optimizelegibility; background: none 0% 0% / auto repeat scroll padding-box border-box color(srgb 1 1 1 / 0.05); color: rgb(240, 239, 236); border-radius: 4px; padding-block: 1px; padding-inline: 2px; line-height: 1.4;">view()</code>, and inside it the status bar, which builds the selection-filter menu. That menu asks for the distinct entity type names in the layout, and<span> </span><code data-epitaxy-inline-code="" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); font-family: anthropic-mono, ui-monospace, monospace, &quot;SF Mono&quot;, ui-monospace, Menlo, Consolas, monospace; font-feature-settings: &quot;calt&quot; 0, &quot;liga&quot; 0; font-variation-settings: normal; font-size: 12px; font-variant-ligatures: none; text-rendering: optimizelegibility; background: none 0% 0% / auto repeat scroll padding-box border-box color(srgb 1 1 1 / 0.05); color: rgb(240, 239, 236); border-radius: 4px; padding-block: 1px; padding-inline: 2px; line-height: 1.4;">Scene::entity_type_names_in_layout</code><span> </span>did this on every frame:</p><ol style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px 0px 16px; padding: 0px 0px 0px 20px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); list-style: decimal; text-rendering: optimizelegibility; gap: 6px; flex-direction: column; display: flex; color: rgb(240, 239, 236); font-family: anthropic-sans, system-ui, &quot;Segoe UI&quot;, Roboto, Helvetica, Arial, sans-serif, ui-sans-serif, system-ui, -apple-system, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(17, 17, 17); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility;">cloned the layout's entire handle list — 1 166 357 handles, ~9 MB;</li><li style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility;">a<span> </span><code data-epitaxy-inline-code="" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); font-family: anthropic-mono, ui-monospace, monospace, &quot;SF Mono&quot;, ui-monospace, Menlo, Consolas, monospace; font-feature-settings: &quot;calt&quot; 0, &quot;liga&quot; 0; font-variation-settings: normal; font-size: 12px; font-variant-ligatures: none; text-rendering: optimizelegibility; background: none 0% 0% / auto repeat scroll padding-box border-box color(srgb 1 1 1 / 0.05); color: rgb(240, 239, 236); border-radius: 4px; padding-block: 1px; padding-inline: 2px; line-height: 1.4;">get_entity</code><span> </span>map lookup for each;</li><li style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility;">a<span> </span><code data-epitaxy-inline-code="" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); font-family: anthropic-mono, ui-monospace, monospace, &quot;SF Mono&quot;, ui-monospace, Menlo, Consolas, monospace; font-feature-settings: &quot;calt&quot; 0, &quot;liga&quot; 0; font-variation-settings: normal; font-size: 12px; font-variant-ligatures: none; text-rendering: optimizelegibility; background: none 0% 0% / auto repeat scroll padding-box border-box color(srgb 1 1 1 / 0.05); color: rgb(240, 239, 236); border-radius: 4px; padding-block: 1px; padding-inline: 2px; line-height: 1.4;">String</code><span> </span>allocation for each;</li><li style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility;">a<span> </span><code data-epitaxy-inline-code="" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); font-family: anthropic-mono, ui-monospace, monospace, &quot;SF Mono&quot;, ui-monospace, Menlo, Consolas, monospace; font-feature-settings: &quot;calt&quot; 0, &quot;liga&quot; 0; font-variation-settings: normal; font-size: 12px; font-variant-ligatures: none; text-rendering: optimizelegibility; background: none 0% 0% / auto repeat scroll padding-box border-box color(srgb 1 1 1 / 0.05); color: rgb(240, 239, 236); border-radius: 4px; padding-block: 1px; padding-inline: 2px; line-height: 1.4;">BTreeSet&lt;String&gt;</code><span> </span>insert for each.</li></ol><p style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px 0px 16px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility; color: rgb(240, 239, 236); font-family: anthropic-sans, system-ui, &quot;Segoe UI&quot;, Roboto, Helvetica, Arial, sans-serif, ui-sans-serif, system-ui, -apple-system, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(17, 17, 17); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">About 107 ms of a 110 ms frame, to produce roughly twenty names, for a popup that is only visible when opened.</p><h2 style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px 0px 16px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); font-size: 17px; font-weight: 580; text-rendering: optimizelegibility; line-height: 22px; letter-spacing: -0.01em; color: rgb(240, 239, 236); margin-block: 24px 8px; padding-block: 0px; font-family: anthropic-sans, system-ui, &quot;Segoe UI&quot;, Roboto, Helvetica, Arial, sans-serif, ui-sans-serif, system-ui, -apple-system, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(17, 17, 17); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Change</h2><ul style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px 0px 16px; padding: 0px 0px 0px 20px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); list-style: outside; text-rendering: optimizelegibility; gap: 6px; flex-direction: column; display: flex; color: rgb(240, 239, 236); font-family: anthropic-sans, system-ui, &quot;Segoe UI&quot;, Roboto, Helvetica, Arial, sans-serif, ui-sans-serif, system-ui, -apple-system, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(17, 17, 17); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility;">Cache the result against<span> </span><code data-epitaxy-inline-code="" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); font-family: anthropic-mono, ui-monospace, monospace, &quot;SF Mono&quot;, ui-monospace, Menlo, Consolas, monospace; font-feature-settings: &quot;calt&quot; 0, &quot;liga&quot; 0; font-variation-settings: normal; font-size: 12px; font-variant-ligatures: none; text-rendering: optimizelegibility; background: none 0% 0% / auto repeat scroll padding-box border-box color(srgb 1 1 1 / 0.05); color: rgb(240, 239, 236); border-radius: 4px; padding-block: 1px; padding-inline: 2px; line-height: 1.4;">(geometry_epoch, layout block)</code>. The set only changes when entities are added or removed.</li><li style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility;">Make the scan borrow the handle list instead of cloning it, and collect<span> </span><code data-epitaxy-inline-code="" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); font-family: anthropic-mono, ui-monospace, monospace, &quot;SF Mono&quot;, ui-monospace, Menlo, Consolas, monospace; font-feature-settings: &quot;calt&quot; 0, &quot;liga&quot; 0; font-variation-settings: normal; font-size: 12px; font-variant-ligatures: none; text-rendering: optimizelegibility; background: none 0% 0% / auto repeat scroll padding-box border-box color(srgb 1 1 1 / 0.05); color: rgb(240, 239, 236); border-radius: 4px; padding-block: 1px; padding-inline: 2px; line-height: 1.4;">&amp;str</code>, allocating only for the names actually returned.</li></ul><p style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px 0px 16px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility; color: rgb(240, 239, 236); font-family: anthropic-sans, system-ui, &quot;Segoe UI&quot;, Roboto, Helvetica, Arial, sans-serif, ui-sans-serif, system-ui, -apple-system, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(17, 17, 17); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code data-epitaxy-inline-code="" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); font-family: anthropic-mono, ui-monospace, monospace, &quot;SF Mono&quot;, ui-monospace, Menlo, Consolas, monospace; font-feature-settings: &quot;calt&quot; 0, &quot;liga&quot; 0; font-variation-settings: normal; font-size: 12px; font-variant-ligatures: none; text-rendering: optimizelegibility; background: none 0% 0% / auto repeat scroll padding-box border-box color(srgb 1 1 1 / 0.05); color: rgb(240, 239, 236); border-radius: 4px; padding-block: 1px; padding-inline: 2px; line-height: 1.4;">view()</code><span> </span>drops to 3.3–6.0 ms — identical to the small drawing, so document size no longer affects interactivity at all.</p><h2 style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px 0px 16px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); font-size: 17px; font-weight: 580; text-rendering: optimizelegibility; line-height: 22px; letter-spacing: -0.01em; color: rgb(240, 239, 236); margin-block: 24px 8px; padding-block: 0px; font-family: anthropic-sans, system-ui, &quot;Segoe UI&quot;, Roboto, Helvetica, Arial, sans-serif, ui-sans-serif, system-ui, -apple-system, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(17, 17, 17); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Notes</h2><p style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px 0px 16px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility; color: rgb(240, 239, 236); font-family: anthropic-sans, system-ui, &quot;Segoe UI&quot;, Roboto, Helvetica, Arial, sans-serif, ui-sans-serif, system-ui, -apple-system, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(17, 17, 17); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">iced is immediate mode: every widget is rebuilt on every mouse move. That is fine as long as nothing in that path is O(document). It may be worth treating "anything in<span> </span><code data-epitaxy-inline-code="" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); font-family: anthropic-mono, ui-monospace, monospace, &quot;SF Mono&quot;, ui-monospace, Menlo, Consolas, monospace; font-feature-settings: &quot;calt&quot; 0, &quot;liga&quot; 0; font-variation-settings: normal; font-size: 12px; font-variant-ligatures: none; text-rendering: optimizelegibility; background: none 0% 0% / auto repeat scroll padding-box border-box color(srgb 1 1 1 / 0.05); color: rgb(240, 239, 236); border-radius: 4px; padding-block: 1px; padding-inline: 2px; line-height: 1.4;">view</code><span> </span>that touches the document must be cached against<span> </span><code data-epitaxy-inline-code="" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); font-family: anthropic-mono, ui-monospace, monospace, &quot;SF Mono&quot;, ui-monospace, Menlo, Consolas, monospace; font-feature-settings: &quot;calt&quot; 0, &quot;liga&quot; 0; font-variation-settings: normal; font-size: 12px; font-variant-ligatures: none; text-rendering: optimizelegibility; background: none 0% 0% / auto repeat scroll padding-box border-box color(srgb 1 1 1 / 0.05); color: rgb(240, 239, 236); border-radius: 4px; padding-block: 1px; padding-inline: 2px; line-height: 1.4;">geometry_epoch</code>" as a rule.</p><h2 style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px 0px 16px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); font-size: 17px; font-weight: 580; text-rendering: optimizelegibility; line-height: 22px; letter-spacing: -0.01em; color: rgb(240, 239, 236); margin-block: 24px 8px; padding-block: 0px; font-family: anthropic-sans, system-ui, &quot;Segoe UI&quot;, Roboto, Helvetica, Arial, sans-serif, ui-sans-serif, system-ui, -apple-system, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(17, 17, 17); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Verification</h2><p style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px 0px 16px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility; color: rgb(240, 239, 236); font-family: anthropic-sans, system-ui, &quot;Segoe UI&quot;, Roboto, Helvetica, Arial, sans-serif, ui-sans-serif, system-ui, -apple-system, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(17, 17, 17); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code data-epitaxy-inline-code="" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); font-family: anthropic-mono, ui-monospace, monospace, &quot;SF Mono&quot;, ui-monospace, Menlo, Consolas, monospace; font-feature-settings: &quot;calt&quot; 0, &quot;liga&quot; 0; font-variation-settings: normal; font-size: 12px; font-variant-ligatures: none; text-rendering: optimizelegibility; background: none 0% 0% / auto repeat scroll padding-box border-box color(srgb 1 1 1 / 0.05); color: rgb(240, 239, 236); border-radius: 4px; padding-block: 1px; padding-inline: 2px; line-height: 1.4;">cargo check</code><span> </span>and<span> </span><code data-epitaxy-inline-code="" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); font-family: anthropic-mono, ui-monospace, monospace, &quot;SF Mono&quot;, ui-monospace, Menlo, Consolas, monospace; font-feature-settings: &quot;calt&quot; 0, &quot;liga&quot; 0; font-variation-settings: normal; font-size: 12px; font-variant-ligatures: none; text-rendering: optimizelegibility; background: none 0% 0% / auto repeat scroll padding-box border-box color(srgb 1 1 1 / 0.05); color: rgb(240, 239, 236); border-radius: 4px; padding-block: 1px; padding-inline: 2px; line-height: 1.4;">cargo clippy</code><span> </span>clean on the touched files;<span> </span><code data-epitaxy-inline-code="" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); font-family: anthropic-mono, ui-monospace, monospace, &quot;SF Mono&quot;, ui-monospace, Menlo, Consolas, monospace; font-feature-settings: &quot;calt&quot; 0, &quot;liga&quot; 0; font-variation-settings: normal; font-size: 12px; font-variant-ligatures: none; text-rendering: optimizelegibility; background: none 0% 0% / auto repeat scroll padding-box border-box color(srgb 1 1 1 / 0.05); color: rgb(240, 239, 236); border-radius: 4px; padding-block: 1px; padding-inline: 2px; line-height: 1.4;">cargo test --lib</code><span> </span>gives 544 passed, 1 failed —<span> </span><code data-epitaxy-inline-code="" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); font-family: anthropic-mono, ui-monospace, monospace, &quot;SF Mono&quot;, ui-monospace, Menlo, Consolas, monospace; font-feature-settings: &quot;calt&quot; 0, &quot;liga&quot; 0; font-variation-settings: normal; font-size: 12px; font-variant-ligatures: none; text-rendering: optimizelegibility; background: none 0% 0% / auto repeat scroll padding-box border-box color(srgb 1 1 1 / 0.05); color: rgb(240, 239, 236); border-radius: 4px; padding-block: 1px; padding-inline: 2px; line-height: 1.4;">join_keeps_source_thickness</code>, which also fails on an unmodified<span> </span><code data-epitaxy-inline-code="" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); font-family: anthropic-mono, ui-monospace, monospace, &quot;SF Mono&quot;, ui-monospace, Menlo, Consolas, monospace; font-feature-settings: &quot;calt&quot; 0, &quot;liga&quot; 0; font-variation-settings: normal; font-size: 12px; font-variant-ligatures: none; text-rendering: optimizelegibility; background: none 0% 0% / auto repeat scroll padding-box border-box color(srgb 1 1 1 / 0.05); color: rgb(240, 239, 236); border-radius: 4px; padding-block: 1px; padding-inline: 2px; line-height: 1.4;">main</code>.</p><p style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility; color: rgb(240, 239, 236); font-family: anthropic-sans, system-ui, &quot;Segoe UI&quot;, Roboto, Helvetica, Arial, sans-serif, ui-sans-serif, system-ui, -apple-system, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(17, 17, 17); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Manually: the selection-filter popup still lists the correct types, and updates after entities are added or deleted.</p>