### PR TITLE
registry: note Storm Sewer free/Pro split in description

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -7,7 +7,7 @@
   {
     "repo": "mf4633/opencad-storm-sewer-plugin",
     "name": "Storm Sewer",
-    "description": "Gravity storm-drain network design and analysis (Rational + Manning + HGL, LandXML import)."
+    "description": "Gravity storm-drain network design and analysis (Rational + Manning + HGL, LandXML import). Free to draw and analyze; Pro ($29/yr) adds HTML reports, pipe sizing, multi-RP."
   },
   {
     "repo": "mf4633/opencad-hydrocomplete-plugin",


### PR DESCRIPTION
One-line description update for the Storm Sewer entry. As of v0.3.0 the plugin has a paid tier: drawing, LandXML import, analysis, profile and validation remain free; an optional Pro key ($29/year, validated against hydrocomplete.com) unlocks the HTML report, automatic pipe sizing and the multi-return-period table.

The plugin source stays GPL-3.0-only and continues to build against `ocs_plugin_api` API v2; the release assets are unchanged in shape. Just want the marketplace card to say so before someone installs it and hits the gate.

No code or asset changes in this PR.