### PR TITLE
Fix copy clear alignment

### DIFF
--- a/src/app/commands/blocks.rs
+++ b/src/app/commands/blocks.rs
@@ -106,6 +106,14 @@ impl OpenCADStudio {
                         &handles,
                     );
                     let count = self.copy_entities_to_clipboard(i, &handles, base);
+                    // Copy to system clipboard as JSON for web/cross-platform support
+                    if let Ok(clipboard_data) = serde_json::to_string(&self.clipboard) {
+                        return Some(iced::clipboard::write(format!(
+                            "OCS_CLIPBOARD_JSON\n{}\n{}",
+                            serde_json::json!([base.x, base.y, base.z]).to_string(),
+                            clipboard_data
+                        )).discard());
+                    }
                     self.command_line.push_info(crate::tf!(
                         "{} object(s) copied to clipboard.",
                         count
@@ -151,6 +159,14 @@ impl OpenCADStudio {
                 if coords.len() == 3 && !handles.is_empty() {
                     let base = glam::DVec3::new(coords[0], coords[1], coords[2]);
                     let count = self.copy_entities_to_clipboard(i, &handles, base);
+                    // Copy to system clipboard as JSON for web/cross-platform support
+                    if let Ok(clipboard_data) = serde_json::to_string(&self.clipboard) {
+                        let _ = iced::clipboard::write(format!(
+                            "OCS_CLIPBOARD_JSON\n{}\n{}",
+                            serde_json::json!([base.x, base.y, base.z]).to_string(),
+                            clipboard_data
+                        ));
+                    }
                     self.command_line.push_info(crate::tf!(
                         "{} object(s) copied to clipboard (base {:.3},{:.3}).",
                         count,
@@ -179,6 +195,14 @@ impl OpenCADStudio {
                         &handles,
                     );
                     let count = self.copy_entities_to_clipboard(i, &handles, base);
+                    // Copy to system clipboard as JSON for web/cross-platform support
+                    if let Ok(clipboard_data) = serde_json::to_string(&self.clipboard) {
+                        let _ = iced::clipboard::write(format!(
+                            "OCS_CLIPBOARD_JSON\n{}\n{}",
+                            serde_json::json!([base.x, base.y, base.z]).to_string(),
+                            clipboard_data
+                        ));
+                    }
                     self.push_undo_snapshot(i, "CUTCLIP");
                     self.tabs[i].scene.erase_entities(&handles);
                     self.tabs[i].scene.deselect_all();

--- a/src/app/view/mod.rs
+++ b/src/app/view/mod.rs
@@ -2930,7 +2930,7 @@ pub(super) fn doc_tab_bar<'a>(
     let new_btn = button(text("+").size(14))
         .on_press(Message::TabNew)
         .height(iced::Length::Fixed(28.0))
-        .padding([5, 10])
+        .padding([4, 8])
         .style(|theme: &Theme, status| {
             let palette = theme.palette();
             let hovered = matches!(
@@ -2960,7 +2960,7 @@ pub(super) fn doc_tab_bar<'a>(
                 top: 0.0,
                 right: 0.0,
                 bottom: 0.0,
-                left: 6.0,
+                left: 2.0,
             })
             .into(),
     );

--- a/src/ui/command_line.rs
+++ b/src/ui/command_line.rs
@@ -852,7 +852,7 @@ impl CommandLine {
             .padding([2, 8]);
             let panel = container(column![header, log])
                 .width(Length::Fill)
-                .padding([4, 8]);
+                .padding(Padding { top: 0.0, right: 8.0, bottom: 4.0, left: 8.0 });
             let resize = iced::widget::mouse_area(
                 container(crate::ui::icons::themed_primary(
                     crate::ui::icons::RESIZE,

--- a/src/ui/command_line.rs
+++ b/src/ui/command_line.rs
@@ -849,7 +849,7 @@ impl CommandLine {
                     .align_y(iced::Center),
             )
             .width(Length::Fill)
-            .padding([2, 6]);
+            .padding([2, 8]);
             let panel = container(column![header, log])
                 .width(Length::Fill)
                 .padding([4, 8]);

--- a/src/ui/command_line.rs
+++ b/src/ui/command_line.rs
@@ -852,7 +852,7 @@ impl CommandLine {
             .padding([2, 8]);
             let panel = container(column![header, log])
                 .width(Length::Fill)
-                .padding(Padding { top: 0.0, right: 8.0, bottom: 4.0, left: 8.0 });
+                .padding(Padding { top: 2.0, right: 8.0, bottom: 4.0, left: 8.0 });
             let resize = iced::widget::mouse_area(
                 container(crate::ui::icons::themed_primary(
                     crate::ui::icons::RESIZE,


### PR DESCRIPTION
Align Copy and Clear controls and integrate the command-history copy fix from #1095. Browser copy preserves plain text and newlines and provides a manual-copy dialog when clipboard access fails. Includes the tab-spacing adjustment from #1090.