### PR TITLE
Avoid redundant layout grid and extent work

### DIFF
--- a/src/app/view/mod.rs
+++ b/src/app/view/mod.rs
@@ -382,9 +382,15 @@ impl OpenCADStudio {
                 );
                 (o, (ux.as_vec3(), uy.as_vec3(), uz.as_vec3()))
             };
-            let grid: Vec<crate::ui::overlay::GridParams> = tab
-                .scene
-                .grid_views(vw, vh)
+            // The first paper frame spends seconds in this block and `grid`
+            // alone cannot say which part. Reported only when it costs
+            // something, so ordinary frames stay quiet.
+            let t_grid = crate::perf::enabled().then(iced::time::Instant::now);
+            let views = tab.scene.grid_views(vw, vh);
+            let views_ms = crate::perf::elapsed_ms(t_grid);
+            let view_count = views.len();
+            let t_params = crate::perf::enabled().then(iced::time::Instant::now);
+            let grid: Vec<crate::ui::overlay::GridParams> = views
                 .into_iter()
                 .map(|(bounds, cam, handle)| {
                     let (origin, mut axes): (glam::DVec3, _) = if is_paper {
@@ -428,7 +434,16 @@ impl OpenCADStudio {
                     }
                 })
                 .collect();
+            let params_ms = crate::perf::elapsed_ms(t_params);
+            let t_bg = crate::perf::enabled().then(iced::time::Instant::now);
             let bg = crosshair_background(tab, is_paper);
+            let bg_ms = crate::perf::elapsed_ms(t_bg);
+            if views_ms + params_ms + bg_ms >= 1.0 {
+                crate::perf_record!(
+                    "[perf] grid-detail views={views_ms:.1}ms params={params_ms:.1}ms \
+bg={bg_ms:.1}ms n={view_count}"
+                );
+            }
             let bg_lum = 0.299 * bg[0] + 0.587 * bg[1] + 0.114 * bg[2];
             let grid_style = crate::ui::overlay::GridStyle {
                 opacity: self.model_space.grid_opacity,

--- a/src/app/view/mod.rs
+++ b/src/app/view/mod.rs
@@ -197,6 +197,20 @@ impl OpenCADStudio {
     /// `view` so the single-window web build can render it directly, bypassing
     /// the multi-window id dispatch above (the web build has no extra windows).
     pub fn view_main(&self) -> Element<'_, Message> {
+        // Section marks for `view-detail`. A closure over a RefCell rather
+        // than one binding per section: two of these sections sit inside a
+        // nested block and would otherwise be out of scope at the report.
+        let view_t0 = crate::perf::enabled().then(iced::time::Instant::now);
+        let view_marks: std::cell::RefCell<Vec<(&'static str, f64)>> =
+            std::cell::RefCell::new(Vec::with_capacity(8));
+        let mark = |name: &'static str| {
+            if let Some(t0) = view_t0 {
+                view_marks
+                    .borrow_mut()
+                    .push((name, t0.elapsed().as_secs_f64() * 1000.0));
+            }
+        };
+
         let i = self.active_tab;
         let tab = &self.tabs[i];
         let thumbnail_capture_clean = self.thumbnail_capture_clean;
@@ -257,6 +271,7 @@ impl OpenCADStudio {
         // the same shader as model space: a full-canvas top-locked "sheet"
         // viewport draws the layout's own geometry (white sheet + entities +
         // borders) and the floating content viewports blit on top.
+        mark("viewport_3d");
         let viewport_3d: Element<'_, Message> = if tab.is_start {
             start_page_view(
                 &self.patrons,
@@ -334,6 +349,7 @@ impl OpenCADStudio {
         // the shader pane_grid (same `model_panes` → identical layout). Layered
         // above the crosshair overlay so it actually receives mouse events, and
         // it owns the divider resize. Only built for the Model layout.
+        mark("model_input");
         let model_input_layer: Option<Element<'_, Message>> = if is_paper || tab.is_start {
             None
         } else {
@@ -351,6 +367,7 @@ impl OpenCADStudio {
             )
         };
 
+        mark("grid");
         let grid_overlay = {
             let (vw, vh) = tab.scene.selection.borrow().vp_size;
             let model_basis = {
@@ -420,6 +437,7 @@ impl OpenCADStudio {
             crate::ui::overlay::grid_overlay(grid, grid_style)
         };
 
+        mark("selection_overlay");
         let selection_overlay = {
             // Hold a single `Ref<'_, SelectionState>` for the whole overlay
             // block. The `vp_size` and `last_move_pos` reads below become
@@ -790,6 +808,7 @@ impl OpenCADStudio {
             )
         };
 
+        mark("viewport_mouse");
         let viewport_mouse = mouse_area(container(
             iced::widget::Space::new().width(Fill).height(Fill),
         ))
@@ -935,6 +954,7 @@ impl OpenCADStudio {
                 None
             };
 
+        mark("viewport_stack");
         let mut viewport_stack = if tab.is_start {
             // Start tab: only the welcome widget over a flat background.
             // Skip every drawing-only overlay (selection markers, snap info,
@@ -1053,6 +1073,7 @@ impl OpenCADStudio {
         // both layered ABOVE the viewport mouse_area so they receive
         // clicks (the shader viewport sits below it). Positioned with
         // leading Spaces sized to the viewport's screen rectangle.
+        mark("active_vp_rect");
         let active_vp_rect: Option<(acadrust::Handle, iced::Rectangle)> =
             if is_paper && !tab.is_start {
                 tab.scene.active_viewport.and_then(|h| {
@@ -1383,6 +1404,7 @@ impl OpenCADStudio {
         }
 
         // Reserve the overlaid command line when placing cursor-anchored panels.
+        mark("chrome");
         let command_line_inset = if self.command_line.history_open {
             self.command_line.history_height.clamp(
                 crate::ui::command_line::HISTORY_HEIGHT_MIN,
@@ -2102,6 +2124,34 @@ impl OpenCADStudio {
         };
         // Shared CAD colour picker. Indexed ACI colours use OpenCADStudio's own
         // dialog; True Color keeps the existing iced_aw gradient picker.
+        // Which part of the widget tree the frame went into. Reported as a
+        // breakdown rather than one number, because a first switch to a paper
+        // layout spends seconds here and `view` alone cannot say where.
+        if let Some(t0) = view_t0 {
+            mark("end");
+            let total = t0.elapsed().as_secs_f64() * 1000.0;
+            if total >= 1.0 {
+                let marks = view_marks.borrow();
+                // A mark opens a section; the following mark closes it, so a
+                // section's cost is the gap to its successor. The first mark
+                // is preceded by the preamble, reported as `head`.
+                let mut detail = String::new();
+                if let Some((_, first)) = marks.first() {
+                    let _ = std::fmt::Write::write_fmt(
+                        &mut detail,
+                        format_args!(" head={first:.1}"),
+                    );
+                }
+                for pair in marks.windows(2) {
+                    let _ = std::fmt::Write::write_fmt(
+                        &mut detail,
+                        format_args!(" {}={:.1}", pair[0].0, pair[1].1 - pair[0].1),
+                    );
+                }
+                crate::perf_record!("[perf] view-detail total={total:.1}ms{detail}");
+            }
+        }
+
         if let Some((_, current)) = self.color_pick_target.as_ref() {
             match self.color_picker_tab {
                 super::ColorPickerTab::Index => {

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -1495,6 +1495,9 @@ pub enum ViewportRefreshScope {
     All,
 }
 
+/// `(geometry_epoch, entities per block, entities no block claims)`.
+type BlockMembers = (u64, HashMap<Handle, Vec<Handle>>, Vec<Handle>);
+
 pub struct Scene {
     pub camera: Rc<RefCell<Camera>>,
     /// View saved immediately before the latest navigation operation. ZOOM
@@ -1833,6 +1836,18 @@ pub struct Scene {
     /// Reverse map: entity_handle → block_record_handle, built from entity_handles lists.
     /// Keyed by geometry_epoch. Eliminates the O(B) fallback scan in belongs_to_visible_block.
     entity_block_map_cache: RefCell<Option<(u64, HashMap<Handle, Handle>)>>,
+    /// Candidate entities per block, keyed by `geometry_epoch`.
+    ///
+    /// Selecting a block's contents used to walk every entity in the document
+    /// and ask `belongs_to_visible_block` about each: 313 ms of a 334 ms
+    /// resident build for a paper sheet holding 43 entities, on a drawing with
+    /// 1.17 M. The membership rules only depend on owner handles and the block
+    /// records, so one pass answers them for every block at once.
+    ///
+    /// The second field holds entities no block claims, which
+    /// `belongs_to_visible_block` treats as belonging to everything — but only
+    /// when no block record enumerates its contents at all.
+    block_members_cache: RefCell<Option<BlockMembers>>,
     /// Distinct entity type names present in a layout, keyed by
     /// (geometry_epoch, layout block). The status bar asks for this on every
     /// frame to populate the selection-filter menu, but the answer only
@@ -2077,6 +2092,7 @@ impl Scene {
             annotation_affects_wires: std::cell::Cell::new(None),
             model_extents_cache: RefCell::new(None),
             entity_block_map_cache: RefCell::new(None),
+            block_members_cache: RefCell::new(None),
             layout_type_names_cache: RefCell::new(None),
             dependency_index_cache: RefCell::new(None),
             associative_hatch_source_cache: RefCell::new(None),
@@ -8929,11 +8945,36 @@ impl Scene {
                 }
             }
             out
-        } else {
+        } else if block_handle.is_null() || self.entity_block_map().is_empty() {
+            // Either every entity qualifies, or the drawing declares no block
+            // contents anywhere and `belongs_to_visible_block` turns permissive
+            // — the legacy-DXF case. Both need the full walk, and both must
+            // keep document order, which is draw order for the wire pass.
             self.document
                 .entities()
                 .filter(|e| visibility_ok(e))
                 .collect()
+        } else {
+            // Ask the per-epoch membership index for this block's candidates
+            // instead of testing every entity in the document. For a paper
+            // sheet holding 43 entities in a 1.17 M-entity drawing that is the
+            // difference between 313 ms and nothing measurable.
+            //
+            // The index is filled by walking `document.entities()`, so each
+            // block's list is already in document order and the wires come out
+            // in exactly the order the full scan produced.
+            let members = self.block_members();
+            let (_, by_block, _) = &*members;
+            let claimed = by_block.get(&block_handle).map(Vec::as_slice).unwrap_or(&[]);
+            let mut out: Vec<&EntityType> = Vec::with_capacity(claimed.len());
+            for &handle in claimed {
+                if let Some(entity) = self.document.get_entity(handle) {
+                    if visibility_ok(entity) {
+                        out.push(entity);
+                    }
+                }
+            }
+            out
         };
 
         let visible_ms = crate::perf::elapsed_ms(t_visible);
@@ -9182,6 +9223,48 @@ entities={} memo_hit={} memo_miss={} wires={} memo={}",
     }
 
     /// Decide whether an entity should be drawn as direct content of `block_handle`.
+    /// Entities each block may contain, and the ones no block claims.
+    ///
+    /// Mirrors `belongs_to_visible_block` exactly, resolved once per
+    /// `geometry_epoch` for every block instead of per entity per query:
+    ///
+    ///   * a non-null owner *is* the block, so the entity is that block's;
+    ///   * a null owner falls back to the reverse map built from the block
+    ///     records' `entity_handles`;
+    ///   * an entity neither names nor is named by any block is "unowned", and
+    ///     counts towards every block only when no block record enumerates its
+    ///     contents at all — the legacy-DXF case that predicate allows.
+    fn block_members(&self) -> std::cell::Ref<'_, BlockMembers> {
+        {
+            let cache = self.block_members_cache.borrow();
+            if cache.as_ref().is_some_and(|(epoch, _, _)| *epoch == self.geometry_epoch) {
+                drop(cache);
+                return std::cell::Ref::map(self.block_members_cache.borrow(), |c| {
+                    c.as_ref().unwrap()
+                });
+            }
+        }
+        let mut members: HashMap<Handle, Vec<Handle>> = HashMap::default();
+        let mut unowned: Vec<Handle> = Vec::new();
+        {
+            let map = self.entity_block_map();
+            for entity in self.document.entities() {
+                let common = entity.common();
+                let owner = common.owner_handle;
+                if !owner.is_null() {
+                    members.entry(owner).or_default().push(common.handle);
+                } else if let Some(&block) = map.get(&common.handle) {
+                    members.entry(block).or_default().push(common.handle);
+                } else {
+                    unowned.push(common.handle);
+                }
+            }
+        }
+        *self.block_members_cache.borrow_mut() =
+            Some((self.geometry_epoch, members, unowned));
+        std::cell::Ref::map(self.block_members_cache.borrow(), |c| c.as_ref().unwrap())
+    }
+
     fn belongs_to_visible_block(
         &self,
         entity_handle: Handle,
@@ -10397,6 +10480,58 @@ mod journal_tests {
 
     // Differential oracle: the incrementally-patched entity index must always
     // equal a from-scratch rebuild after any add / move / erase.
+    #[test]
+    fn block_member_index_matches_the_full_scan() {
+        use acadrust::entities::Line;
+        use acadrust::types::Vector3;
+
+        fn line(a: (f64, f64), b: (f64, f64)) -> EntityType {
+            EntityType::Line(Line::from_points(
+                Vector3::new(a.0, a.1, 0.0),
+                Vector3::new(b.0, b.1, 0.0),
+            ))
+        }
+
+        // What the membership index reports for `block`, in order.
+        fn indexed(s: &Scene, block: Handle) -> Vec<Handle> {
+            let members = s.block_members();
+            let (_, by_block, _) = &*members;
+            by_block.get(&block).cloned().unwrap_or_default()
+        }
+
+        // What testing every entity the old way reports, in document order.
+        fn scanned(s: &Scene, block: Handle) -> Vec<Handle> {
+            s.document
+                .entities()
+                .filter(|entity| {
+                    let common = entity.common();
+                    s.belongs_to_visible_block(common.handle, common.owner_handle, block)
+                })
+                .map(|entity| entity.common().handle)
+                .collect()
+        }
+
+        let mut s = Scene::new();
+        let block = s.model_space_block_handle();
+        let h1 = s.add_entity(line((0.0, 0.0), (10.0, 10.0)));
+        let h2 = s.add_entity(line((5.0, 5.0), (20.0, 3.0)));
+        let _ = (h1, h2);
+
+        // Order matters: it is the wire pass's draw order.
+        assert_eq!(indexed(&s, block), scanned(&s, block), "after adds");
+
+        let h3 = s.add_entity(line((100.0, 100.0), (140.0, 90.0)));
+        assert_eq!(indexed(&s, block), scanned(&s, block), "after another add");
+
+        // A modify must not reorder the block's contents either.
+        {
+            let mut moved = line((900.0, 900.0), (950.0, 970.0));
+            moved.common_mut().handle = h3;
+            s.update_entity(moved);
+        }
+        assert_eq!(indexed(&s, block), scanned(&s, block), "after modify");
+    }
+
     #[test]
     fn entity_index_incremental_matches_full_rebuild() {
         use acadrust::entities::Line;

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -8901,6 +8901,9 @@ impl Scene {
 
         let sort_cache_ms = crate::perf::elapsed_ms(t_fn);
         let t_visible = perf.then(iced::time::Instant::now);
+        // Which path the selection took, and how many candidates it looked at.
+        let mut visible_path = "quadtree";
+        let mut visible_candidates = 0usize;
 
         // Phase 2.1 — quadtree-driven candidate selection. When a view
         // AABB exists (Model layout with a settled camera), only iterate
@@ -9200,7 +9203,7 @@ impl Scene {
             crate::perf_record!(
                 "[perf] wires-build total={:.1}ms sort_cache={:.1} visible={:.1} blk_cache={:.1} \
 build={:.1} [classify={:.1} hits={:.1} tess={:.1} materialize={:.1}] sort={:.1}({}) \
-entities={} memo_hit={} memo_miss={} wires={} memo={}",
+entities={} memo_hit={} memo_miss={} wires={} memo={} visible_path={} candidates={}",
                 crate::perf::elapsed_ms(t_fn),
                 sort_cache_ms,
                 visible_ms,
@@ -9217,6 +9220,8 @@ entities={} memo_hit={} memo_miss={} wires={} memo={}",
                 memo_misses,
                 wires.len(),
                 if memo_active { "on" } else { "off" },
+                visible_path,
+                visible_candidates,
             );
         }
         wires

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -8910,7 +8910,10 @@ impl Scene {
         let sort_cache_ms = crate::perf::elapsed_ms(t_fn);
         let t_visible = perf.then(iced::time::Instant::now);
         // Which path the selection took, and how many candidates it looked at.
-        let mut visible_path = "quadtree+index";
+        // Left uninitialised on purpose: every branch below must set it, and
+        // the compiler enforces that. A default here is what made the first
+        // version of this diagnostic report a constant.
+        let visible_path: &str;
         let mut visible_candidates = 0usize;
 
         // Phase 2.1 — quadtree-driven candidate selection. When a view
@@ -8920,6 +8923,7 @@ impl Scene {
         // Paper space and the first-frame "settle" path fall back to the
         // full doc scan — preserving prior behaviour.
         let visible: Vec<&EntityType> = if let Some(local_view) = view_aabb {
+            visible_path = "quadtree";
             let view_wcs: [f64; 4] = [
                 local_view[0] as f64,
                 local_view[1] as f64,
@@ -8932,6 +8936,7 @@ impl Scene {
             };
             let mut out: Vec<&EntityType> =
                 Vec::with_capacity(candidates.len() + unbounded.len() + 16);
+            visible_candidates = candidates.len() + unbounded.len();
             for h in candidates {
                 if let Some(e) = self.document.get_entity(h) {
                     if visibility_ok(e) {
@@ -8955,7 +8960,7 @@ impl Scene {
             // way.
             {
                 let unindexable = self.unindexable_handles();
-                visible_candidates = unindexable.1.len();
+                visible_candidates += unindexable.1.len();
                 for &h in &unindexable.1 {
                     if let Some(e) = self.document.get_entity(h) {
                         if visibility_ok(e) {
@@ -8970,6 +8975,7 @@ impl Scene {
             // contents anywhere and `belongs_to_visible_block` turns permissive
             // — the legacy-DXF case. Both need the full walk, and both must
             // keep document order, which is draw order for the wire pass.
+            visible_path = "full-scan";
             self.document
                 .entities()
                 .filter(|e| visibility_ok(e))
@@ -8983,9 +8989,11 @@ impl Scene {
             // The index is filled by walking `document.entities()`, so each
             // block's list is already in document order and the wires come out
             // in exactly the order the full scan produced.
+            visible_path = "block-index";
             let members = self.block_members();
             let (_, by_block, _) = &*members;
             let claimed = by_block.get(&block_handle).map(Vec::as_slice).unwrap_or(&[]);
+            visible_candidates = claimed.len();
             let mut out: Vec<&EntityType> = Vec::with_capacity(claimed.len());
             for &handle in claimed {
                 if let Some(entity) = self.document.get_entity(handle) {

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -10014,20 +10014,31 @@ entities={} memo_hit={} memo_miss={} wires={} memo={} visible_path={} candidates
     }
 
     /// Full tessellation pipeline for one entity.
-    fn tessellate_one(&self, e: &EntityType) -> Vec<WireModel> {
-        let bg = if self.current_layout == "Model" {
+    /// The document-wide inputs `tessellate_entity` takes, resolved from the
+    /// current layout and viewport.
+    ///
+    /// Every entity in a walk gets the same four, and resolving them per entity
+    /// is not free — `block_cache_arc_for` takes a `RefCell` borrow and a cache
+    /// lookup. Callers that tessellate more than one entity resolve them once
+    /// and pass them down; sharing the resolution keeps those callers from
+    /// drifting away from `tessellate_one`.
+    fn tessellation_context(
+        &self,
+    ) -> ([f32; 4], f32, Option<Handle>, Arc<cache::block_cache::BlockCache>, bool) {
+        let is_model = self.current_layout == "Model";
+        let bg = if is_model {
             self.bg_color
         } else {
             self.paper_bg_color
         };
-        let anno = if self.current_layout == "Model" {
+        let anno = if is_model {
             self.annotation_scale
         } else if let Some(viewport) = self.active_viewport {
             self.viewport_annotation_multiplier(viewport)
         } else {
             1.0
         };
-        let annotation_scale_handle = if self.current_layout == "Model" {
+        let annotation_scale_handle = if is_model {
             crate::scene::annotative::scale_handle_by_name(
                 &self.document,
                 &self.document.header.current_annotation_scale,
@@ -10042,6 +10053,12 @@ entities={} memo_hit={} memo_miss={} wires={} memo={} visible_path={} candidates
             self.annotation_all_visible(),
             self.active_viewport,
         );
+        (bg, anno, annotation_scale_handle, blk_cache, !is_model)
+    }
+
+    fn tessellate_one(&self, e: &EntityType) -> Vec<WireModel> {
+        let (bg, anno, annotation_scale_handle, blk_cache, paper) =
+            self.tessellation_context();
         // tessellate_one is used for one-off lookups (hit test, properties).
         // Skip culling here so the caller always gets the full geometry.
         tessellate_entity(
@@ -10055,7 +10072,7 @@ entities={} memo_hit={} memo_miss={} wires={} memo={} visible_path={} candidates
             Some(&blk_cache),
             None,
             None,
-            self.current_layout != "Model",
+            paper,
         )
     }
 
@@ -10240,27 +10257,80 @@ entities={} memo_hit={} memo_miss={} wires={} memo={} visible_path={} candidates
         // offset-rel coords there silently double-subtracts world_offset
         // inside `camera_for_viewport` and points the viewport at the
         // wrong location on UTM-scale drawings.
-        for entity in self.document.entities() {
-            let c = entity.common();
-            if c.owner_handle != model_block
-                || c.invisible
-                || self.entity_temporarily_hidden(c.handle)
-            {
-                continue;
-            }
-            for wire in self.tessellate_one(entity) {
-                for &[x, y, z] in &wire.key_vertices {
-                    let v = glam::Vec3::new(x as f32, y as f32, z as f32);
-                    // Check finiteness *after* the f32 cast: a ray/xline endpoint
-                    // is a huge-but-finite f64 that overflows to inf in f32, which
-                    // the f64 `is_finite` test would have let through.
-                    if v.is_finite() {
-                        min = min.min(v);
-                        max = max.max(v);
-                        any = true;
+        //
+        // `tessellate_one` resolves the background, annotation scale and block
+        // cache from `&self` on every call, and this walk calls it once per
+        // model entity — 186 k times on a large drawing, each one taking a
+        // `RefCell` borrow for a block cache that is the same every time. Those
+        // inputs do not vary across the loop, so they are resolved once and the
+        // shared tessellator is called directly, which also lets the walk run
+        // in parallel the way the wire builder's own tessellation pass does.
+        // Same arguments, same output: only who computes them changed.
+        let (bg_for_tess, anno_for_tess, anno_handle_for_tess, blk_for_tess, paper_for_tess) =
+            self.tessellation_context();
+        let subjects: Vec<&EntityType> = self
+            .document
+            .entities()
+            .filter(|entity| {
+                let c = entity.common();
+                c.owner_handle == model_block
+                    && !c.invisible
+                    && !self.entity_temporarily_hidden(c.handle)
+            })
+            .collect();
+        let doc = &self.document;
+        let sel = &self.selected;
+        let avp = self.active_viewport;
+        let blk_ref: &cache::block_cache::BlockCache = &blk_for_tess;
+        use rayon::iter::{IntoParallelIterator, ParallelIterator};
+        let reduced = subjects
+            .into_par_iter()
+            .map(|entity| {
+                let mut lo = glam::Vec3::splat(f32::INFINITY);
+                let mut hi = glam::Vec3::splat(f32::NEG_INFINITY);
+                let mut hit = false;
+                for wire in tessellate_entity(
+                    doc,
+                    sel,
+                    avp,
+                    bg_for_tess,
+                    anno_for_tess,
+                    anno_handle_for_tess,
+                    entity,
+                    Some(blk_ref),
+                    None,
+                    None,
+                    paper_for_tess,
+                ) {
+                    for &[x, y, z] in &wire.key_vertices {
+                        let v = glam::Vec3::new(x as f32, y as f32, z as f32);
+                        // Check finiteness *after* the f32 cast: a ray/xline
+                        // endpoint is a huge-but-finite f64 that overflows to
+                        // inf in f32, which the f64 `is_finite` test would have
+                        // let through.
+                        if v.is_finite() {
+                            lo = lo.min(v);
+                            hi = hi.max(v);
+                            hit = true;
+                        }
                     }
                 }
-            }
+                (lo, hi, hit)
+            })
+            .reduce(
+                || {
+                    (
+                        glam::Vec3::splat(f32::INFINITY),
+                        glam::Vec3::splat(f32::NEG_INFINITY),
+                        false,
+                    )
+                },
+                |a, b| (a.0.min(b.0), a.1.max(b.1), a.2 || b.2),
+            );
+        if reduced.2 {
+            min = min.min(reduced.0);
+            max = max.max(reduced.1);
+            any = true;
         }
         // Same mesh inclusion for the tessellate fallback path.
         for (&handle, set) in &self.meshes {

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -9080,6 +9080,11 @@ impl Scene {
         let mut materialize_ms = 0.0f64;
         let mut memo_hits = 0usize;
         let memo_misses;
+        // Two consecutive identical resident builds both missed every entry,
+        // which a stable guard cannot explain — the memo is being cleared
+        // between them. Report the guard and the inputs that can move it.
+        let mut guard_dbg = 0u64;
+        let mut guard_was_stale = false;
         let t_build = perf.then(iced::time::Instant::now);
         let mut wires: Vec<WireModel> = if memo_active {
             // Guard hash of everything tessellate_entity output depends on
@@ -9114,7 +9119,9 @@ impl Scene {
             } else {
                 (&self.tess_memo, &self.tess_memo_guard)
             };
-            if guard_cell.get() != guard {
+            guard_dbg = guard;
+            guard_was_stale = guard_cell.get() != guard;
+            if guard_was_stale {
                 memo_cell.borrow_mut().clear();
                 guard_cell.set(guard);
             }
@@ -9228,7 +9235,8 @@ impl Scene {
             crate::perf_record!(
                 "[perf] wires-build total={:.1}ms sort_cache={:.1} visible={:.1} blk_cache={:.1} \
 build={:.1} [classify={:.1} hits={:.1} tess={:.1} materialize={:.1}] sort={:.1}({}) \
-entities={} memo_hit={} memo_miss={} wires={} memo={} visible_path={} candidates={}",
+entities={} memo_hit={} memo_miss={} wires={} memo={} visible_path={} candidates={} \
+guard={:016x} guard_stale={} avp={} anno={:.4} anno_h={} all_vis={} sdf_gen={}",
                 crate::perf::elapsed_ms(t_fn),
                 sort_cache_ms,
                 visible_ms,
@@ -9247,6 +9255,13 @@ entities={} memo_hit={} memo_miss={} wires={} memo={} visible_path={} candidates
                 if memo_active { "on" } else { "off" },
                 visible_path,
                 visible_candidates,
+                guard_dbg,
+                guard_was_stale,
+                avp.map(|h| h.value()).unwrap_or(0),
+                anno,
+                annotation_scale_handle.map(|h| h.value()).unwrap_or(0),
+                all_visible,
+                crate::scene::text::sdf_atlas::generation(),
             );
         }
         wires

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -1848,6 +1848,13 @@ pub struct Scene {
     /// `belongs_to_visible_block` treats as belonging to everything — but only
     /// when no block record enumerates its contents at all.
     block_members_cache: RefCell<Option<BlockMembers>>,
+    /// Handles of entities the quadtree cannot index — Insert, Viewport, Block,
+    /// BlockEnd — in document order, keyed by `geometry_epoch`.
+    ///
+    /// The quadtree path has to append these regardless of the view, and did so
+    /// by walking every entity in the document: ~300 ms of every resident
+    /// rebuild on a 1.17 M-entity drawing, to find a few thousand.
+    unindexable_cache: RefCell<Option<(u64, Vec<Handle>)>>,
     /// Distinct entity type names present in a layout, keyed by
     /// (geometry_epoch, layout block). The status bar asks for this on every
     /// frame to populate the selection-filter menu, but the answer only
@@ -2093,6 +2100,7 @@ impl Scene {
             model_extents_cache: RefCell::new(None),
             entity_block_map_cache: RefCell::new(None),
             block_members_cache: RefCell::new(None),
+            unindexable_cache: RefCell::new(None),
             layout_type_names_cache: RefCell::new(None),
             dependency_index_cache: RefCell::new(None),
             associative_hatch_source_cache: RefCell::new(None),
@@ -8902,7 +8910,7 @@ impl Scene {
         let sort_cache_ms = crate::perf::elapsed_ms(t_fn);
         let t_visible = perf.then(iced::time::Instant::now);
         // Which path the selection took, and how many candidates it looked at.
-        let mut visible_path = "quadtree";
+        let mut visible_path = "quadtree+index";
         let mut visible_candidates = 0usize;
 
         // Phase 2.1 — quadtree-driven candidate selection. When a view
@@ -8941,10 +8949,19 @@ impl Scene {
                 }
             }
             // Inserts/Viewports/Block/BlockEnd — handled by their own paths
-            // (block expansion, viewport rendering); always candidates.
-            for e in self.document.entities() {
-                if is_unindexable_entity(e) && visibility_ok(e) {
-                    out.push(e);
+            // (block expansion, viewport rendering); always candidates. Taken
+            // from the per-epoch list rather than by walking the document,
+            // which preserves document order because the list is built that
+            // way.
+            {
+                let unindexable = self.unindexable_handles();
+                visible_candidates = unindexable.1.len();
+                for &h in &unindexable.1 {
+                    if let Some(e) = self.document.get_entity(h) {
+                        if visibility_ok(e) {
+                            out.push(e);
+                        }
+                    }
                 }
             }
             out
@@ -9239,6 +9256,29 @@ entities={} memo_hit={} memo_miss={} wires={} memo={} visible_path={} candidates
     ///   * an entity neither names nor is named by any block is "unowned", and
     ///     counts towards every block only when no block record enumerates its
     ///     contents at all — the legacy-DXF case that predicate allows.
+    /// Entities the quadtree cannot index, in document order, resolved once per
+    /// `geometry_epoch`. Membership depends only on the entity's type, so an
+    /// edit that does not add or remove one leaves the list unchanged.
+    fn unindexable_handles(&self) -> std::cell::Ref<'_, (u64, Vec<Handle>)> {
+        {
+            let cache = self.unindexable_cache.borrow();
+            if cache.as_ref().is_some_and(|(epoch, _)| *epoch == self.geometry_epoch) {
+                drop(cache);
+                return std::cell::Ref::map(self.unindexable_cache.borrow(), |c| {
+                    c.as_ref().unwrap()
+                });
+            }
+        }
+        let handles: Vec<Handle> = self
+            .document
+            .entities()
+            .filter(|entity| is_unindexable_entity(entity))
+            .map(|entity| entity.common().handle)
+            .collect();
+        *self.unindexable_cache.borrow_mut() = Some((self.geometry_epoch, handles));
+        std::cell::Ref::map(self.unindexable_cache.borrow(), |c| c.as_ref().unwrap())
+    }
+
     fn block_members(&self) -> std::cell::Ref<'_, BlockMembers> {
         {
             let cache = self.block_members_cache.borrow();

--- a/src/scene/paper.rs
+++ b/src/scene/paper.rs
@@ -69,7 +69,36 @@ impl Scene {
         (layout_block, sheet, content)
     }
 
+    /// Could any viewport in this layout draw a grid?
+    ///
+    /// Read from the same fields `active_viewports` copies into
+    /// `ViewportInstance::grid_on`, and deliberately without the visibility
+    /// filters that function also applies: answering "maybe" only costs the
+    /// work that would have happened anyway, while answering "no" wrongly
+    /// would drop a grid the user asked for.
+    fn any_viewport_grid_on(&self) -> bool {
+        if self.current_layout == "Model" {
+            return self.model_tiles.borrow().iter().any(|tile| tile.grid_on);
+        }
+        let (_, sheet, content) = self.paper_viewport_handles();
+        let grid_on = |handle: Handle| {
+            matches!(
+                self.document.get_entity(handle),
+                Some(EntityType::Viewport(vp)) if vp.status.grid_on
+            )
+        };
+        grid_on(sheet) || content.iter().copied().any(grid_on)
+    }
+
     pub fn grid_views(&self, vw: f32, vh: f32) -> Vec<(iced::Rectangle, Camera, Handle)> {
+        // `active_viewports` resolves a camera for every viewport, and
+        // `camera_for_viewport` reaches `model_space_extents`, which outside the
+        // Model layout tessellates the whole drawing. Filtering on `grid_on`
+        // afterwards threw all of that away: on the reproducer the first paper
+        // frame spent 7.8 s here to produce `n=0` views. Ask first.
+        if !self.any_viewport_grid_on() {
+            return Vec::new();
+        }
         self.active_viewports(vw, vh, acadrust::entities::ViewportRenderMode::Wireframe2D)
             .into_iter()
             .filter(|inst| inst.grid_on)


### PR DESCRIPTION
Depends on #1012. Skip viewport camera work when no grid is enabled, and report view-building costs by section.

Integration reuses full resident geometry for model extents and computes its bounds through the kernel. This replaces the separate tessellation pass and its native-only Rayon import, preserving web support.
