### PR TITLE
Release unused viewport memory safely

### DIFF
--- a/src/scene/pipeline/gpu_tests.rs
+++ b/src/scene/pipeline/gpu_tests.rs
@@ -16,6 +16,9 @@ fn block_edits_preserve_cache_coordinates_and_arena_partition() {
     .expect("GPU device");
     let validation = device.push_error_scope(wgpu::ErrorFilter::Validation);
     let mut pipeline = Pipeline::new(&device, &queue, wgpu::TextureFormat::Bgra8UnormSrgb);
+    // Definition geometry is shared across viewport slots, so it lives on the
+    // MultiPipeline; a single-slot test supplies its own.
+    let mut block_geometry = wire_gpu::BlockGeometryCache::default();
     let block = |handle: u64, x: f64| WireModel {
         name: handle.to_string(),
         points: vec![[x as f32, 0.0, 0.0], [x as f32 + 1.0, 0.0, 0.0]],
@@ -28,25 +31,25 @@ fn block_edits_preserve_cache_coordinates_and_arena_partition() {
     let first = block(1, 10.0);
     let second = block(2, 20.0);
     let depth = rustc_hash::FxHashMap::from_iter([(1, [0.1, 0.01]), (2, [0.2, 0.01])]);
-    let original = pipeline.upload_block_wires(&device, &queue, &[&first, &second], &depth);
-    let unchanged = pipeline.upload_block_wires(&device, &queue, &[&first, &second], &depth);
+    let original = pipeline.upload_block_wires(&device, &queue, &[&first, &second], &depth, &mut block_geometry);
+    let unchanged = pipeline.upload_block_wires(&device, &queue, &[&first, &second], &depth, &mut block_geometry);
     assert_eq!(original[0].geometry_id(), unchanged[0].geometry_id());
     assert_eq!(original[0].instance_count, 2);
 
-    let removed = pipeline.upload_block_wires(&device, &queue, &[&second], &depth);
+    let removed = pipeline.upload_block_wires(&device, &queue, &[&second], &depth, &mut block_geometry);
     assert_ne!(
         original[0].geometry_id(),
         removed[0].geometry_id(),
         "removing the base instance must replace vertices baked at its old position"
     );
     let moved = block(2, 30.0);
-    let moved_gpu = pipeline.upload_block_wires(&device, &queue, &[&moved], &depth);
+    let moved_gpu = pipeline.upload_block_wires(&device, &queue, &[&moved], &depth, &mut block_geometry);
     assert_ne!(removed[0].geometry_id(), moved_gpu[0].geometry_id());
-    let restored = pipeline.upload_block_wires(&device, &queue, &[&first, &second], &depth);
+    let restored = pipeline.upload_block_wires(&device, &queue, &[&first, &second], &depth, &mut block_geometry);
     assert_ne!(moved_gpu[0].geometry_id(), restored[0].geometry_id());
     assert_eq!(restored[0].instance_count, 2);
     assert_eq!(
-        pipeline.block_geometry.len(),
+        block_geometry.len(),
         1,
         "discard obsolete geometry"
     );

--- a/src/scene/pipeline/gpu_tests.rs
+++ b/src/scene/pipeline/gpu_tests.rs
@@ -268,3 +268,54 @@ fn bounded_gpu_uploads_preserve_geometry_and_instancing() {
         "GPU validation failed"
     );
 }
+
+/// The shadow map is 16 MiB and every slot used to hold one whether or not its
+/// visual style enabled shadows. Now it is allocated on the transition, which
+/// means the frame bind group is rebuilt while the device is watching — the one
+/// path the other GPU tests never take.
+#[test]
+#[ignore = "requires a GPU adapter"]
+fn toggling_shadows_reallocates_without_upsetting_the_device() {
+    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+    let adapter = block_on(instance.request_adapter(&wgpu::RequestAdapterOptions::default()))
+        .expect("GPU adapter");
+    let (device, queue) = block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+        required_limits: adapter.limits(),
+        ..Default::default()
+    }))
+    .expect("GPU device");
+    let validation = device.push_error_scope(wgpu::ErrorFilter::Validation);
+    let mut pipeline = Pipeline::new(&device, &queue, wgpu::TextureFormat::Bgra8UnormSrgb);
+
+    assert!(
+        pipeline.shadow_full.is_none(),
+        "a fresh slot must not hold a shadow map"
+    );
+    let camera = crate::scene::view::camera::Camera::default();
+    let bounds = iced::Rectangle::new(iced::Point::ORIGIN, iced::Size::new(64.0, 64.0));
+    let with_shadows = |on: bool| {
+        let mut u = Uniforms::new(&camera, bounds, false);
+        u.shadow_params[0] = if on { 1.0 } else { 0.0 };
+        u
+    };
+
+    // Off → on → off → on, so both transitions are exercised twice and the
+    // second `on` proves the release did not leave the bind group stale.
+    for expected in [true, false, true] {
+        pipeline.upload_uniforms(&device, &queue, &with_shadows(expected));
+        assert_eq!(
+            pipeline.shadow_full.is_some(),
+            expected,
+            "shadow target should follow shadow_params[0]"
+        );
+    }
+    // Releasing a cold slot gives it back and must rebuild the bind group too.
+    pipeline.release_heavy_resources(&device);
+    assert!(pipeline.shadow_full.is_none(), "a released slot holds none");
+
+    device.poll(wgpu::PollType::wait_indefinitely()).unwrap();
+    assert!(
+        block_on(validation.pop()).is_none(),
+        "GPU validation failed"
+    );
+}

--- a/src/scene/pipeline/gpu_tests.rs
+++ b/src/scene/pipeline/gpu_tests.rs
@@ -30,19 +30,20 @@ fn block_edits_preserve_cache_coordinates_and_arena_partition() {
     let depth = rustc_hash::FxHashMap::from_iter([(1, [0.1, 0.01]), (2, [0.2, 0.01])]);
     let original = pipeline.upload_block_wires(&device, &queue, &[&first, &second], &depth);
     let unchanged = pipeline.upload_block_wires(&device, &queue, &[&first, &second], &depth);
-    assert_eq!(original[0].vertex_buffer, unchanged[0].vertex_buffer);
+    assert_eq!(original[0].geometry_id(), unchanged[0].geometry_id());
     assert_eq!(original[0].instance_count, 2);
 
     let removed = pipeline.upload_block_wires(&device, &queue, &[&second], &depth);
     assert_ne!(
-        original[0].vertex_buffer, removed[0].vertex_buffer,
+        original[0].geometry_id(),
+        removed[0].geometry_id(),
         "removing the base instance must replace vertices baked at its old position"
     );
     let moved = block(2, 30.0);
     let moved_gpu = pipeline.upload_block_wires(&device, &queue, &[&moved], &depth);
-    assert_ne!(removed[0].vertex_buffer, moved_gpu[0].vertex_buffer);
+    assert_ne!(removed[0].geometry_id(), moved_gpu[0].geometry_id());
     let restored = pipeline.upload_block_wires(&device, &queue, &[&first, &second], &depth);
-    assert_ne!(moved_gpu[0].vertex_buffer, restored[0].vertex_buffer);
+    assert_ne!(moved_gpu[0].geometry_id(), restored[0].geometry_id());
     assert_eq!(restored[0].instance_count, 2);
     assert_eq!(
         pipeline.block_geometry.len(),

--- a/src/scene/pipeline/mod.rs
+++ b/src/scene/pipeline/mod.rs
@@ -94,6 +94,10 @@ pub struct Pipeline {
     /// compatibility mode. Passed to `WireGpu::from_run` / `from_batch`.
     pub(crate) wire_const_bgl: Option<wgpu::BindGroupLayout>,
     block_wire_const_bgl: wgpu::BindGroupLayout,
+    /// Which block-wire pipeline was built. Decides whether a definition's
+    /// segments go to a vertex buffer six times over or to a storage buffer
+    /// once.
+    block_wire_mode: wire_gpu::WirePipelineMode,
     wipeout_pipeline: wgpu::RenderPipeline,
     /// Capability-selected hatch renderer. Storage and texture transports are
     /// private backends behind one upload/LOD/draw lifecycle.
@@ -581,7 +585,8 @@ impl Pipeline {
             bind_group_layouts: &wire_bgls,
             immediate_size: 0,
         });
-        let block_wire_const_bgl = wire_gpu::block_const_bind_group_layout(device);
+        let block_wire_const_bgl =
+            wire_gpu::block_const_bind_group_layout(device, wire_mode.uses_storage());
         let block_wire_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some("block_wire.pipeline_layout"),
             bind_group_layouts: &[Some(&frame_bgl), Some(&block_wire_const_bgl)],
@@ -602,9 +607,13 @@ impl Pipeline {
         });
         let block_wire_shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
             label: Some("block_wire.shader"),
-            source: wgpu::ShaderSource::Wgsl(std::borrow::Cow::Borrowed(include_str!(
-                "../../shaders/block_wire.wgsl"
-            ))),
+            source: wgpu::ShaderSource::Wgsl(std::borrow::Cow::Borrowed(
+                if wire_mode.uses_storage() {
+                    include_str!("../../shaders/block_wire_storage.wgsl")
+                } else {
+                    include_str!("../../shaders/block_wire.wgsl")
+                },
+            )),
         });
 
         // Stencil test shared by every paper content pipeline: draw only where
@@ -880,6 +889,14 @@ impl Pipeline {
             multiview_mask: None,
             cache: None,
         });
+        let block_wire_buffers: &[wgpu::VertexBufferLayout<'_>] = if wire_mode.uses_storage() {
+            &[wire_gpu::BlockWireInstance::layout()]
+        } else {
+            &[
+                wire_gpu::BlockWireVertex::layout(),
+                wire_gpu::BlockWireInstance::layout(),
+            ]
+        };
         let make_block_wire_pipeline = |
             label: &'static str,
             fragment: &'static str,
@@ -892,10 +909,10 @@ impl Pipeline {
                 vertex: wgpu::VertexState {
                     module: &block_wire_shader,
                     entry_point: Some("vs_main"),
-                    buffers: &[
-                        wire_gpu::BlockWireVertex::layout(),
-                        wire_gpu::BlockWireInstance::layout(),
-                    ],
+                    // Storage mode has no geometry vertex buffer: the
+                    // instances become slot 0 and the segments arrive through
+                    // the bind group.
+                    buffers: block_wire_buffers,
                     compilation_options: wgpu::PipelineCompilationOptions::default(),
                 },
                 primitive: wgpu::PrimitiveState {
@@ -2215,6 +2232,7 @@ impl Pipeline {
             block_wire_xray_pipeline,
             wire_const_bgl,
             block_wire_const_bgl,
+            block_wire_mode: wire_mode,
             wipeout_pipeline,
             hatch_gpu,
             image_pipeline,
@@ -2349,7 +2367,10 @@ impl Pipeline {
             wires,
             depth_map,
             None,
-            &self.block_wire_const_bgl,
+            wire_gpu::BlockWireTarget {
+                const_bgl: &self.block_wire_const_bgl,
+                mode: self.block_wire_mode,
+            },
             Some(&mut self.block_geometry),
         )
     }
@@ -2415,7 +2436,10 @@ impl Pipeline {
             &block_wires,
             depth_map,
             None,
-            &self.block_wire_const_bgl,
+            wire_gpu::BlockWireTarget {
+                const_bgl: &self.block_wire_const_bgl,
+                mode: self.block_wire_mode,
+            },
             Some(&mut self.block_geometry),
         );
 
@@ -2554,7 +2578,10 @@ impl Pipeline {
                 &selected_blocks,
                 depth_map,
                 Some(tint),
-                &self.block_wire_const_bgl,
+                wire_gpu::BlockWireTarget {
+                    const_bgl: &self.block_wire_const_bgl,
+                    mode: self.block_wire_mode,
+                },
                 None,
             )
         } else {
@@ -2566,7 +2593,10 @@ impl Pipeline {
             &hover_blocks,
             depth_map,
             Some(WireModel::HOVER),
-            &self.block_wire_const_bgl,
+            wire_gpu::BlockWireTarget {
+                const_bgl: &self.block_wire_const_bgl,
+                mode: self.block_wire_mode,
+            },
             None,
         ));
         self.gpu_selected_block_wires = block_gpu;
@@ -4288,10 +4318,7 @@ impl Pipeline {
                     });
                     block_black_active = use_black;
                 }
