### PR TITLE
perf: stop discarding the loader thread's work, and cut two per-rebuild scans

### DIFF
--- a/src/app/update/file.rs
+++ b/src/app/update/file.rs
@@ -1438,6 +1438,8 @@ pub(super) fn on_open_file(&mut self) -> Task<Message> {
                 if let Some(prepared) = prepared_geometry {
                     self.tabs[i].scene.install_prepared_open_geometry(prepared);
                 }
+                // Pay for the interaction index here, not on the first hover.
+                self.tabs[i].scene.warm_interaction_caches();
                 self.tabs[i]
                     .scene
                     .replace_selection(rustc_hash::FxHashSet::default());

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -443,6 +443,14 @@ pub struct PreparedOpenGeometry {
     /// exactly the old behaviour.
     pub tess_memo: HashMap<Handle, Arc<Vec<WireModel>>>,
     pub tess_guard: u64,
+    /// Block definitions the loader thread built while tessellating, keyed as
+    /// `block_defn_cache` keys them but without an epoch — the receiving scene
+    /// stamps its own.
+    ///
+    /// Dropped with the throwaway scene before, which is why the first edit
+    /// spent 1147 ms rebuilding definitions the loader had just built from the
+    /// same, unmodified document.
+    pub block_defns: Vec<(u64, Arc<cache::block_cache::BlockCache>)>,
 }
 
 impl std::fmt::Debug for PreparedOpenGeometry {
@@ -451,6 +459,7 @@ impl std::fmt::Debug for PreparedOpenGeometry {
             .field("wires", &self.wires.len())
             .field("interaction_index", &self.interaction_index.is_some())
             .field("tess_memo", &self.tess_memo.len())
+            .field("block_defns", &self.block_defns.len())
             .finish()
     }
 }
@@ -1031,6 +1040,11 @@ pub fn prepare_open_geometry(
     // Taken, not cloned: the scene is discarded on the next line.
     let tess_memo = std::mem::take(&mut *scene.resident_tess_memo.borrow_mut());
     let tess_guard = scene.resident_tess_guard.get();
+    let block_defns: Vec<(u64, Arc<cache::block_cache::BlockCache>)> =
+        std::mem::take(&mut *scene.block_defn_cache.borrow_mut())
+            .into_iter()
+            .map(|(key, (_epoch, cache))| (key, cache))
+            .collect();
     let doc = std::mem::replace(&mut scene.document, CadDocument::new());
     (
         doc,
@@ -1039,6 +1053,7 @@ pub fn prepare_open_geometry(
             interaction_index,
             tess_memo,
             tess_guard,
+            block_defns,
         },
     )
 }
@@ -2228,6 +2243,16 @@ impl Scene {
         if !prepared.tess_memo.is_empty() {
             *self.resident_tess_memo.borrow_mut() = prepared.tess_memo;
             self.resident_tess_guard.set(prepared.tess_guard);
+        }
+        // Same for the block definitions, stamped with this scene's block
+        // epoch: the document has not been touched between the loader
+        // finishing and this call, so they describe it exactly.
+        if !prepared.block_defns.is_empty() {
+            let epoch = self.block_epoch;
+            let mut cache = self.block_defn_cache.borrow_mut();
+            for (key, defns) in prepared.block_defns {
+                cache.insert(key, (epoch, defns));
+            }
         }
         if let Some(index) = prepared.interaction_index {
             self.cache_interaction_index(self.geometry_epoch, prepared.wires, index);

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -9066,7 +9066,12 @@ impl Scene {
             if let Some((_, ref idx)) = *cache {
                 if let Some(sort_map) = idx.get(&block_handle) {
                     sorted = true;
-                    wires.sort_by_key(|w| {
+                    // `sort_by_cached_key`, not `sort_by_key`: the key parses
+                    // the wire's name out of a `String`, and `sort_by_key` calls
+                    // it O(n log n) times. On the resident set that is ~198 k
+                    // wires parsed eighteen times over — 295 ms on every rebuild,
+                    // including rebuilds where nothing was re-tessellated.
+                    wires.sort_by_cached_key(|w| {
                         let key = Self::handle_from_wire_name(&w.name)
                             .map(|h| h.value())
                             .unwrap_or(u64::MAX);

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -432,6 +432,17 @@ struct ResidentWireLayout {
 pub struct PreparedOpenGeometry {
     pub wires: Arc<Vec<WireModel>>,
     pub interaction_index: Option<Arc<crate::scene::pick::interaction_index::InteractionIndex>>,
+    /// The per-entity tessellation memo the loader thread filled while building
+    /// `wires`, with the guard hash it was valid under.
+    ///
+    /// `prepare_open_geometry` works on a throwaway `Scene`, so this used to be
+    /// dropped with it and the first geometry edit re-tessellated all 186 455
+    /// entities from cold — 1.3 s of work the loader had already done. The
+    /// guard travels with it because the memo is only usable under the state it
+    /// was built for; a mismatch on the receiving side clears it, which is
+    /// exactly the old behaviour.
+    pub tess_memo: HashMap<Handle, Arc<Vec<WireModel>>>,
+    pub tess_guard: u64,
 }
 
 impl std::fmt::Debug for PreparedOpenGeometry {
@@ -439,6 +450,7 @@ impl std::fmt::Debug for PreparedOpenGeometry {
         f.debug_struct("PreparedOpenGeometry")
             .field("wires", &self.wires.len())
             .field("interaction_index", &self.interaction_index.is_some())
+            .field("tess_memo", &self.tess_memo.len())
             .finish()
     }
 }
@@ -1016,12 +1028,17 @@ pub fn prepare_open_geometry(
             wires.len(),
         );
     }
+    // Taken, not cloned: the scene is discarded on the next line.
+    let tess_memo = std::mem::take(&mut *scene.resident_tess_memo.borrow_mut());
+    let tess_guard = scene.resident_tess_guard.get();
     let doc = std::mem::replace(&mut scene.document, CadDocument::new());
     (
         doc,
         PreparedOpenGeometry {
             wires,
             interaction_index,
+            tess_memo,
+            tess_guard,
         },
     )
 }
@@ -2206,6 +2223,12 @@ impl Scene {
                 layout: None,
             },
         );
+        // Adopt the loader thread's tessellation memo so the first edit patches
+        // the entities it touched instead of rebuilding every one of them.
+        if !prepared.tess_memo.is_empty() {
+            *self.resident_tess_memo.borrow_mut() = prepared.tess_memo;
+            self.resident_tess_guard.set(prepared.tess_guard);
+        }
         if let Some(index) = prepared.interaction_index {
             self.cache_interaction_index(self.geometry_epoch, prepared.wires, index);
         }

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -7912,6 +7912,11 @@ impl Scene {
     /// already waiting. A second on an open that is already seconds long reads
     /// very differently from a second-long freeze on a mouse move.
     pub(crate) fn warm_interaction_caches(&self) {
+        // Both indexes on the hover path, not just one. The handle index alone
+        // left `hover-detail ... handles=384.6` on the first hover: the same
+        // stage also builds the entity quadtree, which is keyed on
+        // `geometry_epoch` and equally cold at that point.
+        let _ = self.entity_index();
         let _ = self.interaction_handle_index();
     }
 

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -7874,6 +7874,22 @@ impl Scene {
         }
     }
 
+    /// Build the interaction handle index and the insert-hatch map now, while
+    /// the drawing is still opening.
+    ///
+    /// Both are built lazily on first use, and first use is the user's first
+    /// hover over the canvas — where the cold build cost 992 ms mid-gesture
+    /// (`hover-detail ... handles=986.1`). They cannot move to the loader
+    /// thread: they read `hatches` / `meshes` / `block_meshes`, which are
+    /// installed on the real `Scene` after the loader is done.
+    ///
+    /// This does not make the work cheaper, it moves it to where the user is
+    /// already waiting. A second on an open that is already seconds long reads
+    /// very differently from a second-long freeze on a mouse move.
+    pub(crate) fn warm_interaction_caches(&self) {
+        let _ = self.interaction_handle_index();
+    }
+
     fn interaction_handle_index(
         &self,
     ) -> Arc<crate::scene::pick::interaction_index::InteractionHandleIndex> {


### PR DESCRIPTION
Five independent costs on the open and first-edit path, found by timing the
stages rather than by inspection. All measured on a 1.17 M-entity drawing
(197 996 wires).

## The loader thread's caches were thrown away

`prepare_open_geometry` builds the first Model wire set on a throwaway `Scene`.
That scene fills two caches — the per-entity tessellation memo, one entry for
each of 186 455 entities, and the block definition cache — and both went to the
grave with it. `install_prepared_open_geometry` transferred the wire set and the
interaction index but neither cache.

So the first geometry edit rebuilt from cold:

```
[perf] wires-build total=2723.3ms memo_hit=0 memo_miss=186455 blk_cache=1147.2
```

against 487 ms once both are warm. `PreparedOpenGeometry` now carries them,
moved rather than cloned since the scene is dropped immediately afterwards.

The memo's guard hash travels with it: the memo is only usable under the state
it was built for, and a mismatch on the receiving side clears it, which is what
happened unconditionally before. The block definitions are stamped with the
receiving scene's `block_epoch`, which is sound because the document is not
touched between the loader finishing and that call.

**First edit: 2723 ms → 487 ms.**

## Draw order parsed each wire name eighteen times

The resident wire sort keys on the entity handle parsed out of each wire's name
`String`. `sort_by_key` evaluates that key on every comparison, so a
198 k-wire set parsed every name roughly eighteen times over — 295 ms on every
rebuild of the resident set, including rebuilds that re-tessellated nothing.

`sort_by_cached_key` evaluates it once per element and is stable in the same
way, so draw order is unchanged. **295 ms → 36 ms.**

## The first hover froze for a second

```
[perf] hover-detail query=0.1 handles=986.1 ... candidates=253
```

`interaction_handle_index` and the entity quadtree it reaches for are both
built lazily, and first use is the user's first hover over the canvas. Neither
can move to the loader thread: they read `hatches`, `meshes` and `block_meshes`,
which are installed on the real `Scene` only after the loader has finished.

They are now built at the end of the open instead. This does not make the work
cheaper — it moves it to where the user is already waiting. A second inside an
operation that is already seconds long reads very differently from a
second-long freeze on a mouse move.

## Measured

| | before | after |
|---|---:|---:|
| first edit after open | 2723 ms | 487 ms |
| resident sort, every rebuild | 295 ms | 36 ms |
| block cache on first edit | 1147 ms | 0 ms |
| first hover | 992 ms | ~0 ms |

## Verification

`cargo check` and `cargo clippy` clean; `cargo test --lib` 583 passed,
0 failed.