### PR TITLE
Skip the wire partition when a patch cannot change its output

### DIFF
--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -9415,14 +9415,59 @@ vis_index={:.1} visible_probe={:.1}",
     }
 
     /// Resolve owner handles and block-record membership once per geometry epoch.
+    ///
+    /// The walk visits every entity in the drawing and the epoch moves on every
+    /// edit, so it used to run again for each one — 19 ms of a 55 ms selection
+    /// on a 586 k-entity drawing, to add a single handle to a single list.
+    ///
+    /// A lone addition is folded in instead. Only a lone one: entities are
+    /// appended to the document, so a single new handle belongs at the end of
+    /// its block's list, while `replay_since` returns several changes in no
+    /// particular order and each list is in document order because that is
+    /// draw order. Anything else — a removal, a modification that could move an
+    /// entity between blocks, more than one change — takes the full walk.
     fn block_members(&self) -> std::cell::Ref<'_, BlockMembers> {
+        let mut cached_epoch = None;
         {
             let cache = self.block_members_cache.borrow();
-            if cache.as_ref().is_some_and(|(epoch, _)| *epoch == self.geometry_epoch) {
-                drop(cache);
-                return std::cell::Ref::map(self.block_members_cache.borrow(), |c| {
-                    c.as_ref().unwrap()
+            if let Some((epoch, _)) = cache.as_ref() {
+                if *epoch == self.geometry_epoch {
+                    drop(cache);
+                    return std::cell::Ref::map(self.block_members_cache.borrow(), |c| {
+                        c.as_ref().unwrap()
+                    });
+                }
+                cached_epoch = Some(*epoch);
+            }
+        }
+
+        if let Some(since) = cached_epoch {
+            let lone_add = self.replay_since(since).filter(|deltas| {
+                deltas.len() == 1 && deltas[0].1 == ChangeKind::Added
+            });
+            if let Some(deltas) = lone_add {
+                let handle = deltas[0].0;
+                // Resolve the owner before touching the cache: both lookups
+                // borrow, and `entity_block_map` is its own `RefCell`.
+                let owner = self.document.get_entity(handle).and_then(|entity| {
+                    let owner = entity.common().owner_handle;
+                    if !owner.is_null() {
+                        Some(owner)
+                    } else {
+                        self.entity_block_map().get(&handle).copied()
+                    }
                 });
+                let mut cache = self.block_members_cache.borrow_mut();
+                if let Some((epoch, members)) = cache.as_mut() {
+                    if let Some(owner) = owner {
+                        members.entry(owner).or_default().push(handle);
+                    }
+                    *epoch = self.geometry_epoch;
+                    drop(cache);
+                    return std::cell::Ref::map(self.block_members_cache.borrow(), |c| {
+                        c.as_ref().unwrap()
+                    });
+                }
             }
         }
         let mut members: HashMap<Handle, Vec<Handle>> = HashMap::default();
@@ -10597,6 +10642,42 @@ mod journal_tests {
 
     // Differential oracle: the incrementally-patched entity index must always
     // equal a from-scratch rebuild after any add / move / erase.
+    #[test]
+    /// Folding a lone addition must land the handle where the full walk would
+    /// have put it — at the end of its block's list, because that list is in
+    /// document order and document order is draw order.
+    #[test]
+    fn folding_one_addition_matches_the_full_scan() {
+        use acadrust::entities::Line;
+        use acadrust::types::Vector3;
+
+        let mut scene = Scene::new();
+        fn add(scene: &mut Scene, x: f64) -> Handle {
+            scene.add_entity(EntityType::Line(Line::from_points(
+                Vector3::new(x, 0.0, 0.0),
+                Vector3::new(x + 1.0, 0.0, 0.0),
+            )))
+        }
+        add(&mut scene, 0.0);
+        add(&mut scene, 1.0);
+        // Build the index, then add one more so the next call folds.
+        let block = scene.model_space_block_handle();
+        let before = scene.block_members().1.get(&block).cloned().unwrap_or_default();
+        let third = add(&mut scene, 2.0);
+        let folded = scene.block_members().1.get(&block).cloned().unwrap_or_default();
+
+        scene.block_members_cache.borrow_mut().take();
+        let rebuilt = scene.block_members().1.get(&block).cloned().unwrap_or_default();
+
+        assert_eq!(folded, rebuilt, "the folded index must equal a full rebuild");
+        assert_eq!(
+            folded.last(),
+            Some(&third),
+            "an appended entity belongs at the end of its block's list",
+        );
+        assert_eq!(folded.len(), before.len() + 1);
+    }
+
     #[test]
     fn block_member_index_matches_the_full_scan() {
         use acadrust::entities::Line;

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -437,6 +437,10 @@ pub struct PreparedOpenGeometry {
     pub tess_guard: u64,
     /// Loader block definitions; the receiving scene supplies its own epoch.
     pub block_defns: Vec<(u64, Arc<cache::block_cache::BlockCache>)>,
+    /// The loader's draw-order map. Computing it walks all 1.17 M entities and
+    /// costs ~300 ms; the loader already paid that, and the receiving scene
+    /// used to pay it again on the first frame.
+    pub(crate) draw_depths: Option<DrawDepthCache>,
 }
 
 impl std::fmt::Debug for PreparedOpenGeometry {
@@ -557,7 +561,8 @@ fn inserted_draw_depth_label(order: &[DrawDepthEntry], position: usize) -> Optio
     }
 }
 
-struct DrawDepthCache {
+#[derive(Clone)]
+pub(crate) struct DrawDepthCache {
     epoch: u64,
     depths: Arc<HashMap<u64, [f32; 2]>>,
     /// Per-block stable order labels, including deleted tombstones retained for
@@ -1026,6 +1031,7 @@ pub fn prepare_open_geometry(
     // Taken, not cloned: the scene is discarded on the next line.
     let tess_memo = std::mem::take(&mut *scene.resident_tess_memo.borrow_mut());
     let tess_guard = scene.resident_tess_guard.get();
+    let draw_depths = scene.draw_depth_cache.borrow_mut().take();
     let block_defns: Vec<(u64, Arc<cache::block_cache::BlockCache>)> =
         std::mem::take(&mut *scene.block_defn_cache.borrow_mut())
             .into_iter()
@@ -1040,6 +1046,7 @@ pub fn prepare_open_geometry(
             tess_memo,
             tess_guard,
             block_defns,
+            draw_depths,
         },
     )
 }
@@ -2249,6 +2256,15 @@ impl Scene {
         if !prepared.tess_memo.is_empty() {
             *self.resident_tess_memo.borrow_mut() = prepared.tess_memo;
             self.resident_tess_guard.set(prepared.tess_guard);
+        }
+        // The draw-order map, on the same terms as the block definitions
+        // below: the document is the loader's own, unmodified since, so its
+        // order labels describe this scene exactly. Only the epoch is this
+        // scene's. Without this the first frame recomputed it — a walk of
+        // every entity in the drawing, ~300 ms, for a map that already existed.
+        if let Some(mut depths) = prepared.draw_depths {
+            depths.epoch = self.geometry_epoch;
+            *self.draw_depth_cache.borrow_mut() = Some(depths);
         }
         // Same for the block definitions, stamped with this scene's block
         // epoch: the document has not been touched between the loader
@@ -10541,6 +10557,60 @@ mod journal_tests {
             s.update_entity(moved);
         }
         assert_eq!(indexed(&s, block), scanned(&s, block), "after modify");
+    }
+
+    /// The loader computes the draw-order map and the receiving scene used to
+    /// compute it again — a walk of every entity, ~300 ms, for a map that
+    /// already existed. Handing it over is only sound if it describes the
+    /// receiving scene's document exactly, so that is what this asserts.
+    #[test]
+    fn the_handed_over_draw_depth_map_matches_a_recompute() {
+        use acadrust::entities::{Circle, Line};
+        use acadrust::types::Vector3;
+
+        let mut scene = Scene::new();
+        scene.add_entity(EntityType::Line(Line::from_points(
+            Vector3::new(0.0, 0.0, 0.0),
+            Vector3::new(1.0, 0.0, 0.0),
+        )));
+        scene.add_entity(EntityType::Circle(Circle::new()));
+        scene.add_entity(EntityType::Line(Line::from_points(
+            Vector3::new(2.0, 0.0, 0.0),
+            Vector3::new(3.0, 0.0, 0.0),
+        )));
+
+        // What the loader would hand over, and what it built it from.
+        let expected = scene.draw_depth_map();
+        let handed_over = scene
+            .draw_depth_cache
+            .borrow_mut()
+            .take()
+            .expect("the map was just computed, so it is cached");
+
+        // Installing it stands in for `install_prepared_open_geometry`: the
+        // epoch is the receiving scene's, the contents are the loader's.
+        scene.bump_geometry();
+        scene.install_prepared_open_geometry(PreparedOpenGeometry {
+            wires: Arc::new(Vec::new()),
+            interaction_index: None,
+            tess_memo: HashMap::default(),
+            tess_guard: 0,
+            block_defns: Vec::new(),
+            draw_depths: Some(handed_over),
+        });
+        assert_eq!(
+            *scene.draw_depth_map(),
+            *expected,
+            "the handed-over map must be served as-is",
+        );
+
+        // ...and it must be the map this scene would have produced itself.
+        *scene.draw_depth_cache.borrow_mut() = None;
+        assert_eq!(
+            *scene.draw_depth_map(),
+            *expected,
+            "a recompute must agree with what was handed over",
+        );
     }
 
     #[test]

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -8939,6 +8939,11 @@ impl Scene {
         // version of this diagnostic report a constant.
         let visible_path: &str;
         let mut visible_candidates: usize;
+        // `visible` costs ~400 ms over 444 937 candidates, and two things in
+        // the loop could own that: resolving each handle through the document's
+        // hash index, or the predicate, which looks a layer up **by name** —
+        // a string hash per entity. Timed separately, under PERF only.
+        let mut visible_probe_ms = 0.0f64;
 
         // Phase 2.1 — quadtree-driven candidate selection. When a view
         // AABB exists (Model layout with a settled camera), only iterate
@@ -9026,6 +9031,20 @@ impl Scene {
                         out.push(entity);
                     }
                 }
+            }
+            if perf {
+                // A second, resolve-only pass. It repeats work rather than
+                // instrumenting inside the loop, where a clock read per
+                // iteration would cost more than what it measures.
+                let t_probe = iced::time::Instant::now();
+                let mut resolved = 0usize;
+                for &handle in claimed {
+                    if self.document.get_entity(handle).is_some() {
+                        resolved += 1;
+                    }
+                }
+                std::hint::black_box(resolved);
+                visible_probe_ms = t_probe.elapsed().as_secs_f64() * 1000.0;
             }
             out
         };
@@ -9271,7 +9290,8 @@ impl Scene {
                 "[perf] wires-build total={:.1}ms sort_cache={:.1} visible={:.1} blk_cache={:.1} colors={:.1} \
 build={:.1} [classify={:.1} hits={:.1} tess={:.1} materialize={:.1}] sort={:.1}({}) \
 entities={} memo_hit={} memo_miss={} wires={} memo={} visible_path={} candidates={} \
-guard={:016x} guard_stale={} avp={} anno={:.4} anno_h={} all_vis={} sdf_gen={}",
+guard={:016x} guard_stale={} avp={} anno={:.4} anno_h={} all_vis={} sdf_gen={} \
+visible_probe={:.1}",
                 crate::perf::elapsed_ms(t_fn),
                 sort_cache_ms,
                 visible_ms,
@@ -9298,6 +9318,7 @@ guard={:016x} guard_stale={} avp={} anno={:.4} anno_h={} all_vis={} sdf_gen={}",
                 annotation_scale_handle.map(|h| h.value()).unwrap_or(0),
                 all_visible,
                 crate::scene::text::sdf_atlas::generation(),
+                visible_probe_ms,
             );
         }
         wires

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -10660,6 +10660,44 @@ mod journal_tests {
     // Differential oracle: the incrementally-patched entity index must always
     // equal a from-scratch rebuild after any add / move / erase.
     #[test]
+    /// The partition skip turns on a membership test, and the test has to tell
+    /// a drawn line from a drawn circle. A line carries a tangent geom for
+    /// snapping and no triangles, so the cheap structural filter admits it —
+    /// deciding on that alone called every line a contributor and the skip
+    /// never fired once in a real session.
+    #[test]
+    fn the_partition_membership_test_separates_lines_from_curves() {
+        use acadrust::entities::{Circle, Line};
+        use acadrust::types::Vector3;
+        use crate::scene::pipeline::wire_arena::feeds_analytical_uploads;
+
+        let mut scene = Scene::new();
+        let feeds = |scene: &Scene, handle: Handle| {
+            let entity = scene.document.get_entity(handle).unwrap().clone();
+            scene
+                .tessellate_one(&entity)
+                .iter()
+                .any(feeds_analytical_uploads)
+        };
+
+        let line = scene.add_entity(EntityType::Line(Line::from_points(
+            Vector3::new(0.0, 0.0, 0.0),
+            Vector3::new(10.0, 5.0, 0.0),
+        )));
+        assert!(
+            !feeds(&scene, line),
+            "a drawn line must not force the partition walk",
+        );
+
+        let mut circle = Circle::new();
+        circle.radius = 4.0;
+        let circle = scene.add_entity(EntityType::Circle(circle));
+        assert!(
+            feeds(&scene, circle),
+            "a drawn circle feeds the analytical uploads and must force the walk",
+        );
+    }
+
     /// The partition skip reuses uploads that bake a draw depth, and it is only
     /// sound while existing depths hold still. An incremental add must leave
     /// them alone and must not bump the generation; a rebuild from scratch may

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -1706,6 +1706,12 @@ pub struct Scene {
     /// constants. `[depth, half]` retains a fixed child sub-range for block
     /// composition. Full sort/layout/block changes rebuild the labels.
     draw_depth_cache: RefCell<Option<DrawDepthCache>>,
+    /// Bumped only when the draw-order map is rebuilt from scratch, which is
+    /// the one case that can change an existing entity's depth — an
+    /// incremental insert allocates into the reserved label gap and leaves
+    /// every other label alone. Consumers that cached anything carrying a baked
+    /// depth compare this before reusing it.
+    draw_depth_generation: std::cell::Cell<u64>,
     /// Shared empty map for 3-D wireframe, where true depth wins instead of
     /// the entity submission order used by the optimized 2-D style.
     no_draw_depths: Arc<HashMap<u64, [f32; 2]>>,
@@ -2053,6 +2059,7 @@ impl Scene {
             interaction_handle_index_cache: RefCell::new(None),
             sort_cache: RefCell::new(None),
             draw_depth_cache: RefCell::new(None),
+            draw_depth_generation: std::cell::Cell::new(0),
             no_draw_depths: Arc::new(HashMap::default()),
             hatch_cache: RefCell::new(HashMap::default()),
             wipeout_cache: RefCell::new(HashMap::default()),
@@ -5998,6 +6005,11 @@ impl Scene {
     /// A full build assigns sparse labels in effective draw order. Incremental
     /// Add/Remove then changes only the named handle: existing siblings retain
     /// their depth, avoiding an O(all entities) map rewrite and GPU const upload.
+    /// See [`Self::draw_depth_generation`].
+    pub(in crate::scene) fn draw_depth_generation(&self) -> u64 {
+        self.draw_depth_generation.get()
+    }
+
     pub(super) fn draw_depth_map(&self) -> Arc<HashMap<u64, [f32; 2]>> {
         {
             let cache = self.draw_depth_cache.borrow();
@@ -6126,6 +6138,11 @@ impl Scene {
                 }
             }
         }
+
+        // From here the labels are assigned afresh, so an existing entity's
+        // depth can move. Anything holding a baked depth has to rebuild.
+        self.draw_depth_generation
+            .set(self.draw_depth_generation.get().wrapping_add(1));
 
         use acadrust::objects::ObjectType;
         // Per-block SortEntitiesTable overrides: block -> (entity_val -> sort_val).
@@ -10643,6 +10660,52 @@ mod journal_tests {
     // Differential oracle: the incrementally-patched entity index must always
     // equal a from-scratch rebuild after any add / move / erase.
     #[test]
+    /// The partition skip reuses uploads that bake a draw depth, and it is only
+    /// sound while existing depths hold still. An incremental add must leave
+    /// them alone and must not bump the generation; a rebuild from scratch may
+    /// move them and must bump it.
+    #[test]
+    fn adding_an_entity_leaves_existing_draw_depths_alone() {
+        use acadrust::entities::Line;
+        use acadrust::types::Vector3;
+
+        fn add(scene: &mut Scene, x: f64) -> Handle {
+            scene.add_entity(EntityType::Line(Line::from_points(
+                Vector3::new(x, 0.0, 0.0),
+                Vector3::new(x + 1.0, 0.0, 0.0),
+            )))
+        }
+        let mut scene = Scene::new();
+        let first = add(&mut scene, 0.0);
+        let second = add(&mut scene, 1.0);
+        let before = scene.draw_depth_map();
+        let generation = scene.draw_depth_generation();
+
+        add(&mut scene, 2.0);
+        let after = scene.draw_depth_map();
+        assert_eq!(
+            scene.draw_depth_generation(),
+            generation,
+            "an incremental add must not invalidate baked depths",
+        );
+        for handle in [first, second] {
+            assert_eq!(
+                after.get(&handle.value()),
+                before.get(&handle.value()),
+                "an existing entity's depth must not move when another is added",
+            );
+        }
+
+        // A rebuild from scratch reassigns labels, so it has to say so.
+        scene.draw_depth_cache.borrow_mut().take();
+        let _ = scene.draw_depth_map();
+        assert_ne!(
+            scene.draw_depth_generation(),
+            generation,
+            "a full rebuild must invalidate anything holding a baked depth",
+        );
+    }
+
     /// Folding a lone addition must land the handle where the full walk would
     /// have put it — at the end of its block's list, because that list is in
     /// document order and document order is draw order.

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -8827,6 +8827,32 @@ impl Scene {
         annotation_scale_handle: Option<Handle>,
         all_visible: bool,
     ) -> bool {
+        let layer = self.document.layers.get(&e.common().layer);
+        self.resident_entity_visible_with_layer(
+            e,
+            block_handle,
+            frozen_layers,
+            annotation_scale_handle,
+            all_visible,
+            layer,
+        )
+    }
+
+    /// `resident_entity_visible` with the layer already resolved.
+    ///
+    /// `Table::get` normalises the name with `to_uppercase`, which allocates,
+    /// and the selection calls this once per candidate — 444 938 allocations on
+    /// the reproducer, ~440 ms, to look up a few hundred distinct layers. A
+    /// caller in a loop resolves each name once and passes the result here.
+    fn resident_entity_visible_with_layer(
+        &self,
+        e: &EntityType,
+        block_handle: Handle,
+        frozen_layers: Option<&HashSet<Handle>>,
+        annotation_scale_handle: Option<Handle>,
+        all_visible: bool,
+        layer: Option<&acadrust::tables::layer::Layer>,
+    ) -> bool {
         let c = e.common();
         if c.invisible {
             return false;
@@ -8839,7 +8865,6 @@ impl Scene {
         if matches!(e, EntityType::Block(_) | EntityType::BlockEnd(_)) {
             return false;
         }
-        let layer = self.document.layers.get(&c.layer);
         if layer
             .map(|l| l.flags.off || l.flags.frozen)
             .unwrap_or(false)
@@ -8866,8 +8891,8 @@ impl Scene {
         self.belongs_to_visible_block(c.handle, c.owner_handle, block_handle)
     }
 
-    fn wires_for_block_culled(
-        &self,
+    fn wires_for_block_culled<'doc>(
+        &'doc self,
         block_handle: Handle,
         view_aabb: Option<[f32; 4]>,
         wpp: Option<f32>,
@@ -8921,13 +8946,45 @@ impl Scene {
         // Visibility test reused by both paths below — and by the resident
         // incremental patch, so a changed entity is included/excluded exactly as
         // a from-scratch build would (no divergence).
-        let visibility_ok = |e: &EntityType| {
-            self.resident_entity_visible(
+        // `Table::get` normalises with `to_uppercase`, so every layer lookup
+        // allocates. The selection asks once per candidate and a drawing has a
+        // few hundred layers, so the name is resolved once and remembered.
+        // Keys borrow the entity's own layer string, which lives in the
+        // document for the whole call.
+        type LayerRef<'a> = Option<&'a acadrust::tables::layer::Layer>;
+        let layer_of: RefCell<rustc_hash::FxHashMap<&'doc str, LayerRef<'doc>>> =
+            RefCell::new(rustc_hash::FxHashMap::default());
+        // Kill switch, so one binary can measure both paths on one drawing.
+        // Same shape as `OCS_NO_RESIDENT_MEMO`.
+        fn layer_memo_enabled() -> bool {
+            static EN: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+            *EN.get_or_init(|| std::env::var("OCS_NO_LAYER_MEMO").is_err())
+        }
+        let memo_on = layer_memo_enabled();
+        let visibility_ok = |e: &'doc EntityType| {
+            let name = e.common().layer.as_str();
+            if !memo_on {
+                return self.resident_entity_visible(
+                    e,
+                    block_handle,
+                    frozen_layers,
+                    annotation_scale_handle,
+                    all_visible,
+                );
+            }
+            let layer = match layer_of.borrow_mut().entry(name) {
+                std::collections::hash_map::Entry::Occupied(hit) => *hit.get(),
+                std::collections::hash_map::Entry::Vacant(slot) => {
+                    *slot.insert(self.document.layers.get(name))
+                }
+            };
+            self.resident_entity_visible_with_layer(
                 e,
                 block_handle,
                 frozen_layers,
                 annotation_scale_handle,
                 all_visible,
+                layer,
             )
         };
 
@@ -8943,6 +9000,7 @@ impl Scene {
         // the loop could own that: resolving each handle through the document's
         // hash index, or the predicate, which looks a layer up **by name** —
         // a string hash per entity. Timed separately, under PERF only.
+        let mut visible_index_ms = 0.0f64;
         let mut visible_probe_ms = 0.0f64;
 
         // Phase 2.1 — quadtree-driven candidate selection. When a view
@@ -9020,7 +9078,13 @@ impl Scene {
             // block's list is already in document order and the wires come out
             // in exactly the order the full scan produced.
             visible_path = "block-index";
+            // The index itself: rebuilt by walking the whole document once per
+            // `geometry_epoch`, and the epoch moves on every edit. Timed
+            // separately because it is inside `visible` and is not per-entity
+            // work, so no per-candidate breakdown can ever account for it.
+            let t_members = perf.then(iced::time::Instant::now);
             let members = self.block_members();
+            visible_index_ms = crate::perf::elapsed_ms(t_members);
             let (_, by_block) = &*members;
             let claimed = by_block.get(&block_handle).map(Vec::as_slice).unwrap_or(&[]);
             visible_candidates = claimed.len();
@@ -9033,9 +9097,13 @@ impl Scene {
                 }
             }
             if perf {
-                // A second, resolve-only pass. It repeats work rather than
-                // instrumenting inside the loop, where a clock read per
-                // iteration would cost more than what it measures.
+                // Resolve-only pass, for the share of `visible` that is the
+                // document's hash index rather than the predicate. Repeated
+                // rather than clocked per iteration, and PERF only.
+                //
+                // It runs after the real loop, so it reads a warm cache and
+                // undercounts what the first traversal actually paid. Treat it
+                // as a floor, not as the cost.
                 let t_probe = iced::time::Instant::now();
                 let mut resolved = 0usize;
                 for &handle in claimed {
@@ -9291,7 +9359,7 @@ impl Scene {
 build={:.1} [classify={:.1} hits={:.1} tess={:.1} materialize={:.1}] sort={:.1}({}) \
 entities={} memo_hit={} memo_miss={} wires={} memo={} visible_path={} candidates={} \
 guard={:016x} guard_stale={} avp={} anno={:.4} anno_h={} all_vis={} sdf_gen={} \
-visible_probe={:.1}",
+vis_index={:.1} visible_probe={:.1}",
                 crate::perf::elapsed_ms(t_fn),
                 sort_cache_ms,
                 visible_ms,
@@ -9318,6 +9386,7 @@ visible_probe={:.1}",
                 annotation_scale_handle.map(|h| h.value()).unwrap_or(0),
                 all_visible,
                 crate::scene::text::sdf_atlas::generation(),
+                visible_index_ms,
                 visible_probe_ms,
             );
         }
@@ -10578,6 +10647,65 @@ mod journal_tests {
             s.update_entity(moved);
         }
         assert_eq!(indexed(&s, block), scanned(&s, block), "after modify");
+    }
+
+    /// The layer memo keys on the entity's **raw** layer string, while
+    /// `Table::get` normalises with `to_uppercase`. Two spellings of one layer
+    /// therefore take two memo slots, and both must resolve to that same layer
+    /// — otherwise the memo would hide geometry the unmemoized path shows.
+    ///
+    /// Covers the property the memo rests on (the table is case-insensitive)
+    /// and the predicate that reads it, not the memo's own bookkeeping.
+    #[test]
+    fn the_layer_memo_respects_case_insensitive_layer_names() {
+        use acadrust::entities::Line;
+        use acadrust::tables::layer::Layer;
+        use acadrust::types::Vector3;
+
+        let mut scene = Scene::new();
+        let mut hidden = Layer::new("Walls");
+        hidden.flags.off = true;
+        scene.document.layers.add_or_replace(hidden);
+
+        let mut on_layer = |layer: &str| {
+            let mut line = Line::from_points(
+                Vector3::new(0.0, 0.0, 0.0),
+                Vector3::new(1.0, 0.0, 0.0),
+            );
+            line.common.layer = layer.to_string();
+            scene.add_entity(EntityType::Line(line))
+        };
+        // Three spellings of the same, switched-off layer, plus one that is
+        // genuinely a different layer and stays visible.
+        on_layer("Walls");
+        on_layer("WALLS");
+        on_layer("walls");
+        on_layer("Doors");
+
+        let block = scene.model_space_block_handle();
+        let visible: Vec<_> = scene
+            .document
+            .entities()
+            .filter(|e| scene.resident_entity_visible(e, block, None, None, true))
+            .map(|e| e.common().layer.clone())
+            .collect();
+        assert_eq!(
+            visible,
+            vec!["Doors".to_string()],
+            "every spelling of a switched-off layer must be hidden",
+        );
+
+        // The memo takes one slot per spelling; each must find the same layer.
+        let resolved: Vec<_> = ["Walls", "WALLS", "walls"]
+            .iter()
+            .map(|name| scene.document.layers.get(name).map(|l| l.name.clone()))
+            .collect();
+        assert_eq!(
+            resolved,
+            vec![Some("Walls".to_string()); 3],
+            "the table is case-insensitive, which is what lets the memo key on \
+             the raw name",
+        );
     }
 
     /// The loader computes the draw-order map and the receiving scene used to

--- a/src/scene/pipeline/mod.rs
+++ b/src/scene/pipeline/mod.rs
@@ -4987,6 +4987,12 @@ impl Pipeline {
         self.silhouette_key = (usize::MAX, u64::MAX, [u32::MAX; 3], false);
         self.silhouette_source_key = (usize::MAX, usize::MAX, u64::MAX);
         self.render_sig = u64::MAX;
+        // The partition record describes uploads this slot is no longer
+        // entitled to reuse. A reused slot rebuilds anyway, because its content
+        // id changed, but leaving a stale record here would make that an
+        // accident rather than a guarantee.
+        self.partition_contributors.clear();
+        self.partition_depth_generation = u64::MAX;
     }
 
     /// Catch errors delivered after the previous upload/submit completed.

--- a/src/scene/pipeline/mod.rs
+++ b/src/scene/pipeline/mod.rs
@@ -251,6 +251,13 @@ pub struct Pipeline {
     pub(crate) wire_arena_fallback_handles: rustc_hash::FxHashSet<acadrust::Handle>,
     /// The Model content id both arenas currently mirror (`u64::MAX` = none).
     pub(crate) wire_arena_id: u64,
+    /// Entities that fed the instanced / circle / ellipse uploads this slot is
+    /// holding. A patch touching none of them cannot change those uploads, so
+    /// the partition walk over the whole resident set can be skipped.
+    pub(crate) partition_contributors: rustc_hash::FxHashSet<acadrust::Handle>,
+    /// The draw-depth generation those uploads baked. A full depth rebuild
+    /// reassigns every label, so they stop being reusable when it moves.
+    pub(crate) partition_depth_generation: u64,
     /// Last content/camera/viewport tuple used to derive visible instance
     /// ranges from the resident arena.
     pub(crate) wire_cull_key: (u64, u64, u32, u32),
@@ -2338,6 +2345,8 @@ impl Pipeline {
             wire_arena_fallback_kind: None,
             wire_arena_fallback_handles: rustc_hash::FxHashSet::default(),
             wire_arena_id: u64::MAX,
+            partition_contributors: rustc_hash::FxHashSet::default(),
+            partition_depth_generation: u64::MAX,
             wire_cull_key: (u64::MAX, u64::MAX, 0, 0),
             hatch_lod_key: (usize::MAX, u64::MAX, 0, 0, false),
             wipeout_lod_key: (usize::MAX, u64::MAX, 0, 0, false),
@@ -4991,6 +5000,8 @@ impl Pipeline {
         self.wire_arena = None;
         self.wire_arena_mesh = None;
         self.wire_arena_id = u64::MAX;
+        self.partition_contributors.clear();
+        self.partition_depth_generation = u64::MAX;
         self.alloc_size = Size::new(0, 0);
         self.shadow_full = None;
         self.background_source_id = usize::MAX;
@@ -5022,6 +5033,8 @@ impl Pipeline {
         self.wire_arena_fallback_kind = None;
         self.wire_arena_fallback_handles.clear();
         self.wire_arena_id = u64::MAX;
+        self.partition_contributors.clear();
+        self.partition_depth_generation = u64::MAX;
 
         self.gpu_selected_wires.clear();
         self.gpu_selected_block_wires.clear();

--- a/src/scene/pipeline/wire_arena.rs
+++ b/src/scene/pipeline/wire_arena.rs
@@ -199,12 +199,16 @@ pub fn partition_wires<'a>(
             instanced.push(wire);
             continue;
         }
-        let depth = super::wire_gpu::wire_draw_depth(wire, depth_map);
+        // `wire_draw_depth` is a hash lookup and its result is used only by the
+        // analytical extractions below, which most wires never reach. Computing
+        // it first cost one lookup per resident wire on every patch — 236 956
+        // of them for the ~56 000 that are circles or ellipses.
         if !wire.tangent_geoms.is_empty()
             && wire.fill_tris.is_empty()
             && wire.pick_tris.is_empty()
             && wire.text_verts.is_empty()
         {
+            let depth = super::wire_gpu::wire_draw_depth(wire, depth_map);
             if let Some(insts) = super::circle_gpu::extract_circle_instances(wire, depth) {
                 circle_instances.extend(insts);
                 continue;

--- a/src/scene/pipeline/wire_arena.rs
+++ b/src/scene/pipeline/wire_arena.rs
@@ -184,17 +184,23 @@ pub struct PartitionedWires<'a> {
 /// Whether a change to this wire can alter what `partition_wires` produces for
 /// the instanced, circle and ellipse uploads.
 ///
-/// Deliberately conservative: a wire that looks analytical here may still fail
-/// extraction and end up in `regular`, which costs an unnecessary re-partition
-/// and never a stale upload. Shared with `partition_wires` so the test that
-/// decides to skip cannot drift from the walk it is skipping.
+/// Decided by attempting the extraction, exactly as the walk decides it. The
+/// cheap structural test alone is not enough: an ordinary drawn line carries a
+/// tangent geom for snapping and no triangles, so it passes that test, fails
+/// extraction, and lands in `regular` — a membership test that stopped there
+/// would call every line a contributor and never skip anything.
+///
+/// `draw_depth` only rides along in the extracted instance, so the value passed
+/// here cannot change the answer.
 pub fn feeds_analytical_uploads(wire: &WireModel) -> bool {
-    wire.display_visible
-        && (wire.render_instance.is_some()
-            || (!wire.tangent_geoms.is_empty()
-                && wire.fill_tris.is_empty()
-                && wire.pick_tris.is_empty()
-                && wire.text_verts.is_empty()))
+    if !wire.display_visible {
+        return false;
+    }
+    if wire.render_instance.is_some() {
+        return true;
+    }
+    super::circle_gpu::extract_circle_instances(wire, 0.0).is_some()
+        || super::ellipse_gpu::extract_ellipse_instances(wire, 0.0).is_some()
 }
 
 /// Single-pass classification and extraction of all viewport wire categories.

--- a/src/scene/pipeline/wire_arena.rs
+++ b/src/scene/pipeline/wire_arena.rs
@@ -174,6 +174,27 @@ pub struct PartitionedWires<'a> {
     pub instanced: Vec<&'a WireModel>,
     pub circle_instances: Vec<super::circle_gpu::CircleInstance>,
     pub ellipse_instances: Vec<super::ellipse_gpu::EllipseInstance>,
+    /// Entities that fed `instanced` / `circle_instances` / `ellipse_instances`.
+    ///
+    /// A patch that touches none of these cannot change those three uploads, so
+    /// the caller can keep the ones it already has and skip the walk entirely.
+    pub contributors: rustc_hash::FxHashSet<Handle>,
+}
+
+/// Whether a change to this wire can alter what `partition_wires` produces for
+/// the instanced, circle and ellipse uploads.
+///
+/// Deliberately conservative: a wire that looks analytical here may still fail
+/// extraction and end up in `regular`, which costs an unnecessary re-partition
+/// and never a stale upload. Shared with `partition_wires` so the test that
+/// decides to skip cannot drift from the walk it is skipping.
+pub fn feeds_analytical_uploads(wire: &WireModel) -> bool {
+    wire.display_visible
+        && (wire.render_instance.is_some()
+            || (!wire.tangent_geoms.is_empty()
+                && wire.fill_tris.is_empty()
+                && wire.pick_tris.is_empty()
+                && wire.text_verts.is_empty()))
 }
 
 /// Single-pass classification and extraction of all viewport wire categories.
@@ -190,12 +211,19 @@ pub fn partition_wires<'a>(
     let mut instanced = Vec::new();
     let mut circle_instances = Vec::new();
     let mut ellipse_instances = Vec::new();
+    let mut contributors: rustc_hash::FxHashSet<Handle> = rustc_hash::FxHashSet::default();
+    let note = |wire: &WireModel, set: &mut rustc_hash::FxHashSet<Handle>| {
+        if let Some(handle) = handle_of(wire) {
+            set.insert(handle);
+        }
+    };
 
     for wire in wires {
         if !wire.display_visible {
             continue;
         }
         if wire.render_instance.is_some() {
+            note(wire, &mut contributors);
             instanced.push(wire);
             continue;
         }
@@ -210,10 +238,12 @@ pub fn partition_wires<'a>(
         {
             let depth = super::wire_gpu::wire_draw_depth(wire, depth_map);
             if let Some(insts) = super::circle_gpu::extract_circle_instances(wire, depth) {
+                note(wire, &mut contributors);
                 circle_instances.extend(insts);
                 continue;
             }
             if let Some(insts) = super::ellipse_gpu::extract_ellipse_instances(wire, depth) {
+                note(wire, &mut contributors);
                 ellipse_instances.extend(insts);
                 continue;
             }
@@ -233,6 +263,7 @@ pub fn partition_wires<'a>(
         instanced,
         circle_instances,
         ellipse_instances,
+        contributors,
     }
 }
 

--- a/src/scene/view/render.rs
+++ b/src/scene/view/render.rs
@@ -149,6 +149,9 @@ pub struct ViewportData {
     /// by the wire / face3d pipelines as a clip-z bias. WireModels carry no
     /// depth field (84 construction sites); the bias is looked up by handle
     /// at GPU-upload time from this map instead.
+    /// See `Scene::draw_depth_generation`. Cached uploads that bake a depth are
+    /// only reusable while this is unchanged.
+    pub(in crate::scene) draw_depth_generation: u64,
     pub(in crate::scene) draw_depths:
         std::sync::Weak<rustc_hash::FxHashMap<u64, [f32; 2]>>,
     pub(in crate::scene) hatches: Arc<Vec<HatchModel>>,
@@ -842,47 +845,79 @@ impl shader::Primitive for Primitive {
                         // A one-entity patch costs 73 ms in this block, and the
                         // three steps below are all O(resident set) rather than
                         // O(changes). Which of them dominates decides the fix.
+                        // The partition walks the whole resident set, and on
+                        // a patch it almost always produces the three uploads it
+                        // produced last frame. Skip it when no changed entity
+                        // feeds them and none did before.
+                        //
+                        // Safe because adding an entity does not disturb any
+                        // other entity's draw depth: `inserted_draw_depth_label`
+                        // allocates into the reserved label gap rather than
+                        // renumbering, so instances already uploaded stay right.
+                        let analytical_untouched = _patched
+                            && inner.partition_depth_generation == vp.draw_depth_generation
+                            && patch.is_some_and(|patch| {
+                                patch.changes.iter().all(|(handle, _)| {
+                                    !inner.partition_contributors.contains(handle)
+                                        && !patch.runs.get(handle).is_some_and(|run| {
+                                            run.iter()
+                                                .any(wire_arena::feeds_analytical_uploads)
+                                        })
+                                })
+                            });
                         let t_part = _perf.then(iced::time::Instant::now);
-                        let partitioned =
-                            wire_arena::partition_wires(&vp_wires, &draw_depths);
+                        let partitioned = (!analytical_untouched)
+                            .then(|| wire_arena::partition_wires(&vp_wires, &draw_depths));
                         let part_ms = t_part
                             .map_or(0.0, |t| t.elapsed().as_secs_f64() * 1000.0);
                         let t_blk = _perf.then(iced::time::Instant::now);
-                        inner.gpu_block_wires = std::sync::Arc::new(
-                            inner.upload_block_wires(
-                                device,
-                                queue,
-                                &partitioned.instanced,
-                                &draw_depths,
-                                &mut pipeline.block_geometry,
-                            ),
-                        );
-                        let blk_ms = t_blk
-                            .map_or(0.0, |t| t.elapsed().as_secs_f64() * 1000.0);
-                        let t_curve = _perf.then(iced::time::Instant::now);
-                        inner.gpu_circles = std::sync::Arc::new(
-                            inner.upload_circles_from_instances(
-                                device,
-                                queue,
-                                &partitioned.circle_instances,
-                            ),
-                        );
-                        inner.gpu_ellipses = std::sync::Arc::new(
-                            inner.upload_ellipses_from_instances(
-                                device,
-                                queue,
-                                &partitioned.ellipse_instances,
-                            ),
-                        );
+                        let mut blk_ms = 0.0f64;
+                        let mut curve_ms = 0.0f64;
+                        // `None` means the three uploads this slot holds are
+                        // still the answer, so they are left alone.
+                        if let Some(partitioned) = &partitioned {
+                            inner.gpu_block_wires = std::sync::Arc::new(
+                                inner.upload_block_wires(
+                                    device,
+                                    queue,
+                                    &partitioned.instanced,
+                                    &draw_depths,
+                                    &mut pipeline.block_geometry,
+                                ),
+                            );
+                            blk_ms = t_blk
+                                .map_or(0.0, |t| t.elapsed().as_secs_f64() * 1000.0);
+                            let t_curve = _perf.then(iced::time::Instant::now);
+                            inner.gpu_circles = std::sync::Arc::new(
+                                inner.upload_circles_from_instances(
+                                    device,
+                                    queue,
+                                    &partitioned.circle_instances,
+                                ),
+                            );
+                            inner.gpu_ellipses = std::sync::Arc::new(
+                                inner.upload_ellipses_from_instances(
+                                    device,
+                                    queue,
+                                    &partitioned.ellipse_instances,
+                                ),
+                            );
+                            inner
+                                .partition_contributors
+                                .clone_from(&partitioned.contributors);
+                            inner.partition_depth_generation = vp.draw_depth_generation;
+                            curve_ms = t_curve
+                                .map_or(0.0, |t| t.elapsed().as_secs_f64() * 1000.0);
+                        }
                         if _perf {
                             crate::perf_record!(
                                 "[perf] arena-post partition={part_ms:.1}ms blocks={blk_ms:.1}ms \
-curves={:.1}ms wires={} instanced={} circles={} ellipses={}",
-                                t_curve.map_or(0.0, |t| t.elapsed().as_secs_f64() * 1000.0),
+curves={curve_ms:.1}ms skipped={} wires={} instanced={} circles={} ellipses={}",
+                                partitioned.is_none(),
                                 vp_wires.len(),
-                                partitioned.instanced.len(),
-                                partitioned.circle_instances.len(),
-                                partitioned.ellipse_instances.len(),
+                                partitioned.as_ref().map_or(0, |p| p.instanced.len()),
+                                partitioned.as_ref().map_or(0, |p| p.circle_instances.len()),
+                                partitioned.as_ref().map_or(0, |p| p.ellipse_instances.len()),
                             );
                         }
                         if _patched {
@@ -4259,6 +4294,7 @@ impl Scene {
             face3d_wires,
             text_verts,
             preview_text_verts,
+            draw_depth_generation: self.draw_depth_generation(),
             draw_depths: Arc::downgrade(&draw_depths),
             hatches,
             wipeout_hatches,

--- a/src/scene/view/render.rs
+++ b/src/scene/view/render.rs
@@ -839,8 +839,15 @@ impl shader::Primitive for Primitive {
                             gpus.extend(arena.wire_gpus());
                         }
                         inner.gpu_wires = std::sync::Arc::new(gpus);
+                        // A one-entity patch costs 73 ms in this block, and the
+                        // three steps below are all O(resident set) rather than
+                        // O(changes). Which of them dominates decides the fix.
+                        let t_part = _perf.then(iced::time::Instant::now);
                         let partitioned =
                             wire_arena::partition_wires(&vp_wires, &draw_depths);
+                        let part_ms = t_part
+                            .map_or(0.0, |t| t.elapsed().as_secs_f64() * 1000.0);
+                        let t_blk = _perf.then(iced::time::Instant::now);
                         inner.gpu_block_wires = std::sync::Arc::new(
                             inner.upload_block_wires(
                                 device,
@@ -850,6 +857,9 @@ impl shader::Primitive for Primitive {
                                 &mut pipeline.block_geometry,
                             ),
                         );
+                        let blk_ms = t_blk
+                            .map_or(0.0, |t| t.elapsed().as_secs_f64() * 1000.0);
+                        let t_curve = _perf.then(iced::time::Instant::now);
                         inner.gpu_circles = std::sync::Arc::new(
                             inner.upload_circles_from_instances(
                                 device,
@@ -864,6 +874,17 @@ impl shader::Primitive for Primitive {
                                 &partitioned.ellipse_instances,
                             ),
                         );
+                        if _perf {
+                            crate::perf_record!(
+                                "[perf] arena-post partition={part_ms:.1}ms blocks={blk_ms:.1}ms \
+curves={:.1}ms wires={} instanced={} circles={} ellipses={}",
+                                t_curve.map_or(0.0, |t| t.elapsed().as_secs_f64() * 1000.0),
+                                vp_wires.len(),
+                                partitioned.instanced.len(),
+                                partitioned.circle_instances.len(),
+                                partitioned.ellipse_instances.len(),
+                            );
+                        }
                         if _patched {
                             wire_arena::patch_handle_index(
                                 &mut inner.wire_handle_index,

--- a/src/scene/view/render.rs
+++ b/src/scene/view/render.rs
@@ -910,15 +910,27 @@ impl shader::Primitive for Primitive {
                                 .map_or(0.0, |t| t.elapsed().as_secs_f64() * 1000.0);
                         }
                         if _perf {
-                            crate::perf_record!(
-                                "[perf] arena-post partition={part_ms:.1}ms blocks={blk_ms:.1}ms \
-curves={curve_ms:.1}ms skipped={} wires={} instanced={} circles={} ellipses={}",
-                                partitioned.is_none(),
-                                vp_wires.len(),
-                                partitioned.as_ref().map_or(0, |p| p.instanced.len()),
-                                partitioned.as_ref().map_or(0, |p| p.circle_instances.len()),
-                                partitioned.as_ref().map_or(0, |p| p.ellipse_instances.len()),
-                            );
+                            // Counts only when a partition produced them.
+                            // Printing zeros on a skip reads as "no circles"
+                            // rather than "not recomputed", which is the
+                            // opposite of what the line is reporting.
+                            match &partitioned {
+                                Some(partitioned) => crate::perf_record!(
+                                    "[perf] arena-post partition={part_ms:.1}ms \
+blocks={blk_ms:.1}ms curves={curve_ms:.1}ms skipped=false wires={} instanced={} \
+circles={} ellipses={}",
+                                    vp_wires.len(),
+                                    partitioned.instanced.len(),
+                                    partitioned.circle_instances.len(),
+                                    partitioned.ellipse_instances.len(),
+                                ),
+                                None => crate::perf_record!(
+                                    "[perf] arena-post skipped=true wires={} \
+retained_contributors={}",
+                                    vp_wires.len(),
+                                    inner.partition_contributors.len(),
+                                ),
+                            }
                         }
                         if _patched {
                             wire_arena::patch_handle_index(


### PR DESCRIPTION
Stacked on #1075.

Retains block, circle, and ellipse uploads when a resident-wire patch cannot change their contributors and the baked draw-depth generation is unchanged. Contributor transitions force repartitioning.

Validation: line patches skip analytical repartitioning; circle patches do not; full draw-depth rebuilds invalidate retained uploads.
