### PR TITLE
feat(cursor): add point cursor for active commands

### DIFF
--- a/src/app/view/mod.rs
+++ b/src/app/view/mod.rs
@@ -802,6 +802,9 @@ bg={bg_ms:.1}ms n={view_count}"
                 .hover_highlight
                 .map(|h| tab.scene.is_layer_locked(h))
                 .unwrap_or(false);
+            let point_cursor = tab.active_cmd.as_ref().is_some_and(|cmd| {
+                !cmd.needs_entity_pick() && !cmd.is_selection_gathering()
+            });
             crate::ui::overlay::selection_overlay(
                 std::sync::Arc::clone(&tab.scene.selection),
                 snap_info,
@@ -827,6 +830,7 @@ bg={bg_ms:.1}ms n={view_count}"
                     size_percent: self.cursor_size,
                     pick_box: self.pick_box,
                     cursor_type: self.cursor_type,
+                    point_mode: point_cursor,
                     color: self.crosshair_color,
                     isometric: self.isometric_drafting,
                     iso_plane: self.iso_plane,

--- a/src/ui/overlay.rs
+++ b/src/ui/overlay.rs
@@ -69,6 +69,7 @@ pub struct CrosshairOptions {
     pub isometric: bool,
     pub iso_plane: IsoPlane,
     pub snap_angle_deg: f32,
+    pub point_mode: bool,
 }
 
 /// Rendering style for the viewport grid.
@@ -1469,7 +1470,12 @@ impl canvas::Program<Message> for SelectionCanvas {
                     style: canvas::Style::Solid(color),
                     ..Default::default()
                 };
-                let sq = pick_box_half_px(self.crosshair.pick_box);
+                let point_mode = self.crosshair.point_mode;
+                let sq = if point_mode {
+                    0.0
+                } else {
+                    pick_box_half_px(self.crosshair.pick_box)
+                };
                 let arm = crosshair_arm_px(bounds, self.crosshair.size_percent);
                 let base_angles: [f64; 2] = if self.crosshair.isometric {
                     self.crosshair.iso_plane.angles()
@@ -1479,7 +1485,9 @@ impl canvas::Program<Message> for SelectionCanvas {
                 for angle in base_angles {
                     let rad = (angle + self.crosshair.snap_angle_deg as f64).to_radians();
                     let dir = Point::new(rad.cos() as f32, -rad.sin() as f32);
-                    let gap = if sq > 0.0 {
+                    let gap = if point_mode {
+                        9.0
+                    } else if sq > 0.0 {
                         sq / dir.x.abs().max(dir.y.abs()).max(1e-6)
                     } else {
                         0.0
@@ -1492,7 +1500,10 @@ impl canvas::Program<Message> for SelectionCanvas {
                     });
                     frame.stroke(&arms, stroke.clone());
                 }
-                if sq > 0.0 {
+                if point_mode {
+                    let dot = canvas::Path::circle(cp, 1.75);
+                    frame.fill(&dot, color);
+                } else if sq > 0.0 {
                     let square = canvas::Path::rectangle(
                         Point::new(cp.x - sq, cp.y - sq),
                         Size::new(sq * 2.0, sq * 2.0),


### PR DESCRIPTION
## Summary

Improves the CAD crosshair feedback while interactive commands are active.

Instead of keeping the normal pick box visible at all times, point-based command steps now display a small center dot with additional separation from the crosshair arms.

## Behavior

- Normal idle cursor keeps the standard pick box
- Point-based command steps show a small center dot
- Entity-selection steps keep the normal pick box
- The regular cursor is restored automatically when the command ends or is cancelled
- Existing OSNAP markers remain unchanged
- Works with rotated/isometric crosshairs

## Examples

- LINE / PLINE / CIRCLE / ARC: center dot
- OFFSET distance / side point: center dot
- OFFSET object selection: normal pick box
- Selection-only command stages: normal pick box

The center marker provides a clearer visual reference for the exact point being entered while drawing.

<img width="822" height="573" alt="imagen" src="https://github.com/user-attachments/assets/ee89604c-5583-4d35-b082-2519f6a1dc7f" />