-                pass.set_bind_group(1, wire.const_bind_group.as_ref(), &[]);
-                pass.set_vertex_buffer(0, wire.vertex_buffer.slice(..));
-                pass.set_vertex_buffer(1, wire.instance_buffer.slice(..));
-                pass.draw(0..wire.vertex_count, 0..wire.instance_count);
+                bind_and_draw_block_wire(&mut pass, wire);
             }
             // Live overlay wires (command preview / interim / grip drag) always
             // on top: the xray pipeline (depth_compare=Always, no depth write)
@@ -4480,10 +4507,7 @@ impl Pipeline {
                     if wire.instance_count == 0 {
                         continue;
                     }
-                    pass.set_bind_group(1, wire.const_bind_group.as_ref(), &[]);
-                    pass.set_vertex_buffer(0, wire.vertex_buffer.slice(..));
-                    pass.set_vertex_buffer(1, wire.instance_buffer.slice(..));
-                    pass.draw(0..wire.vertex_count, 0..wire.instance_count);
+                    bind_and_draw_block_wire(&mut pass, wire);
                 }
             }
             if let Some(atlas) = &self.text_atlas_gpu {
@@ -4703,6 +4727,24 @@ fn aabb_below_pixel(
         if py > max_py { max_py = py; }
     }
     (max_px - min_px).max(max_py - min_py) < threshold_px
+}
+
+/// Bind one block-wire batch and draw it.
+///
+/// The two pipeline modes lay the vertex slots out differently — packed puts
+/// the six-per-segment geometry in slot 0 and the placements in slot 1, while
+/// storage has no geometry vertex buffer at all and the placements become slot
+/// 0. Both draw loops go through here so they cannot drift apart.
+fn bind_and_draw_block_wire(pass: &mut wgpu::RenderPass<'_>, wire: &wire_gpu::BlockWireGpu) {
+    pass.set_bind_group(1, wire.const_bind_group.as_ref(), &[]);
+    match &wire.vertex_buffer {
+        Some(vertices) => {
+            pass.set_vertex_buffer(0, vertices.slice(..));
+            pass.set_vertex_buffer(1, wire.instance_buffer.slice(..));
+        }
+        None => pass.set_vertex_buffer(0, wire.instance_buffer.slice(..)),
+    }
+    pass.draw(0..wire.vertex_count, 0..wire.instance_count);
 }
 
 fn create_depth_texture(device: &wgpu::Device, size: Size<u32>) -> wgpu::Texture {

--- a/src/scene/pipeline/mod.rs
+++ b/src/scene/pipeline/mod.rs
@@ -4956,12 +4956,25 @@ impl MultiPipeline {
 /// `Pipeline::new`, which runs again for every pane `ensure_len` adds. If iced
 /// ever rebuilds the device it builds a new `MultiPipeline` too, so the fresh
 /// device is covered (and the throttle restarts with it).
+static GPU_ERRORS_SEEN: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+/// How many uncaptured device errors have been reported since this device was
+/// created.
+///
+/// Callers snapshot it around an allocation to find out whether what they just
+/// built is usable. Best effort: wgpu surfaces some errors asynchronously, so a
+/// move means "something failed", while no move is not proof that nothing did.
+/// That is the right asymmetry here — the cost of believing a bad buffer is a
+/// frozen viewport, the cost of rebuilding a good one is a frame.
+pub(crate) fn gpu_errors_seen() -> usize {
+    GPU_ERRORS_SEEN.load(std::sync::atomic::Ordering::Relaxed)
+}
+
 fn install_gpu_error_handler(device: &wgpu::Device) {
-    use std::sync::atomic::{AtomicUsize, Ordering};
-    static SEEN: AtomicUsize = AtomicUsize::new(0);
-    SEEN.store(0, Ordering::Relaxed);
+    use std::sync::atomic::Ordering;
+    GPU_ERRORS_SEEN.store(0, Ordering::Relaxed);
     device.on_uncaptured_error(std::sync::Arc::new(|e: wgpu::Error| {
-        let n = SEEN.fetch_add(1, Ordering::Relaxed) + 1;
+        let n = GPU_ERRORS_SEEN.fetch_add(1, Ordering::Relaxed) + 1;
         if n.is_power_of_two() {
             eprintln!("[gpu] uncaptured wgpu error #{n} (frame degraded, session kept alive): {e}");
         }

--- a/src/scene/pipeline/mod.rs
+++ b/src/scene/pipeline/mod.rs
@@ -150,8 +150,16 @@ pub struct Pipeline {
     background_sampler: wgpu::Sampler,
     background_source_id: usize,
     environment_source_id: usize,
-    _shadow_texture: wgpu::Texture,
-    shadow_view: wgpu::TextureView,
+    /// The shadow depth target, allocated only while this viewport actually
+    /// casts shadows. `SHADOW_MAP_SIZE` squared at `Depth32Float` is 16 MiB,
+    /// and every slot used to hold one whether or not its visual style enabled
+    /// shadows — 128 MiB across eight viewports, none of it ever sampled.
+    shadow_full: Option<(wgpu::Texture, wgpu::TextureView)>,
+    /// Bound at the frame group's shadow slot while `shadow_full` is `None`.
+    /// The binding must be filled for the layout to be satisfied, but nothing
+    /// samples it when shadows are off, so 1x1 is the whole requirement.
+    _shadow_fallback_texture: wgpu::Texture,
+    shadow_fallback_view: wgpu::TextureView,
     shadow_sampler: wgpu::Sampler,
     shadow_enabled: bool,
     wipeout_bgl1: wgpu::BindGroupLayout,
@@ -489,21 +497,9 @@ impl Pipeline {
             mipmap_filter: wgpu::MipmapFilterMode::Linear,
             ..Default::default()
         });
-        let shadow_texture = device.create_texture(&wgpu::TextureDescriptor {
-            label: Some("shadow.texture"),
-            size: wgpu::Extent3d {
-                width: SHADOW_MAP_SIZE,
-                height: SHADOW_MAP_SIZE,
-                depth_or_array_layers: 1,
-            },
-            mip_level_count: 1,
-            sample_count: 1,
-            dimension: wgpu::TextureDimension::D2,
-            format: wgpu::TextureFormat::Depth32Float,
-            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING,
-            view_formats: &[],
-        });
-        let shadow_view = shadow_texture.create_view(&wgpu::TextureViewDescriptor::default());
+        let shadow_fallback_texture = create_shadow_texture(device, 1);
+        let shadow_fallback_view =
+            shadow_fallback_texture.create_view(&wgpu::TextureViewDescriptor::default());
         let shadow_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
             label: Some("shadow.sampler"),
             address_mode_u: wgpu::AddressMode::ClampToEdge,
@@ -542,7 +538,7 @@ impl Pipeline {
                 },
                 wgpu::BindGroupEntry {
                     binding: 5,
-                    resource: wgpu::BindingResource::TextureView(&shadow_view),
+                    resource: wgpu::BindingResource::TextureView(&shadow_fallback_view),
                 },
                 wgpu::BindGroupEntry {
                     binding: 6,
@@ -2276,8 +2272,9 @@ impl Pipeline {
             background_sampler,
             background_source_id: 0,
             environment_source_id: 0,
-            _shadow_texture: shadow_texture,
-            shadow_view,
+            shadow_full: None,
+            _shadow_fallback_texture: shadow_fallback_texture,
+            shadow_fallback_view,
             shadow_sampler,
             shadow_enabled: false,
             wipeout_bgl1,
@@ -3494,8 +3491,90 @@ impl Pipeline {
         }
     }
 
-    pub fn upload_uniforms(&mut self, queue: &wgpu::Queue, uniforms: &Uniforms) {
+    /// Whatever is bound at the frame group's shadow slot: the real depth
+    /// target when this viewport casts shadows, the 1x1 placeholder otherwise.
+    fn shadow_view(&self) -> &wgpu::TextureView {
+        match &self.shadow_full {
+            Some((_, view)) => view,
+            None => &self.shadow_fallback_view,
+        }
+    }
+
+    /// Rebuild the frame bind group from whatever this slot currently holds.
+    ///
+    /// Three things can change what belongs in it — a background image, an
+    /// environment image, and whether the shadow target exists — and it used to
+    /// be assembled inline at each. One builder means a shadow transition
+    /// cannot forget the background the slot already had.
+    fn rebuild_frame_bind_group(&mut self, device: &wgpu::Device) {
+        let background_view = self
+            .background_texture
+            .create_view(&wgpu::TextureViewDescriptor::default());
+        let environment_view = self
+            .environment_texture
+            .create_view(&wgpu::TextureViewDescriptor::default());
+        self.uniform_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("viewer.bind_group"),
+            layout: &self.frame_bgl,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: self.uniform_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::TextureView(&background_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: wgpu::BindingResource::Sampler(&self.background_sampler),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 3,
+                    resource: wgpu::BindingResource::TextureView(&environment_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 4,
+                    resource: wgpu::BindingResource::Sampler(&self.background_sampler),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 5,
+                    resource: wgpu::BindingResource::TextureView(self.shadow_view()),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 6,
+                    resource: wgpu::BindingResource::Sampler(&self.shadow_sampler),
+                },
+            ],
+        });
+    }
+
+    /// Allocate or drop the shadow target to match `shadow_enabled`.
+    ///
+    /// Only on a transition: the frame bind group has to be rebuilt with the
+    /// new view, and a viewport that keeps its shadow setting should not pay
+    /// for that every frame.
+    fn sync_shadow_target(&mut self, device: &wgpu::Device) {
+        match (self.shadow_enabled, self.shadow_full.is_some()) {
+            (true, false) => {
+                let texture = create_shadow_texture(device, SHADOW_MAP_SIZE);
+                let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+                self.shadow_full = Some((texture, view));
+            }
+            (false, true) => self.shadow_full = None,
+            _ => return,
+        }
+        self.rebuild_frame_bind_group(device);
+    }
+
+    pub fn upload_uniforms(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        uniforms: &Uniforms,
+    ) {
         self.shadow_enabled = uniforms.shadow_params[0] > 0.5;
+        self.sync_shadow_target(device);
         queue.write_buffer(&self.uniform_buffer, 0, bytemuck::bytes_of(uniforms));
     }
 
@@ -3562,46 +3641,7 @@ impl Pipeline {
             environment,
             [128, 128, 128, 255],
         );
-        let background_view = self
-            .background_texture
-            .create_view(&wgpu::TextureViewDescriptor::default());
-        let environment_view = self
-            .environment_texture
-            .create_view(&wgpu::TextureViewDescriptor::default());
-        self.uniform_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-            label: Some("viewer.bind_group"),
-            layout: &self.frame_bgl,
-            entries: &[
-                wgpu::BindGroupEntry {
-                    binding: 0,
-                    resource: self.uniform_buffer.as_entire_binding(),
-                },
-                wgpu::BindGroupEntry {
-                    binding: 1,
-                    resource: wgpu::BindingResource::TextureView(&background_view),
-                },
-                wgpu::BindGroupEntry {
-                    binding: 2,
-                    resource: wgpu::BindingResource::Sampler(&self.background_sampler),
-                },
-                wgpu::BindGroupEntry {
-                    binding: 3,
-                    resource: wgpu::BindingResource::TextureView(&environment_view),
-                },
-                wgpu::BindGroupEntry {
-                    binding: 4,
-                    resource: wgpu::BindingResource::Sampler(&self.background_sampler),
-                },
-                wgpu::BindGroupEntry {
-                    binding: 5,
-                    resource: wgpu::BindingResource::TextureView(&self.shadow_view),
-                },
-                wgpu::BindGroupEntry {
-                    binding: 6,
-                    resource: wgpu::BindingResource::Sampler(&self.shadow_sampler),
-                },
-            ],
-        });
+        self.rebuild_frame_bind_group(device);
         self.background_source_id = background_id;
         self.environment_source_id = environment_id;
     }
@@ -3670,12 +3710,20 @@ impl Pipeline {
         // render rectangle does the clipping).
         let stencil_ref: u32 = if self.clip_boundary.is_some() { 0xFF } else { 0 };
 
-        if self.shadow_enabled && !self.skip_geometry && !mesh_wireframe {
+        // `shadow_enabled` says the style wants shadows; the target existing
+        // says the device could give us one. Without the second test a failed
+        // 16 MiB allocation would render the pass into the 1x1 placeholder.
+        if let Some(shadow_target) = self
+            .shadow_full
+            .as_ref()
+            .map(|(_, view)| view)
+            .filter(|_| self.shadow_enabled && !self.skip_geometry && !mesh_wireframe)
+        {
             let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                 label: Some("shadow.render_pass"),
                 color_attachments: &[],
                 depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
-                    view: &self.shadow_view,
+                    view: shadow_target,
                     depth_ops: Some(wgpu::Operations {
                         load: wgpu::LoadOp::Clear(1.0),
                         store: wgpu::StoreOp::Store,
@@ -4663,6 +4711,13 @@ impl Pipeline {
         self.silhouette_source_groups.clear();
         self.clip_boundary = None;
 
+        // A cold slot's shadow target goes back too. `shadow_enabled` is left
+        // alone, so `sync_shadow_target` reallocates on the next frame that
+        // still wants shadows.
+        if self.shadow_full.take().is_some() {
+            self.rebuild_frame_bind_group(device);
+        }
+
         self.text_atlas_gpu = None;
         self.text_gpu.clear();
         self.block_text_gpu.clear();
@@ -4845,8 +4900,12 @@ impl Pipeline {
         let pixels = u64::from(self.alloc_size.width) * u64::from(self.alloc_size.height);
         GpuLiveBytes {
             slots: 1,
-            // Allocated by every slot whether or not shadows are enabled.
-            shadow: u64::from(SHADOW_MAP_SIZE) * u64::from(SHADOW_MAP_SIZE) * 4,
+            // Only while this viewport casts shadows; the placeholder that
+            // stands in otherwise is 4 bytes.
+            shadow: match &self.shadow_full {
+                Some(_) => u64::from(SHADOW_MAP_SIZE) * u64::from(SHADOW_MAP_SIZE) * 4,
+                None => 4,
+            },
             render_targets: pixels * BYTES_PER_PIXEL,
             text_atlas: self
                 .text_atlas_gpu
@@ -4901,7 +4960,9 @@ impl MultiPipeline {
             }
             // Nothing to give back — releasing again would only churn the
             // render targets it just rebuilt at their smallest size.
-            if self.inners[index].gpu_live_bytes().wire_arena == 0
+            let held = self.inners[index].gpu_live_bytes();
+            if held.wire_arena == 0
+                && held.shadow <= 4
                 && self.inners[index].alloc_size == Size::new(0, 0)
             {
                 continue;
@@ -4946,6 +5007,26 @@ fn bind_and_draw_block_wire(pass: &mut wgpu::RenderPass<'_>, wire: &wire_gpu::Bl
         None => pass.set_vertex_buffer(0, wire.instance_buffer.slice(..)),
     }
     pass.draw(0..wire.vertex_count, 0..wire.instance_count);
+}
+
+/// A square `Depth32Float` render target for the shadow pass. `side` is 1 for
+/// the placeholder that keeps the frame bind group satisfied while shadows are
+/// off, and `SHADOW_MAP_SIZE` for the real thing.
+fn create_shadow_texture(device: &wgpu::Device, side: u32) -> wgpu::Texture {
+    device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("shadow.texture"),
+        size: wgpu::Extent3d {
+            width: side,
+            height: side,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Depth32Float,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING,
+        view_formats: &[],
+    })
 }
 
 fn create_depth_texture(device: &wgpu::Device, size: Size<u32>) -> wgpu::Texture {

--- a/src/scene/pipeline/mod.rs
+++ b/src/scene/pipeline/mod.rs
@@ -217,9 +217,6 @@ pub struct Pipeline {
     /// shared resident buffer.
     pub(crate) gpu_wires: std::sync::Arc<Vec<WireGpu>>,
     pub(crate) gpu_block_wires: std::sync::Arc<Vec<BlockWireGpu>>,
-    /// Block geometry that survives an edit, keyed by the definition it
-    /// expands. See `wire_gpu::BlockGeometryCache`.
-    pub(crate) block_geometry: wire_gpu::BlockGeometryCache,
     /// Persistent per-entity wire instance arena (capability-selected format).
     /// When active, `gpu_wires` is a thin wrapper over this arena's buffers and an
     /// edit patches one entity's slab in place instead of rebuilding every wire.
@@ -2300,7 +2297,6 @@ impl Pipeline {
             surface_format: format,
             gpu_wires: std::sync::Arc::new(vec![]),
             gpu_block_wires: std::sync::Arc::new(vec![]),
-            block_geometry: Default::default(),
             wire_arena: None,
             wire_arena_mesh: None,
             wire_arena_fallback: std::sync::Arc::new(Vec::new()),
@@ -2360,6 +2356,7 @@ impl Pipeline {
         queue: &wgpu::Queue,
         wires: &[&WireModel],
         depth_map: &rustc_hash::FxHashMap<u64, [f32; 2]>,
+        block_geometry: &mut wire_gpu::BlockGeometryCache,
     ) -> Vec<BlockWireGpu> {
         BlockWireGpu::from_wires(
             device,
@@ -2371,7 +2368,7 @@ impl Pipeline {
                 const_bgl: &self.block_wire_const_bgl,
                 mode: self.block_wire_mode,
             },
-            Some(&mut self.block_geometry),
+            Some(block_geometry),
         )
     }
 
@@ -2382,6 +2379,7 @@ impl Pipeline {
         queue: &wgpu::Queue,
         wires: &[WireModel],
         depth_map: &rustc_hash::FxHashMap<u64, [f32; 2]>,
+        block_geometry: &mut wire_gpu::BlockGeometryCache,
     ) -> (
         std::sync::Arc<Vec<WireGpu>>,
         std::sync::Arc<Vec<BlockWireGpu>>,
@@ -2440,7 +2438,7 @@ impl Pipeline {
                 const_bgl: &self.block_wire_const_bgl,
                 mode: self.block_wire_mode,
             },
-            Some(&mut self.block_geometry),
+            Some(block_geometry),
         );
 
         // Parse handles in parallel, preserving wire order for hover slot lists.
@@ -4830,6 +4828,17 @@ pub struct MultiPipeline {
     /// once between them instead of once per slot. Kept trim by dropping entries
     /// no slot still references (`Arc::strong_count == 1`) once it grows past a
     /// small bound.
+    /// Block geometry that survives an edit, keyed by the definition it
+    /// expands rather than by anything a viewport contributes. See
+    /// `wire_gpu::BlockGeometryCache`.
+    ///
+    /// Shared across slots for the same reason `wire_buffer_cache` is: a
+    /// definition's segments are identical in every viewport that draws it, and
+    /// this is the largest upload the renderer makes — 59.5 MiB on the
+    /// reproducer. Held per slot, zooming a paper layout out until four or five
+    /// viewports were on screen uploaded it once each and ran a 2 GB card out
+    /// of memory.
+    pub(crate) block_geometry: wire_gpu::BlockGeometryCache,
     pub(crate) wire_buffer_cache: rustc_hash::FxHashMap<
         u64,
         (
@@ -4985,6 +4994,7 @@ impl iced::widget::shader::Pipeline for MultiPipeline {
     fn new(device: &wgpu::Device, queue: &wgpu::Queue, format: wgpu::TextureFormat) -> Self {
         install_gpu_error_handler(device);
         Self {
+            block_geometry: Default::default(),
             inners: vec![Pipeline::new(device, queue, format)],
             format,
             slot_by_instance: rustc_hash::FxHashMap::default(),

--- a/src/scene/pipeline/mod.rs
+++ b/src/scene/pipeline/mod.rs
@@ -4593,6 +4593,92 @@ impl Pipeline {
         }
     }
 
+    /// Forget every cache key that describes this slot's uploaded content.
+    ///
+    /// Shared by slot reuse and by [`Self::release_heavy_resources`] so the two
+    /// cannot disagree about what "this slot holds nothing you can trust"
+    /// means. Keys only — the buffers themselves are dropped by the caller that
+    /// wants the memory back.
+    pub(crate) fn forget_cached_keys(&mut self) {
+        self.cached_epoch = (u64::MAX, u64::MAX, u64::MAX);
+        self.cached_wire_id = u64::MAX;
+        self.cached_selection = (u64::MAX, u64::MAX);
+        self.cached_highlight_key = (u64::MAX, u64::MAX);
+        self.cached_mesh_content_id = u64::MAX;
+        self.cached_face3d_key = (u64::MAX, false, false, u64::MAX);
+        self.cached_solid_visibility = (u64::MAX, [u32::MAX; 3], u64::MAX);
+        self.cached_hatch_source = None;
+        self.cached_preview_hatch_source = None;
+        self.cached_wipeout_source = None;
+        self.cached_image_source = None;
+        self.cached_text_source = None;
+        self.cached_mesh_source = None;
+        self.cached_face3d_source = None;
+        self.cached_face3d_depth_source = None;
+        self.wire_cull_key = (u64::MAX, u64::MAX, 0, 0);
+        self.hatch_lod_key = (usize::MAX, u64::MAX, 0, 0, false);
+        self.wipeout_lod_key = (usize::MAX, u64::MAX, 0, 0, false);
+        self.silhouette_key = (usize::MAX, u64::MAX, [u32::MAX; 3], false);
+        self.silhouette_source_key = (usize::MAX, usize::MAX, u64::MAX);
+        self.render_sig = u64::MAX;
+    }
+
+    /// Give this slot's device memory back and forget what it held.
+    ///
+    /// A slot nobody is drawing still owns its wire arena, its render targets,
+    /// its text atlas and every category buffer — tens of megabytes each. Held
+    /// while another viewport is asking for an allocation, that is the
+    /// difference between a degraded frame and a session that cannot recover.
+    ///
+    /// Everything released here is derived state with a rebuild path guarded by
+    /// a cache key, and every one of those keys is reset, so the next frame that
+    /// needs this slot builds it again. The cost of releasing a slot that turns
+    /// out to be needed is one slow frame.
+    pub(crate) fn release_heavy_resources(&mut self, device: &wgpu::Device) {
+        self.forget_cached_keys();
+
+        self.gpu_wires = std::sync::Arc::new(Vec::new());
+        self.gpu_block_wires = std::sync::Arc::new(Vec::new());
+        self.wire_handle_index = std::sync::Arc::new(rustc_hash::FxHashMap::default());
+        self.wire_arena = None;
+        self.wire_arena_mesh = None;
+        self.wire_arena_fallback = std::sync::Arc::new(Vec::new());
+        self.wire_arena_fallback_kind = None;
+        self.wire_arena_fallback_handles.clear();
+        self.wire_arena_id = u64::MAX;
+
+        self.gpu_selected_wires.clear();
+        self.gpu_selected_block_wires.clear();
+        self.gpu_preview_wires.clear();
+        self.gpu_wipeouts.clear();
+        self.wipeout_skip_flags.clear();
+        self.gpu_images.clear();
+        self.gpu_mesh_batch.clear();
+        self.gpu_mesh_dynamic.clear();
+        self.mesh_disabled_chunks.clear();
+        self.mesh_dynamic_handles.clear();
+        self.mesh_ranges_by_handle.clear();
+        self.mesh_highlight_draws.clear();
+        self.silhouette_chunks.clear();
+        self.silhouette_source_groups.clear();
+        self.clip_boundary = None;
+
+        self.text_atlas_gpu = None;
+        self.text_gpu.clear();
+        self.block_text_gpu.clear();
+        self.block_text_highlight_gpu.clear();
+        self.text_highlight_gpu.clear();
+        self.text_preview_gpu.clear();
+
+        // Back to the smallest allocation the rounding allows (128x128, about
+        // 0.6 MiB against the ~70 MiB a full-canvas slot holds). Going through
+        // `ensure_depth_texture` rather than reaching for the textures directly
+        // keeps the blit bind group consistent with the views it samples.
+        self.ensure_depth_texture(device, Size::new(1, 1));
+        // ...and make the next real size a mismatch, so it reallocates.
+        self.alloc_size = Size::new(0, 0);
+    }
+
     pub fn ensure_depth_texture(&mut self, device: &wgpu::Device, size: Size<u32>) {
         // Record the requested render size every frame (the blit UV scale reads
         // it); only reallocate the textures when the *rounded* size changes.
@@ -4783,6 +4869,49 @@ impl Pipeline {
 }
 
 impl MultiPipeline {
+    /// Hand back the device memory of slots nobody is drawing.
+    ///
+    /// `reserved` are the slots this frame is about to use; they are never
+    /// touched. Everything else is released once it has been idle for
+    /// `idle_frames` prepare calls — gradually, so an ordinary session pays
+    /// nothing and a layout the user keeps switching back to stays warm.
+    ///
+    /// `urgent` drops that patience: the device has just refused an allocation,
+    /// and holding a viewport nobody can see is what turns a degraded frame
+    /// into a session that never recovers. Releasing early costs one slow frame
+    /// if the slot is wanted again; not releasing costs the drawing.
+    ///
+    /// Returns how many slots were released.
+    pub(crate) fn release_idle_slots(
+        &mut self,
+        device: &wgpu::Device,
+        reserved: &[usize],
+        urgent: bool,
+    ) -> usize {
+        const IDLE_FRAMES: u64 = 64;
+        let idle_frames = if urgent { 0 } else { IDLE_FRAMES };
+        let mut released = 0;
+        for index in 0..self.inners.len() {
+            if reserved.contains(&index) {
+                continue;
+            }
+            let idle = self.slot_clock.saturating_sub(self.slot_last_used[index]);
+            if idle < idle_frames {
+                continue;
+            }
+            // Nothing to give back — releasing again would only churn the
+            // render targets it just rebuilt at their smallest size.
+            if self.inners[index].gpu_live_bytes().wire_arena == 0
+                && self.inners[index].alloc_size == Size::new(0, 0)
+            {
+                continue;
+            }
+            self.inners[index].release_heavy_resources(device);
+            released += 1;
+        }
+        released
+    }
+
     /// Sum across slots, plus the caches held once for all of them.
     pub(crate) fn gpu_live_bytes(&self) -> GpuLiveBytes {
         let mut total = GpuLiveBytes {

--- a/src/scene/pipeline/mod.rs
+++ b/src/scene/pipeline/mod.rs
@@ -4727,6 +4727,80 @@ fn aabb_below_pixel(
     (max_px - min_px).max(max_py - min_py) < threshold_px
 }
 
+/// Device bytes a renderer is holding, counted from the sizes it allocated
+/// rather than from process RSS — the allocator and the driver both keep
+/// high-water memory that RSS cannot distinguish from live resources.
+///
+/// Partial by construction: it covers the categories large enough to decide
+/// where the next fix goes, and says so rather than pretending to be a total.
+#[derive(Default, Clone, Copy, PartialEq)]
+pub(crate) struct GpuLiveBytes {
+    pub slots: usize,
+    pub shadow: u64,
+    pub render_targets: u64,
+    pub text_atlas: u64,
+    pub wire_arena: u64,
+    pub block_geometry: u64,
+}
+
+impl GpuLiveBytes {
+    pub(crate) fn total(&self) -> u64 {
+        self.shadow + self.render_targets + self.text_atlas + self.wire_arena + self.block_geometry
+    }
+}
+
+impl Pipeline {
+    /// This slot's share. `alloc_size` is the real allocation, which is rounded
+    /// up from the requested size and grows only.
+    fn gpu_live_bytes(&self) -> GpuLiveBytes {
+        // 4x MSAA colour (4 B/sample) + 4x MSAA depth-stencil (4 B/sample) +
+        // one single-sample resolve target.
+        const BYTES_PER_PIXEL: u64 = (MSAA_SAMPLES as u64) * 4 + (MSAA_SAMPLES as u64) * 4 + 4;
+        let pixels = u64::from(self.alloc_size.width) * u64::from(self.alloc_size.height);
+        GpuLiveBytes {
+            slots: 1,
+            // Allocated by every slot whether or not shadows are enabled.
+            shadow: u64::from(SHADOW_MAP_SIZE) * u64::from(SHADOW_MAP_SIZE) * 4,
+            render_targets: pixels * BYTES_PER_PIXEL,
+            text_atlas: self
+                .text_atlas_gpu
+                .as_ref()
+                .map(text_gpu::TextAtlasGpu::gpu_bytes)
+                .unwrap_or(0),
+            wire_arena: self
+                .wire_arena
+                .as_ref()
+                .map(wire_arena::PersistentWireArena::gpu_bytes)
+                .unwrap_or(0)
+                + self
+                    .wire_arena_mesh
+                    .as_ref()
+                    .map(wire_arena::PersistentWireArena::gpu_bytes)
+                    .unwrap_or(0),
+            block_geometry: 0,
+        }
+    }
+}
+
+impl MultiPipeline {
+    /// Sum across slots, plus the caches held once for all of them.
+    pub(crate) fn gpu_live_bytes(&self) -> GpuLiveBytes {
+        let mut total = GpuLiveBytes {
+            block_geometry: wire_gpu::block_geometry_bytes(&self.block_geometry),
+            ..Default::default()
+        };
+        for inner in &self.inners {
+            let slot = inner.gpu_live_bytes();
+            total.slots += slot.slots;
+            total.shadow += slot.shadow;
+            total.render_targets += slot.render_targets;
+            total.text_atlas += slot.text_atlas;
+            total.wire_arena += slot.wire_arena;
+        }
+        total
+    }
+}
+
 /// Bind one block-wire batch and draw it.
 ///
 /// The two pipeline modes lay the vertex slots out differently — packed puts

--- a/src/scene/pipeline/text_gpu.rs
+++ b/src/scene/pipeline/text_gpu.rs
@@ -221,6 +221,11 @@ pub struct TextAtlasGpu {
 }
 
 impl TextAtlasGpu {
+    /// Device bytes this atlas holds. `R8`, so one byte per texel.
+    pub fn gpu_bytes(&self) -> u64 {
+        u64::from(self._texture.width()) * u64::from(self._texture.height())
+    }
+
     /// Bind-group layout for group 1: `{ R8 atlas texture, linear sampler }`.
     pub fn bind_group_layout(device: &wgpu::Device) -> wgpu::BindGroupLayout {
         device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {

--- a/src/scene/pipeline/wire_arena.rs
+++ b/src/scene/pipeline/wire_arena.rs
@@ -1369,6 +1369,18 @@ impl PersistentWireArena {
         }
     }
 
+    /// Device bytes this arena holds. The instance buffer is reserved with
+    /// headroom, so this is the allocation, not the occupied prefix — which is
+    /// what a memory budget has to answer for.
+    pub fn gpu_bytes(&self) -> u64 {
+        match &self.inner {
+            PersistentWireArenaKind::Indexed(arena) => {
+                arena.inst_buf.size() + arena.const_buf.size()
+            }
+            PersistentWireArenaKind::Packed(arena) => arena.inst_buf.size(),
+        }
+    }
+
     pub fn wire_gpus_visible(
         &self,
         view_rot: glam::Mat4,

--- a/src/scene/pipeline/wire_gpu.rs
+++ b/src/scene/pipeline/wire_gpu.rs
@@ -334,7 +334,9 @@ impl BlockWireInstance {
 
 #[derive(Clone)]
 pub struct BlockWireGpu {
-    pub vertex_buffer: wgpu::Buffer,
+    /// Packed mode only; `None` in storage mode, where the segments reach the
+    /// shader through `const_bind_group` instead.
+    pub vertex_buffer: Option<wgpu::Buffer>,
     pub instance_buffer: wgpu::Buffer,
     pub vertex_count: u32,
     pub instance_count: u32,
@@ -342,19 +344,38 @@ pub struct BlockWireGpu {
     pub const_bind_group: std::sync::Arc<wgpu::BindGroup>,
 }
 
-pub fn block_const_bind_group_layout(device: &wgpu::Device) -> wgpu::BindGroupLayout {
-    device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-        label: Some("block_wire_const.bgl"),
-        entries: &[wgpu::BindGroupLayoutEntry {
-            binding: 0,
+/// Binding 0 is the definition's constants. In storage mode binding 1 carries
+/// that chunk's segments, which is why the bind group is per-chunk there and
+/// shared across chunks in packed mode.
+pub fn block_const_bind_group_layout(
+    device: &wgpu::Device,
+    uses_storage: bool,
+) -> wgpu::BindGroupLayout {
+    let mut entries = vec![wgpu::BindGroupLayoutEntry {
+        binding: 0,
+        visibility: wgpu::ShaderStages::VERTEX,
+        ty: wgpu::BindingType::Buffer {
+            ty: wgpu::BufferBindingType::Uniform,
+            has_dynamic_offset: false,
+            min_binding_size: None,
+        },
+        count: None,
+    }];
+    if uses_storage {
+        entries.push(wgpu::BindGroupLayoutEntry {
+            binding: 1,
             visibility: wgpu::ShaderStages::VERTEX,
             ty: wgpu::BindingType::Buffer {
-                ty: wgpu::BufferBindingType::Uniform,
+                ty: wgpu::BufferBindingType::Storage { read_only: true },
                 has_dynamic_offset: false,
                 min_binding_size: None,
             },
             count: None,
-        }],
+        });
+    }
+    device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+        label: Some("block_wire_const.bgl"),
+        entries: &entries,
     })
 }
 
@@ -669,23 +690,64 @@ pub(crate) fn wire_draw_depth(
 /// Vertices use the first instance's world coordinates, so changing that base
 /// must invalidate the geometry as well as rebuild the relative placements.
 pub type BlockGeometryCache = rustc_hash::FxHashMap<
-    (u64, bool, [u32; 4], [u64; 3]),
-    (
-        std::sync::Arc<Vec<(wgpu::Buffer, u32)>>,
-        std::sync::Arc<wgpu::BindGroup>,
-    ),
+    BlockGeometryKey,
+    std::sync::Arc<Vec<BlockGeometryChunk>>,
 >;
 
+/// How this device draws block wires. The layout and the mode are decided
+/// together when the pipeline is built and are never chosen independently, so
+/// they travel as one argument.
+#[derive(Clone, Copy)]
+pub struct BlockWireTarget<'a> {
+    pub const_bgl: &'a wgpu::BindGroupLayout,
+    pub mode: WirePipelineMode,
+}
+
+/// `(source_id, mesh_edge, colour bits, base translation bits)`.
+pub type BlockGeometryKey = (u64, bool, [u32; 4], [u64; 3]);
+
+/// One drawable slice of a block definition's geometry.
+///
+/// The two pipeline modes put the segments in different places, so the chunk
+/// carries whichever the mode produced:
+///
+/// * packed — `vertex_buffer` holds six copies of each segment, one per corner
+///   of its quad, and `bind_group` is the definition's constants alone;
+/// * storage — the segments are in a read-only storage buffer inside
+///   `bind_group`, one copy each, and `vertex_buffer` is `None`.
+///
+/// `vertex_count` is six per segment either way: in storage mode the shader
+/// divides `vertex_index` by six to find its segment.
+pub struct BlockGeometryChunk {
+    pub vertex_buffer: Option<wgpu::Buffer>,
+    pub vertex_count: u32,
+    pub bind_group: std::sync::Arc<wgpu::BindGroup>,
+}
+
 impl BlockWireGpu {
+    /// Identity of the geometry this batch draws, comparable across pipeline
+    /// modes.
+    ///
+    /// Packed mode keeps the segments in `vertex_buffer`; storage mode keeps
+    /// them inside `const_bind_group`, which is per-chunk there, and leaves
+    /// `vertex_buffer` `None`. Both are built on the same cache miss and
+    /// reused together on a hit, so the pair answers "is this the same
+    /// geometry as before?" in either mode — which `vertex_buffer` alone
+    /// cannot once it is always `None`.
+    pub fn geometry_id(&self) -> (Option<&wgpu::Buffer>, &wgpu::BindGroup) {
+        (self.vertex_buffer.as_ref(), self.const_bind_group.as_ref())
+    }
+
     pub fn from_wires(
         device: &wgpu::Device,
         queue: &wgpu::Queue,
         wires: &[&WireModel],
         depth_map: &rustc_hash::FxHashMap<u64, [f32; 2]>,
         color_override: Option<[f32; 4]>,
-        const_bgl: &wgpu::BindGroupLayout,
+        target: BlockWireTarget<'_>,
         mut cache: Option<&mut BlockGeometryCache>,
     ) -> Vec<Self> {
+        let BlockWireTarget { const_bgl, mode } = target;
         let mut slots: rustc_hash::FxHashMap<(u64, bool), usize> =
             rustc_hash::FxHashMap::default();
         let mut groups: Vec<(bool, Vec<&WireModel>)> = Vec::new();
@@ -710,7 +772,12 @@ impl BlockWireGpu {
         }
 
         let mut out = Vec::new();
-        let mut live_keys = rustc_hash::FxHashSet::default();
+        let mut live_keys: rustc_hash::FxHashSet<BlockGeometryKey> =
+            rustc_hash::FxHashSet::default();
+        // Geometry bytes actually sent to the device this call, so the storage
+        // path's saving is visible rather than assumed.
+        let mut uploaded_bytes = 0usize;
+        let mut uploaded_segments = 0usize;
         for (mesh_edge, group) in groups {
             let Some(&source) = group.first() else {
                 continue;
@@ -727,21 +794,13 @@ impl BlockWireGpu {
             );
             live_keys.insert(cache_key);
             // Reuse this definition's geometry when it is already on the GPU.
-            if let Some((chunks, bind_group)) = cache
+            if let Some(chunks) = cache
                 .as_deref()
                 .and_then(|c| c.get(&cache_key))
-                .map(|(v, b)| (std::sync::Arc::clone(v), std::sync::Arc::clone(b)))
+                .map(std::sync::Arc::clone)
             {
                 let instances = block_instances(&group, base, mesh_edge, depth_map);
-                push_block_batches(
-                    &mut out,
-                    device,
-                    queue,
-                    &chunks,
-                    &instances,
-                    mesh_edge,
-                    &bind_group,
-                );
+                push_block_batches(&mut out, device, queue, &chunks, &instances, mesh_edge);
                 continue;
             }
             let (segments, mut constant) = emit_wire_native(source, 0, color, 0.0);
@@ -749,34 +808,15 @@ impl BlockWireGpu {
                 continue;
             }
             constant.draw_depth = 0.0;
-            let mut vertices = Vec::with_capacity(segments.len() * 6);
-            for segment in segments {
-                let vertex = BlockWireVertex {
+            let records: Vec<BlockWireVertex> = segments
+                .iter()
+                .map(|segment| BlockWireVertex {
                     pos_a: segment.pos_a,
                     pos_a_low: segment.pos_a_low,
                     pos_b: segment.pos_b,
                     pos_b_low: segment.pos_b_low,
                     distances: [segment.distance_a, segment.distance_b],
                     taper_ratio: segment.taper_ratio,
-                };
-                vertices.extend_from_slice(&[vertex; 6]);
-            }
-            // Bound uploads without splitting a segment's six vertices.
-            let max_verts =
-                super::gpu_budget::max_elements_grouped::<BlockWireVertex>(device, 6);
-            let vertex_chunks: Vec<(wgpu::Buffer, u32)> = vertices
-                .chunks(max_verts)
-                .map(|chunk| {
-                    (
-                        super::gpu_upload::upload_buffer(
-                            device,
-                            queue,
-                            "block_wire.vertices",
-                            chunk,
-                            wgpu::BufferUsages::VERTEX,
-                        ),
-                        chunk.len() as u32,
-                    )
                 })
                 .collect();
             // Queue uploads avoid mapping a failed allocation.
@@ -787,40 +827,105 @@ impl BlockWireGpu {
                 std::slice::from_ref(&constant),
                 wgpu::BufferUsages::UNIFORM,
             );
-            let const_bind_group = std::sync::Arc::new(device.create_bind_group(
-                &wgpu::BindGroupDescriptor {
-                    label: Some("block_wire.const.bg"),
-                    layout: const_bgl,
-                    entries: &[wgpu::BindGroupEntry {
-                        binding: 0,
-                        resource: const_buffer.as_entire_binding(),
-                    }],
-                },
-            ));
-            let vertex_chunks = std::sync::Arc::new(vertex_chunks);
+            // Bound uploads so a block-heavy drawing cannot ask a low-VRAM
+            // device for one multi-hundred-MB buffer.
+            let chunks: Vec<BlockGeometryChunk> = if mode.uses_storage() {
+                // One record per segment. A storage chunk is bounded by the
+                // binding size as well as the buffer budget, and needs no
+                // grouping: the shader indexes segments directly.
+                let max_records =
+                    super::gpu_budget::max_storage_elements::<BlockWireVertex>(device);
+                records
+                    .chunks(max_records)
+                    .map(|chunk| {
+                        let segments = super::gpu_upload::upload_buffer(
+                            device,
+                            queue,
+                            "block_wire.segments",
+                            chunk,
+                            wgpu::BufferUsages::STORAGE,
+                        );
+                        BlockGeometryChunk {
+                            vertex_buffer: None,
+                            vertex_count: chunk.len() as u32 * 6,
+                            bind_group: std::sync::Arc::new(device.create_bind_group(
+                                &wgpu::BindGroupDescriptor {
+                                    label: Some("block_wire.const.bg"),
+                                    layout: const_bgl,
+                                    entries: &[
+                                        wgpu::BindGroupEntry {
+                                            binding: 0,
+                                            resource: const_buffer.as_entire_binding(),
+                                        },
+                                        wgpu::BindGroupEntry {
+                                            binding: 1,
+                                            resource: segments.as_entire_binding(),
+                                        },
+                                    ],
+                                },
+                            )),
+                        }
+                    })
+                    .collect()
+            } else {
+                // Six copies per segment, one per corner of its quad, without
+                // splitting a segment's six vertices across two buffers.
+                let mut vertices = Vec::with_capacity(records.len() * 6);
+                for record in &records {
+                    vertices.extend_from_slice(&[*record; 6]);
+                }
+                let max_verts =
+                    super::gpu_budget::max_elements_grouped::<BlockWireVertex>(device, 6);
+                let shared = std::sync::Arc::new(device.create_bind_group(
+                    &wgpu::BindGroupDescriptor {
+                        label: Some("block_wire.const.bg"),
+                        layout: const_bgl,
+                        entries: &[wgpu::BindGroupEntry {
+                            binding: 0,
+                            resource: const_buffer.as_entire_binding(),
+                        }],
+                    },
+                ));
+                vertices
+                    .chunks(max_verts)
+                    .map(|chunk| BlockGeometryChunk {
+                        vertex_buffer: Some(super::gpu_upload::upload_buffer(
+                            device,
+                            queue,
+                            "block_wire.vertices",
+                            chunk,
+                            wgpu::BufferUsages::VERTEX,
+                        )),
+                        vertex_count: chunk.len() as u32,
+                        bind_group: std::sync::Arc::clone(&shared),
+                    })
+                    .collect()
+            };
+            uploaded_segments += records.len();
+            uploaded_bytes += records.len()
+                * std::mem::size_of::<BlockWireVertex>()
+                * if mode.uses_storage() { 1 } else { 6 };
+            let chunks = std::sync::Arc::new(chunks);
             if let Some(cache) = cache.as_deref_mut() {
-                cache.insert(
-                    cache_key,
-                    (
-                        std::sync::Arc::clone(&vertex_chunks),
-                        std::sync::Arc::clone(&const_bind_group),
-                    ),
-                );
+                cache.insert(cache_key, std::sync::Arc::clone(&chunks));
             }
             let instances = block_instances(&group, base, mesh_edge, depth_map);
-            push_block_batches(
-                &mut out,
-                device,
-                queue,
-                &vertex_chunks,
-                &instances,
-                mesh_edge,
-                &const_bind_group,
-            );
+            push_block_batches(&mut out, device, queue, &chunks, &instances, mesh_edge);
         }
         // Release geometry that this build no longer uses.
         if let Some(cache) = cache {
             cache.retain(|key, _| live_keys.contains(key));
+        }
+        if crate::perf::enabled() && uploaded_segments > 0 {
+            crate::perf_record!(
+                "[perf] block-wire-geometry mode={} definitions={} segments={} bytes={} \
+bytes_if_packed={}",
+                if mode.uses_storage() { "storage" } else { "packed" },
+                live_keys.len(),
+                uploaded_segments,
+                uploaded_bytes,
+                uploaded_segments * std::mem::size_of::<BlockWireVertex>() * 6,
+            );
         }
         out
     }
@@ -863,16 +968,15 @@ fn block_instances(
         .collect()
 }
 
-/// One batch per (vertex chunk × instance chunk). Instance buffers are built
-/// once and shared across vertex chunks rather than re-uploaded per chunk.
+/// One batch per (geometry chunk × instance chunk). Instance buffers are built
+/// once and shared across geometry chunks rather than re-uploaded per chunk.
 fn push_block_batches(
     out: &mut Vec<BlockWireGpu>,
     device: &wgpu::Device,
     queue: &wgpu::Queue,
-    vertex_chunks: &[(wgpu::Buffer, u32)],
+    chunks: &[BlockGeometryChunk],
     instances: &[BlockWireInstance],
     mesh_edge: bool,
-    const_bind_group: &std::sync::Arc<wgpu::BindGroup>,
 ) {
     let max_instances = super::gpu_budget::max_elements::<BlockWireInstance>(device);
     let instance_chunks: Vec<(wgpu::Buffer, u32)> = instances
@@ -884,15 +988,15 @@ fn push_block_batches(
             )
         })
         .collect();
-    for (vertex_buffer, vertex_count) in vertex_chunks {
+    for chunk in chunks {
         for (instance_buffer, instance_count) in &instance_chunks {
             out.push(BlockWireGpu {
-                vertex_buffer: vertex_buffer.clone(),
+                vertex_buffer: chunk.vertex_buffer.clone(),
                 instance_buffer: instance_buffer.clone(),
-                vertex_count: *vertex_count,
+                vertex_count: chunk.vertex_count,
                 instance_count: *instance_count,
                 is_3d_mesh_edge: mesh_edge,
-                const_bind_group: const_bind_group.clone(),
+                const_bind_group: std::sync::Arc::clone(&chunk.bind_group),
             });
         }
     }
@@ -1269,5 +1373,62 @@ impl WireGpu {
                 }
             })
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod block_wire_storage_tests {
+    use super::BlockWireVertex;
+
+    fn module(source: &str) -> naga::Module {
+        naga::front::wgsl::parse_str(source).expect("shader parses")
+    }
+
+    fn validate(module: &naga::Module) -> naga::valid::ModuleInfo {
+        naga::valid::Validator::new(
+            naga::valid::ValidationFlags::all(),
+            naga::valid::Capabilities::all(),
+        )
+        .validate(module)
+        .expect("shader validates")
+    }
+
+    /// A layout mismatch here is invisible until a block draws as garbage on a
+    /// real device, so the stride is checked against the Rust record instead.
+    #[test]
+    fn segment_struct_matches_the_rust_record() {
+        let module = module(include_str!("../../shaders/block_wire_storage.wgsl"));
+        validate(&module);
+        let mut layouter = naga::proc::Layouter::default();
+        layouter
+            .update(module.to_ctx())
+            .expect("layouts are computable");
+        let (handle, _) = module
+            .types
+            .iter()
+            .find(|(_, ty)| ty.name.as_deref() == Some("Segment"))
+            .expect("Segment is declared");
+        assert_eq!(
+            layouter[handle].size as usize,
+            std::mem::size_of::<BlockWireVertex>(),
+            "WGSL Segment and Rust BlockWireVertex must agree byte for byte; \
+             a vec3 member would pad to 16 and break this",
+        );
+        assert_eq!(layouter[handle].alignment * 1u32, 4);
+    }
+
+    /// The two shaders must stay interchangeable: same entry points, same
+    /// fragment behaviour. Only the geometry source differs.
+    #[test]
+    fn both_block_wire_shaders_expose_the_same_entry_points() {
+        let packed = module(include_str!("../../shaders/block_wire.wgsl"));
+        let storage = module(include_str!("../../shaders/block_wire_storage.wgsl"));
+        validate(&packed);
+        let names = |m: &naga::Module| {
+            let mut n: Vec<String> = m.entry_points.iter().map(|e| e.name.clone()).collect();
+            n.sort();
+            n
+        };
+        assert_eq!(names(&packed), names(&storage));
     }
 }

--- a/src/scene/pipeline/wire_gpu.rs
+++ b/src/scene/pipeline/wire_gpu.rs
@@ -703,6 +703,15 @@ pub struct BlockWireTarget<'a> {
     pub mode: WirePipelineMode,
 }
 
+/// Device bytes held by a whole block-geometry cache.
+pub fn block_geometry_bytes(cache: &BlockGeometryCache) -> u64 {
+    cache
+        .values()
+        .flat_map(|chunks| chunks.iter())
+        .map(|chunk| chunk.gpu_bytes)
+        .sum()
+}
+
 /// `(source_id, mesh_edge, colour bits, base translation bits)`.
 pub type BlockGeometryKey = (u64, bool, [u32; 4], [u64; 3]);
 
@@ -722,6 +731,9 @@ pub struct BlockGeometryChunk {
     pub vertex_buffer: Option<wgpu::Buffer>,
     pub vertex_count: u32,
     pub bind_group: std::sync::Arc<wgpu::BindGroup>,
+    /// Device bytes this chunk holds. Recorded at build because in storage mode
+    /// the buffer is owned by `bind_group` and cannot be measured from here.
+    pub gpu_bytes: u64,
 }
 
 impl BlockWireGpu {
@@ -856,6 +868,7 @@ impl BlockWireGpu {
                         BlockGeometryChunk {
                             vertex_buffer: None,
                             vertex_count: chunk.len() as u32 * 6,
+                            gpu_bytes: std::mem::size_of_val(chunk) as u64,
                             bind_group: std::sync::Arc::new(device.create_bind_group(
                                 &wgpu::BindGroupDescriptor {
                                     label: Some("block_wire.const.bg"),
@@ -897,6 +910,7 @@ impl BlockWireGpu {
                 vertices
                     .chunks(max_verts)
                     .map(|chunk| BlockGeometryChunk {
+                        gpu_bytes: std::mem::size_of_val(chunk) as u64,
                         vertex_buffer: Some(super::gpu_upload::upload_buffer(
                             device,
                             queue,

--- a/src/scene/pipeline/wire_gpu.rs
+++ b/src/scene/pipeline/wire_gpu.rs
@@ -778,6 +778,8 @@ impl BlockWireGpu {
         // path's saving is visible rather than assumed.
         let mut uploaded_bytes = 0usize;
         let mut uploaded_segments = 0usize;
+        // Definitions whose upload the device rejected, so they were not cached.
+        let mut poisoned = 0usize;
         for (mesh_edge, group) in groups {
             let Some(&source) = group.first() else {
                 continue;
@@ -803,6 +805,12 @@ impl BlockWireGpu {
                 push_block_batches(&mut out, device, queue, &chunks, &instances, mesh_edge);
                 continue;
             }
+            // A failed allocation still produces a `Buffer`; it is simply
+            // invalid, and every later use of it reports again. Cached, it
+            // freezes the viewport for the rest of the session because the key
+            // keeps hitting and nothing ever rebuilds. Watch the device's error
+            // count across the build and refuse to cache what it condemns.
+            let errors_before = super::gpu_errors_seen();
             let (segments, mut constant) = emit_wire_native(source, 0, color, 0.0);
             if segments.is_empty() {
                 continue;
@@ -906,8 +914,17 @@ impl BlockWireGpu {
                 * std::mem::size_of::<BlockWireVertex>()
                 * if mode.uses_storage() { 1 } else { 6 };
             let chunks = std::sync::Arc::new(chunks);
-            if let Some(cache) = cache.as_deref_mut() {
-                cache.insert(cache_key, std::sync::Arc::clone(&chunks));
+            let built_clean = super::gpu_errors_seen() == errors_before;
+            if built_clean {
+                if let Some(cache) = cache.as_deref_mut() {
+                    cache.insert(cache_key, std::sync::Arc::clone(&chunks));
+                }
+            } else {
+                // Draw this frame with what we have — a degraded frame beats a
+                // blank one — but leave the cache clean so the next frame tries
+                // again. `live_keys` still holds the key, so the retain below
+                // does not evict a good entry from an earlier frame.
+                poisoned += 1;
             }
             let instances = block_instances(&group, base, mesh_edge, depth_map);
             push_block_batches(&mut out, device, queue, &chunks, &instances, mesh_edge);
@@ -919,12 +936,13 @@ impl BlockWireGpu {
         if crate::perf::enabled() && uploaded_segments > 0 {
             crate::perf_record!(
                 "[perf] block-wire-geometry mode={} definitions={} segments={} bytes={} \
-bytes_if_packed={}",
+bytes_if_packed={} poisoned={}",
                 if mode.uses_storage() { "storage" } else { "packed" },
                 live_keys.len(),
                 uploaded_segments,
                 uploaded_bytes,
                 uploaded_segments * std::mem::size_of::<BlockWireVertex>() * 6,
+                poisoned,
             );
         }
         out

--- a/src/scene/view/render.rs
+++ b/src/scene/view/render.rs
@@ -714,6 +714,9 @@ impl shader::Primitive for Primitive {
                             })
                         })
                     };
+                    // Snapshot before any arena allocation, so a rejected
+                    // upload cannot claim this content id below.
+                    let arena_errors_before = crate::scene::pipeline::gpu_errors_seen();
                     let reg_ok = base_ok
                         && if let Some(arena) = inner.wire_arena.as_mut() {
                             let patch = patch.unwrap();
@@ -868,7 +871,15 @@ impl shader::Primitive for Primitive {
                             inner.wire_handle_index =
                                 wire_arena::build_handle_index(&vp_wires[..]);
                         }
-                        inner.wire_arena_id = vp.wire_content_id;
+                        // Only claim the content id when the device accepted
+                        // the upload; otherwise the slot believes it holds this
+                        // content and never rebuilds it.
+                        inner.wire_arena_id =
+                            if crate::scene::pipeline::gpu_errors_seen() == arena_errors_before {
+                                vp.wire_content_id
+                            } else {
+                                u64::MAX
+                            };
                         arena_served = true;
                     } else {
                         inner.wire_arena = None;
@@ -922,6 +933,8 @@ impl shader::Primitive for Primitive {
                                 );
                             }
                             let t_upload = _perf.then(iced::time::Instant::now);
+                            let errors_before =
+                                crate::scene::pipeline::gpu_errors_seen();
                             let entry =
                                 inner.build_wire_buffers(device, queue, &vp_wires[..], &draw_depths);
                             if let Some(start) = t_upload {
@@ -933,9 +946,16 @@ impl shader::Primitive for Primitive {
                                 );
                             }
 
-                            pipeline
-                                .wire_buffer_cache
-                                .insert(vp.wire_content_id, entry.clone());
+                            // Buffers the device rejected are still `Buffer`s.
+                            // Cached under a content id that keeps matching,
+                            // they render nothing for the rest of the session
+                            // and nothing ever rebuilds them. Draw the degraded
+                            // frame, but let the next one try again.
+                            if crate::scene::pipeline::gpu_errors_seen() == errors_before {
+                                pipeline
+                                    .wire_buffer_cache
+                                    .insert(vp.wire_content_id, entry.clone());
+                            }
                             entry
                         }
                     };

--- a/src/scene/view/render.rs
+++ b/src/scene/view/render.rs
@@ -1217,6 +1217,7 @@ impl shader::Primitive for Primitive {
                 self.viewports.len(),
             );
         }
+        report_gpu_live(pipeline);
     }
 
     fn render(
@@ -1567,6 +1568,42 @@ fn solar_direction(
 }
 
 // ── Render-style helpers (impl Scene) ────────────────────────────────────
+
+/// Report what the renderer is holding on the device, when it changes.
+///
+/// Only on change: `prepare` runs thousands of times a session and these
+/// numbers move a handful of times. RSS is deliberately not used — the
+/// allocator and the driver both retain high-water memory that RSS cannot tell
+/// apart from live resources.
+fn report_gpu_live(pipeline: &crate::scene::pipeline::MultiPipeline) {
+    use std::cell::Cell;
+    if !crate::perf::enabled() {
+        return;
+    }
+    thread_local! {
+        static LAST: Cell<Option<crate::scene::pipeline::GpuLiveBytes>> = const { Cell::new(None) };
+    }
+    let now = pipeline.gpu_live_bytes();
+    LAST.with(|last| {
+        if last.get() == Some(now) {
+            return;
+        }
+        last.set(Some(now));
+        const MIB: f64 = 1024.0 * 1024.0;
+        let mib = |bytes: u64| bytes as f64 / MIB;
+        crate::perf_record!(
+            "[perf] gpu-live slots={} total={:.1}MiB shadow={:.1} targets={:.1} \
+text_atlas={:.1} wire_arena={:.1} block_geometry={:.1}",
+            now.slots,
+            mib(now.total()),
+            mib(now.shadow),
+            mib(now.render_targets),
+            mib(now.text_atlas),
+            mib(now.wire_arena),
+            mib(now.block_geometry),
+        );
+    });
+}
 
 impl Scene {
     fn model_tile_vport(&self, index: usize) -> Option<&acadrust::tables::VPort> {

--- a/src/scene/view/render.rs
+++ b/src/scene/view/render.rs
@@ -424,7 +424,7 @@ impl shader::Primitive for Primitive {
                 vp.background_image.as_ref(),
                 vp.environment_image.as_ref(),
             );
-            inner.upload_uniforms(queue, &vp.uniforms);
+            inner.upload_uniforms(device, queue, &vp.uniforms);
 
             // ── Scene-render cache ────────────────────────────────────────
             // A pure cursor move — or any frame where the view, geometry,

--- a/src/scene/view/render.rs
+++ b/src/scene/view/render.rs
@@ -373,6 +373,12 @@ impl shader::Primitive for Primitive {
 
         for (i, vp) in self.viewports.iter().enumerate() {
             let inner = &mut pipeline.inners[slots[i]];
+            // Compared at the end of this viewport's turn. Every "we hold this
+            // now" latch below is stamped after its upload, whether or not the
+            // device accepted it — and the wire latch gates the whole upload
+            // block, so one rejected allocation could leave a slotpermanently empty with
+            // nothing that would ever rebuild it.
+            let slot_errors_before = crate::scene::pipeline::gpu_errors_seen();
             // Pipeline slots are addressed by list index, but off-canvas
             // viewports are dropped from the list — so a slot can be reused by a
             // DIFFERENT viewport across frames (e.g. the first viewport scrolls
@@ -1179,6 +1185,15 @@ impl shader::Primitive for Primitive {
                     vp.hover_region,
                     self.viewcube_text_color,
                 );
+            }
+
+            // A rejected allocation leaves buffers that are invalid but
+            // indistinguishable from good ones at every cache key. Forget
+            // them all, so the next frame rebuilds this slot instead of
+            // drawing nothing for the rest of the session — which is what
+            // sent a user to REGENALL to get the model back.
+            if crate::scene::pipeline::gpu_errors_seen() != slot_errors_before {
+                inner.forget_cached_keys();
             }
         }
         let prepare_ms = nav_prepare_started.elapsed().as_secs_f64() * 1000.0;

--- a/src/scene/view/render.rs
+++ b/src/scene/view/render.rs
@@ -367,6 +367,9 @@ impl shader::Primitive for Primitive {
         let scale = viewport.scale_factor() as f32;
         let instance_ids: Vec<u64> = self.viewports.iter().map(|vp| vp.instance_id).collect();
         let slots = pipeline.resolve_slots(device, queue, &instance_ids);
+        // Compared after the frame's uploads: a move means the device refused
+        // something, which changes how patient the slot release below can be.
+        let errors_at_entry = crate::scene::pipeline::gpu_errors_seen();
 
         for (i, vp) in self.viewports.iter().enumerate() {
             let inner = &mut pipeline.inners[slots[i]];
@@ -381,26 +384,7 @@ impl shader::Primitive for Primitive {
             // the surviving viewport's text/geometry vanish.
             if inner.slot_id != vp.instance_id {
                 inner.slot_id = vp.instance_id;
-                inner.cached_epoch = (u64::MAX, u64::MAX, u64::MAX);
-                inner.cached_wire_id = u64::MAX;
-                inner.cached_selection = (u64::MAX, u64::MAX);
-                inner.cached_mesh_content_id = u64::MAX;
-                inner.cached_face3d_key = (u64::MAX, false, false, u64::MAX);
-                inner.cached_solid_visibility =
-                    (u64::MAX, [u32::MAX; 3], u64::MAX);
-                inner.cached_hatch_source = None;
-                inner.cached_preview_hatch_source = None;
-                inner.cached_wipeout_source = None;
-                inner.cached_image_source = None;
-                inner.cached_text_source = None;
-                inner.cached_mesh_source = None;
-                inner.cached_face3d_source = None;
-                inner.cached_face3d_depth_source = None;
-                inner.wire_cull_key = (u64::MAX, u64::MAX, 0, 0);
-                inner.hatch_lod_key = (usize::MAX, u64::MAX, 0, 0, false);
-                inner.wipeout_lod_key = (usize::MAX, u64::MAX, 0, 0, false);
-                inner.silhouette_key = (usize::MAX, u64::MAX, [u32::MAX; 3], false);
-                inner.render_sig = u64::MAX;
+                inner.forget_cached_keys();
             }
             // The MSAA / depth / resolve textures are always sized to the
             // FULL viewport rectangle (not the on-canvas-visible portion)
@@ -1215,6 +1199,20 @@ impl shader::Primitive for Primitive {
                 "[perf] frame-prepare {:>7.1}ms viewports={}",
                 prepare_ms,
                 self.viewports.len(),
+            );
+        }
+        // Give back what nobody is drawing. Gradual while the device is
+        // healthy; immediate once it has refused an allocation, because the
+        // memory a hidden viewport is holding is exactly what the visible one
+        // could not get — and freeing it is what lets the operator close a
+        // viewport or two and carry on instead of restarting.
+        let errors_now = crate::scene::pipeline::gpu_errors_seen();
+        let urgent = errors_now != errors_at_entry;
+        let released = pipeline.release_idle_slots(device, &slots, urgent);
+        if released > 0 && crate::perf::enabled() {
+            crate::perf_record!(
+                "[perf] slots-released n={released} urgent={urgent} slots={}",
+                pipeline.inners.len(),
             );
         }
         report_gpu_live(pipeline);

--- a/src/scene/view/render.rs
+++ b/src/scene/view/render.rs
@@ -860,6 +860,7 @@ impl shader::Primitive for Primitive {
                                 queue,
                                 &instanced,
                                 &draw_depths,
+                                &mut pipeline.block_geometry,
                             ),
                         );
                         if _patched {
@@ -936,7 +937,13 @@ impl shader::Primitive for Primitive {
                             let errors_before =
                                 crate::scene::pipeline::gpu_errors_seen();
                             let entry =
-                                inner.build_wire_buffers(device, queue, &vp_wires[..], &draw_depths);
+                                inner.build_wire_buffers(
+                                    device,
+                                    queue,
+                                    &vp_wires[..],
+                                    &draw_depths,
+                                    &mut pipeline.block_geometry,
+                                );
                             if let Some(start) = t_upload {
                                 crate::perf_record!(
                                     "[perf] wire-upload {:.1}ms wires={} content_id={}",

--- a/src/shaders/block_wire_storage.wgsl
+++ b/src/shaders/block_wire_storage.wgsl
@@ -1,0 +1,323 @@
+// Block-wire vertex shader, storage-buffer variant.
+//
+// `block_wire.wgsl` carries the segment endpoints as vertex attributes, and a
+// segment must reach the shader once per corner of its quad, so every record
+// is written to VRAM six times: 360 bytes a segment. On a block-heavy drawing
+// that is the buffer that runs a 2 GB card out of memory — the OOM names
+// `block_wire.vertices` directly.
+//
+// Here the segments live in a read-only storage buffer indexed by
+// `vertex_index / 6`, so each record is stored once: 60 bytes a segment. The
+// two shaders are otherwise identical, and must stay so.
+//
+// `Segment` is declared with scalar fields rather than `vec3<f32>`, which
+// would align to 16 bytes in storage and reintroduce padding. All-f32 members
+// give it align 4 and stride 60, matching `BlockWireVertex` byte for byte.
+//
+// Requires storage buffers in the vertex stage; callers select
+// `block_wire.wgsl` when `DeviceCapabilities::supports_wire_storage` is false.
+
+struct Uniforms {
+    viewport_size: vec2<f32>,
+    world_per_pixel: f32,
+    lwdisplay_enable: f32,
+    flat_shade: f32,
+    transparency_enable: f32,
+    linetype_scale: f32,
+    lineweight_scale: f32,
+    view_rot: mat4x4<f32>,
+    eye_high: vec3<f32>,
+    _pad_eh: f32,
+    eye_low: vec3<f32>,
+    _pad_el: f32,
+}
+@group(0) @binding(0) var<uniform> u: Uniforms;
+
+struct WireConst {
+    color: vec4<f32>,
+    pat0: vec4<f32>,
+    pat1: vec4<f32>,
+    half_width: f32,
+    pattern_length: f32,
+    draw_depth: f32,
+    align_end: f32,
+    align_total: f32,
+    world_half_width: f32,
+    _pad1: f32,
+    _pad2: f32,
+    marker_origin_high: vec4<f32>,
+    marker_origin_low: vec4<f32>,
+    marker_normal_scale: vec4<f32>,
+}
+@group(1) @binding(0) var<uniform> wire_const: WireConst;
+
+struct Segment {
+    pos_a_x: f32, pos_a_y: f32, pos_a_z: f32,
+    pos_a_low_x: f32, pos_a_low_y: f32, pos_a_low_z: f32,
+    pos_b_x: f32, pos_b_y: f32, pos_b_z: f32,
+    pos_b_low_x: f32, pos_b_low_y: f32, pos_b_low_z: f32,
+    distance_a: f32, distance_b: f32,
+    // Two `u16` unorms packed into one word, as `Unorm16x2` delivered them.
+    taper_ratio: u32,
+}
+@group(1) @binding(1) var<storage, read> segments: array<Segment>;
+
+struct VertexIn {
+    @location(6) translation: vec3<f32>,
+    @location(7) translation_low: vec3<f32>,
+    @location(8) depth: vec2<f32>,
+}
+
+const DRAW_ORDER_BIAS: f32 = 0.001;
+const MODEL_LINEWEIGHT_BOOST: f32 = 2.0;
+const MODEL_LINEWEIGHT_MAX_PX: f32 = 10.0;
+
+struct VertexOut {
+    @builtin(position) clip_pos: vec4<f32>,
+    @location(0) color: vec4<f32>,
+    @location(1) distance: f32,
+    @location(2) pattern_length: f32,
+    @location(3) pat0: vec4<f32>,
+    @location(4) pat1: vec4<f32>,
+    @location(5) @interpolate(flat) min_elem: f32,
+    @location(6) @interpolate(flat) align_end: f32,
+    @location(7) @interpolate(flat) align_total: f32,
+    @location(8) cap: vec2<f32>,
+    @location(9) @interpolate(flat) cap_ends: vec3<f32>,
+}
+
+fn resolve_hw(taper_ratio: f32, world_hw: f32, px_hw: f32) -> f32 {
+    if taper_ratio > 0.0 {
+        return max((taper_ratio * world_hw) / u.world_per_pixel, 0.5);
+    }
+    if world_hw > 0.0 {
+        return max(world_hw / u.world_per_pixel, 0.5);
+    }
+    var display_hw = max(px_hw * u.lineweight_scale, 0.5);
+    if u.lineweight_scale < 0.0 {
+        let scale = -u.lineweight_scale;
+        let base_hw = select(
+            min(px_hw * MODEL_LINEWEIGHT_BOOST, MODEL_LINEWEIGHT_MAX_PX * 0.5),
+            0.5,
+            px_hw <= 0.5,
+        );
+        display_hw = max(base_hw * scale, 0.5);
+    }
+    return select(0.5, display_hw, u.lwdisplay_enable > 0.5);
+}
+
+fn marker_relative(
+    position_high: vec3<f32>,
+    position_low: vec3<f32>,
+    translation: vec3<f32>,
+    translation_low: vec3<f32>,
+) -> vec3<f32> {
+    if wire_const.marker_normal_scale.w <= 0.0 {
+        return (position_high + translation - u.eye_high)
+            + (position_low + translation_low - u.eye_low);
+    }
+    let origin_high = wire_const.marker_origin_high.xyz;
+    let origin_low = wire_const.marker_origin_low.xyz;
+    let origin_relative = (origin_high + translation - u.eye_high)
+        + (origin_low + translation_low - u.eye_low);
+    let delta = (position_high - origin_high) + (position_low - origin_low);
+    let normal = normalize(wire_const.marker_normal_scale.xyz);
+    let axial = normal * dot(delta, normal);
+    let planar = delta - axial;
+    let origin_clip = u.view_rot * vec4<f32>(origin_relative, 1.0);
+    let projection_scale = max(length(vec3<f32>(
+        u.view_rot[0].y,
+        u.view_rot[1].y,
+        u.view_rot[2].y,
+    )), 1e-12);
+    let view_height = 2.0 * max(abs(origin_clip.w), 1e-6) / projection_scale;
+    let world_size = wire_const.marker_normal_scale.w * 0.01 * view_height;
+    return origin_relative + axial + planar * world_size;
+}
+
+@vertex
+fn vs_main(@builtin(vertex_index) vertex_index: u32, in: VertexIn) -> VertexOut {
+    let corner = vertex_index % 6u;
+    let seg = segments[vertex_index / 6u];
+    let seg_pos_a = vec3<f32>(seg.pos_a_x, seg.pos_a_y, seg.pos_a_z);
+    let seg_pos_a_low = vec3<f32>(seg.pos_a_low_x, seg.pos_a_low_y, seg.pos_a_low_z);
+    let seg_pos_b = vec3<f32>(seg.pos_b_x, seg.pos_b_y, seg.pos_b_z);
+    let seg_pos_b_low = vec3<f32>(seg.pos_b_low_x, seg.pos_b_low_y, seg.pos_b_low_z);
+    let seg_distances = vec2<f32>(seg.distance_a, seg.distance_b);
+    let seg_taper_ratio = unpack2x16unorm(seg.taper_ratio);
+    let which_end_arr = array<f32, 6>(0.0, 1.0, 1.0, 0.0, 1.0, 0.0);
+    let side_arr = array<f32, 6>(-1.0, -1.0, 1.0, -1.0, 1.0, 1.0);
+    let which_end = which_end_arr[corner];
+    let side = side_arr[corner];
+
+    let rel_a = marker_relative(seg_pos_a, seg_pos_a_low, in.translation, in.translation_low);
+    let rel_b = marker_relative(seg_pos_b, seg_pos_b_low, in.translation, in.translation_low);
+    let clip_a = u.view_rot * vec4<f32>(rel_a, 1.0);
+    let clip_b = u.view_rot * vec4<f32>(rel_b, 1.0);
+    let screen_a = clip_a.xy / clip_a.w * u.viewport_size * 0.5;
+    let screen_b = clip_b.xy / clip_b.w * u.viewport_size * 0.5;
+    let segment = screen_b - screen_a;
+    let segment_length = length(segment);
+    var direction = vec2<f32>(1.0, 0.0);
+    if segment_length > 1e-4 {
+        direction = segment / segment_length;
+    }
+    let perpendicular = vec2<f32>(-direction.y, direction.x);
+    let clip_position = mix(clip_a, clip_b, which_end);
+    let half_width_a = resolve_hw(
+        seg_taper_ratio.x,
+        wire_const.world_half_width,
+        wire_const.half_width,
+    );
+    let half_width_b = resolve_hw(
+        seg_taper_ratio.y,
+        wire_const.world_half_width,
+        wire_const.half_width,
+    );
+    let half_width = mix(half_width_a, half_width_b, which_end);
+    let extension = which_end * 2.0 - 1.0;
+    let offset_px = perpendicular * half_width * side
+        + direction * half_width * extension;
+    let ndc_offset = offset_px / (u.viewport_size * 0.5);
+    let final_clip = clip_position
+        + vec4<f32>(ndc_offset * clip_position.w, 0.0, 0.0);
+
+    let scale = u.linetype_scale;
+    var min_element = wire_const.pattern_length * scale;
+    let elements = array<f32, 8>(
+        wire_const.pat0.x * scale,
+        wire_const.pat0.y * scale,
+        wire_const.pat0.z * scale,
+        wire_const.pat0.w * scale,
+        wire_const.pat1.x * scale,
+        wire_const.pat1.y * scale,
+        wire_const.pat1.z * scale,
+        wire_const.pat1.w * scale,
+    );
+    for (var i = 0u; i < 8u; i++) {
+        let value = abs(elements[i]);
+        if value > 0.0 && value < min_element {
+            min_element = value;
+        }
+    }
+
+    var out: VertexOut;
+    out.clip_pos = final_clip;
+    out.clip_pos.z -= in.depth.x * DRAW_ORDER_BIAS * out.clip_pos.w;
+    out.color = wire_const.color;
+    out.distance = mix(seg_distances.x, seg_distances.y, which_end)
+        + extension * half_width * u.world_per_pixel;
+    out.pattern_length = wire_const.pattern_length * scale;
+    out.pat0 = wire_const.pat0 * scale;
+    out.pat1 = wire_const.pat1 * scale;
+    out.min_elem = min_element;
+    out.align_end = wire_const.align_end * scale;
+    out.align_total = wire_const.align_total;
+    out.cap = vec2<f32>(
+        which_end * segment_length + extension * half_width,
+        half_width * side,
+    );
+    out.cap_ends = vec3<f32>(segment_length, half_width_a, half_width_b);
+    return out;
+}
+
+fn in_dash(
+    distance: f32,
+    pattern_length: f32,
+    pat0: vec4<f32>,
+    pat1: vec4<f32>,
+    align_end: f32,
+    align_total: f32,
+) -> bool {
+    let elements = array<f32, 8>(
+        pat0.x, pat0.y, pat0.z, pat0.w,
+        pat1.x, pat1.y, pat1.z, pat1.w,
+    );
+    var count = 0u;
+    for (var i = 0u; i < 8u; i++) {
+        if elements[i] != 0.0 {
+            count = i + 1u;
+        }
+    }
+    var value: f32;
+    if align_total > 0.0 {
+        if distance <= align_end || distance >= align_total - align_end {
+            return true;
+        }
+        var first_dash = 0.0;
+        for (var i = 0u; i < count; i++) {
+            if elements[i] > 0.0 {
+                first_dash = elements[i];
+                break;
+            }
+        }
+        value = ((distance - align_end + first_dash) % pattern_length
+            + pattern_length) % pattern_length;
+    } else {
+        value = ((distance % pattern_length) + pattern_length) % pattern_length;
+    }
+    var position = 0.0;
+    let dot_half = u.world_per_pixel * 0.75;
+    for (var i = 0u; i < count; i++) {
+        let element = elements[i];
+        if element == 0.0 {
+            let delta = abs(value - position);
+            if min(delta, pattern_length - delta) <= dot_half {
+                return true;
+            }
+        } else if element > 0.0 {
+            if value >= position && value < position + element {
+                return true;
+            }
+            position += element;
+        } else {
+            position -= element;
+        }
+    }
+    return false;
+}
+
+fn clipped_cap(cap: vec2<f32>, ends: vec3<f32>) -> bool {
+    if cap.x < 0.0 {
+        return length(cap) > ends.y;
+    }
+    if cap.x > ends.x {
+        return length(vec2<f32>(cap.x - ends.x, cap.y)) > ends.z;
+    }
+    return false;
+}
+
+fn visible_fragment(in: VertexOut) -> bool {
+    if clipped_cap(in.cap, in.cap_ends) {
+        return false;
+    }
+    if in.pattern_length > 0.0 && in.min_elem >= u.world_per_pixel {
+        return in_dash(
+            in.distance,
+            in.pattern_length,
+            in.pat0,
+            in.pat1,
+            in.align_end,
+            in.align_total,
+        );
+    }
+    return true;
+}
+
+@fragment
+fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
+    if !visible_fragment(in) {
+        discard;
+    }
+    let alpha = select(1.0, in.color.a, u.transparency_enable > 0.5);
+    return vec4<f32>(in.color.rgb, alpha);
+}
+
+@fragment
+fn fs_black(in: VertexOut) -> @location(0) vec4<f32> {
+    if !visible_fragment(in) {
+        discard;
+    }
+    let alpha = select(1.0, in.color.a, u.transparency_enable > 0.5);
+    return vec4<f32>(0.0, 0.0, 0.0, alpha);
+}


### PR DESCRIPTION
Depends on #1016. Share block geometry across viewport slots, release cold resources, and allocate full shadow maps only when needed.

Integration counts rendered frames instead of individual widget preparations. Even under memory pressure it protects current and previous frame slots, then removes cache entries no active slot owns. Rejected shadow allocations remain eligible for retry.
