### PR TITLE
feat(insert): add initial PDF underlay attachment

### DIFF
--- a/src/app/commands/blocks.rs
+++ b/src/app/commands/blocks.rs
@@ -515,11 +515,13 @@ impl OpenCADStudio {
                 self.open_attedit_dialog();
             }
 
+            "PDFATTACH" => {
+                return Some(Task::done(Message::PdfAttachPick));
+            }
             "XATTACH" => {
                 // Launch the file picker; XAttachPickResult will start the command.
                 return Some(Task::done(Message::XAttachPick));
             }
-
             cmd if cmd == "WBLOCK" || cmd == "WB" || cmd.starts_with("WBLOCK ") => {
                 let arg = cmd.splitn(2, ' ').nth(1).unwrap_or("").trim();
                 if arg.is_empty() {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3189,6 +3189,12 @@ pub enum Message {
     ImagePick,
     /// Result of the image file picker + pixel dimension decode.
     ImagePickResult(Result<(std::path::PathBuf, u32, u32), String>),
+    // ── PDF Underlay ──────────────────────────────────────────────────────
+    /// Open file-picker dialog for PDFATTACH command (async).
+    PdfAttachPick,
+    /// Result of the PDFATTACH file picker.
+    PdfAttachPickResult(Result<std::path::PathBuf, String>),
+
     // ── XREF ──────────────────────────────────────────────────────────────
     /// Open file-picker dialog for XATTACH command (async).
     XAttachPick,

--- a/src/app/update/mod.rs
+++ b/src/app/update/mod.rs
@@ -902,7 +902,60 @@ impl OpenCADStudio {
                 }
                 Task::none()
             }
+            Message::PdfAttachPick => Task::perform(
+                async {
+                    let handle = crate::sys::file_dialog()
+                        .set_title("Select PDF Underlay")
+                        .add_filter("PDF Files", &["pdf", "PDF"])
+                        .pick_file()
+                        .await;
 
+                    match handle {
+                        Some(h) => Ok(crate::sys::handle_path(&h)),
+                        None => Err("Cancelled".to_string()),
+                    }
+                },
+                Message::PdfAttachPickResult,
+            ),
+
+            Message::PdfAttachPickResult(Ok(path)) => {
+                use acadrust::objects::{ObjectType, UnderlayDefinition};
+                use crate::command::CadCommand;
+                use crate::modules::insert::pdf_attach::PdfAttachCommand;
+
+                let i = self.active_tab;
+                let path_str = path.to_string_lossy().into_owned();
+
+                let definition_handle = self.tabs[i].scene.document.allocate_handle();
+
+                let mut definition = UnderlayDefinition::pdf(&path_str, "1");
+                definition.handle = definition_handle;
+
+                self.tabs[i]
+                    .scene
+                    .document
+                    .objects
+                    .insert(
+                        definition_handle,
+                        ObjectType::UnderlayDefinition(definition),
+                    );
+
+                let cmd = PdfAttachCommand::new(definition_handle);
+
+                self.command_line.push_info(&cmd.prompt());
+                self.tabs[i].active_cmd = Some(Box::new(cmd));
+
+                Task::none()
+            }
+
+            Message::PdfAttachPickResult(Err(e)) => {
+                if e != "Cancelled" {
+                    self.command_line
+                        .push_error(crate::tf!("PDFATTACH: {e}").as_ref());
+                }
+
+                Task::none()
+            }
             Message::XAttachPick => Task::perform(
                 async {
                     let handle = crate::sys::file_dialog()

--- a/src/modules/insert/mod.rs
+++ b/src/modules/insert/mod.rs
@@ -16,6 +16,7 @@ pub mod minsert;
 mod mview_block;
 mod open_obj;
 mod pc_attach;
+pub(crate) mod pdf_attach;
 mod snap_underlays;
 pub(crate) mod solid3d_cmds;
 mod underlay_layers;
@@ -45,6 +46,7 @@ impl CadModule for InsertModule {
                     title: "Reference",
                     tools: vec![
                         RibbonItem::LargeTool(xattach::tool()),
+                        RibbonItem::LargeTool(pdf_attach::tool()),
                         RibbonItem::LargeTool(xclip::tool()),
                         RibbonItem::LargeTool(xadjust::tool()),
                         RibbonItem::Tool(underlay_layers::tool()),

--- a/src/modules/insert/pdf_attach.rs
+++ b/src/modules/insert/pdf_attach.rs
@@ -1,0 +1,69 @@
+use acadrust::entities::Underlay;
+use acadrust::types::{Handle, Vector3};
+use acadrust::EntityType;
+use glam::DVec3;
+
+use crate::command::{CadCommand, CmdResult, WorkingPlane};
+use crate::modules::{IconKind, ModuleEvent, ToolDef};
+use crate::t;
+
+pub const ICON: IconKind =
+    IconKind::Svg(include_bytes!("../../../assets/icons/underlay_layers.svg"));
+
+pub fn tool() -> ToolDef {
+    ToolDef {
+        id: "PDFATTACH",
+        label: "Attach PDF",
+        icon: ICON,
+        event: ModuleEvent::Command("PDFATTACH".to_string()),
+    }
+}
+
+pub struct PdfAttachCommand {
+    definition_handle: Handle,
+    plane: WorkingPlane,
+}
+
+impl PdfAttachCommand {
+    pub fn new(definition_handle: Handle) -> Self {
+        Self {
+            definition_handle,
+            plane: WorkingPlane::default(),
+        }
+    }
+}
+
+impl CadCommand for PdfAttachCommand {
+    fn set_working_plane(&mut self, plane: WorkingPlane) {
+        self.plane = plane;
+    }
+
+    fn name(&self) -> &'static str {
+        "PDFATTACH"
+    }
+
+    fn prompt(&self) -> String {
+        t!("PDFATTACH  Specify insertion point:").into_owned()
+    }
+
+    fn on_point(&mut self, pt: DVec3) -> CmdResult {
+        let point = self.plane.to_local(pt);
+
+        let mut underlay = Underlay::pdf();
+        underlay.definition_handle = self.definition_handle;
+        underlay.insertion_point = Vector3::new(point.x, point.y, point.z);
+
+        CmdResult::CommitAndExit(
+            self.plane
+                .place_entity(EntityType::Underlay(underlay)),
+        )
+    }
+
+    fn on_enter(&mut self) -> CmdResult {
+        CmdResult::Cancel
+    }
+}
+
+inventory::submit!(crate::command::CommandRegistration {
+    names: &["PDFATTACH"]
+});

--- a/src/scene/modify.rs
+++ b/src/scene/modify.rs
@@ -1308,5 +1308,29 @@ impl Scene {
             _ => {}
         }
         // The grip-drag caller refreshes changed resident meshes per move.
+        // Raster images, OLE frames and PDF underlays keep a derived ImageModel
+        // with their textured quad geometry. A grip edit mutates the entity directly,
+        // so rebuild that cache as well or only the wire frame follows the grip.
+        let image_bearing = self.document.get_entity(handle).is_some_and(|entity| {
+            matches!(
+                entity,
+                EntityType::RasterImage(_)
+                    | EntityType::Ole2Frame(_)
+                    | EntityType::Underlay(_)
+            )
+        });
+
+        if image_bearing {
+            let model = self
+                .document
+                .get_entity(handle)
+                .and_then(|entity| self.image_seed_for(entity));
+
+            self.images.remove(&handle);
+
+            if let Some(model) = model {
+                self.images.insert(handle, model);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds initial PDF attachment support through the Insert > Reference ribbon panel.
<img width="317" height="118" alt="imagen" src="https://github.com/user-attachments/assets/7ea312e3-06df-491e-b80c-d43f02832494" />


PDF pages are currently rasterized for display and attached as underlays.

## Current scope

- PDF file picker
- PDF underlay creation
- First-page rendering
- Interactive insertion point
- Rasterized viewport display

## Limitations

- Only the first PDF page is currently attached
- PDF rendering currently depends on `pdftoppm`
- No page selection dialog yet
- No dedicated scale / rotation options yet

This provides the initial PDFATTACH workflow and leaves room for more complete PDF underlay support in follow-up work.

Initial support to #1011 