### PR TITLE
Cut the cost of finding what a selection box contains

### DIFF
--- a/src/app/properties.rs
+++ b/src/app/properties.rs
@@ -2426,6 +2426,11 @@ impl OpenCADStudio {
     }
 
     /// Rebuild the cached selected_grips from the current entity selection.
+    /// Selections larger than this get no grips, matching AutoCAD's
+    /// `GRIPOBJLIMIT` default. The DWG header does not carry the variable, so
+    /// the default stands in for it.
+    const GRIP_OBJECT_LIMIT: usize = 100;
+
     pub(super) fn refresh_selected_grips(&mut self) {
         let i = self.active_tab;
         let locked_active_grip = self.tabs[i].active_grip.as_ref().is_some_and(|grip| {
@@ -2453,6 +2458,22 @@ impl OpenCADStudio {
                 .then(|| selected[0].0);
             let mut grips = Vec::new();
             let mut handles = Vec::new();
+            // Above the limit, no grips at all — the same rule AutoCAD applies
+            // through GRIPOBJLIMIT, and for the same reason. Every selected
+            // entity contributes several grips, the whole list is projected and
+            // rebuilt into markers on **every frame**, and a 185 096-entity
+            // selection put ~3.9 s in this function and then held the view at
+            // ~10 fps for as long as the selection stood.
+            //
+            // Downstream this reads as "this selection has no grips": the
+            // consumers all iterate the list, so they simply find nothing, and
+            // grip editing is unavailable for a selection far past the size
+            // where dragging one is a sensible thing to do.
+            let selected = if selected.len() > Self::GRIP_OBJECT_LIMIT {
+                Vec::new()
+            } else {
+                selected
+            };
             for (handle, entity) in selected {
                 if self.tabs[i].scene.is_layer_locked(handle) {
                     continue;
@@ -4025,5 +4046,53 @@ mod chprop_integration_tests {
         let new_lw = LineWeight::from_value(50);
         let _ = app.update(Message::RibbonLineweightChanged(new_lw));
         assert_eq!(app.ribbon.active_lineweight, new_lw);
+    }
+}
+
+#[cfg(test)]
+mod grip_limit_tests {
+    use super::*;
+
+    /// Every selected entity contributes grips, and the whole list is projected
+    /// and rebuilt into markers on every frame. A 185 096-entity selection put
+    /// ~3.9 s in `refresh_selected_grips` and then held the view at ~10 fps for
+    /// as long as the selection stood, which is what AutoCAD's `GRIPOBJLIMIT`
+    /// exists to prevent.
+    #[test]
+    fn a_selection_past_the_limit_gets_no_grips() {
+        use acadrust::entities::{EntityType, Line};
+        use acadrust::types::Vector3;
+
+        let select_n = |n: usize| -> usize {
+            let mut app = OpenCADStudio::new_for_test();
+            app.automation_op(r#"{"op":"new"}"#);
+            let i = app.active_tab;
+            let handles: Vec<_> = (0..n)
+                .map(|k| {
+                    let x = k as f64;
+                    app.tabs[i].scene.add_entity(EntityType::Line(
+                        Line::from_points(
+                            Vector3::new(x, 0.0, 0.0),
+                            Vector3::new(x + 1.0, 1.0, 0.0),
+                        ),
+                    ))
+                })
+                .collect();
+            for handle in handles {
+                app.tabs[i].scene.select_entity(handle, false);
+            }
+            app.refresh_selected_grips();
+            app.tabs[i].selected_grips.len()
+        };
+
+        assert!(
+            select_n(OpenCADStudio::GRIP_OBJECT_LIMIT) > 0,
+            "a selection at the limit must still show its grips",
+        );
+        assert_eq!(
+            select_n(OpenCADStudio::GRIP_OBJECT_LIMIT + 1),
+            0,
+            "one past the limit must show none at all",
+        );
     }
 }

--- a/src/app/update/viewport.rs
+++ b/src/app/update/viewport.rs
@@ -4093,6 +4093,10 @@ impl OpenCADStudio {
                                         aabb
                                     },
                                 );
+                        // A 186 k-entity box selection sits at ~800 ms in this
+                        // handler and two guesses about which step owns it have
+                        // both been wrong. Split it.
+                        let t_sel = crate::perf::enabled().then(Instant::now);
                         let area_candidates = self.tabs[i].scene.interaction_candidates_in_aabb(
                             all_wires,
                             world_aabb,
@@ -4101,6 +4105,9 @@ impl OpenCADStudio {
                             eye,
                             bounds,
                         );
+                        let cand_ms = t_sel
+                            .map_or(0.0, |t| t.elapsed().as_secs_f64() * 1000.0);
+                        let t_hit = crate::perf::enabled().then(Instant::now);
                         let candidate_handles = self.tabs[i]
                             .scene
                             .interaction_candidate_handles(&area_candidates);
@@ -4161,20 +4168,30 @@ impl OpenCADStudio {
                         // selection, Shift+box removes the boxed
                         // entities. Esc / empty-space click still clears.
                         // PICKADD 0 (#226): a plain box REPLACES.
+                        let hit_ms = t_hit
+                            .map_or(0.0, |t| t.elapsed().as_secs_f64() * 1000.0);
+                        let t_apply = crate::perf::enabled().then(Instant::now);
                         if self.shift_down || self.select_remove_mode {
-                            for h in &handles {
-                                self.tabs[i].scene.deselect_entity(*h);
-                            }
+                            self.tabs[i].scene.deselect_entities(&handles);
                         } else {
                             if !selection_pick_add && !handles.is_empty() {
                                 self.tabs[i].scene.deselect_all();
                             }
-                            for h in &handles {
-                                self.tabs[i].scene.select_entity(*h, false);
-                            }
+                            self.tabs[i].scene.select_entities(&handles);
                             self.tabs[i].scene.expand_selection_for_groups(&handles);
                         }
+                        let apply_ms = t_apply
+                            .map_or(0.0, |t| t.elapsed().as_secs_f64() * 1000.0);
+                        let t_props = crate::perf::enabled().then(Instant::now);
                         self.refresh_properties();
+                        if crate::perf::enabled() {
+                            crate::perf_record!(
+                                "[perf] select-commit kind=drag-box candidates={cand_ms:.1}ms \
+hit={hit_ms:.1}ms apply={apply_ms:.1}ms properties={:.1}ms picked={}",
+                                t_props.map_or(0.0, |t| t.elapsed().as_secs_f64() * 1000.0),
+                                handles.len(),
+                            );
+                        }
                         selection_just_completed = true;
                     }
                 } else {
@@ -4208,9 +4225,7 @@ impl OpenCADStudio {
                     // leaves the current selection untouched so a stray
                     // drag never discards hard-won picks.
                     if self.shift_down || self.select_remove_mode {
-                        for h in &handles {
-                            self.tabs[i].scene.deselect_entity(*h);
-                        }
+                        self.tabs[i].scene.deselect_entities(&handles);
                     } else {
                         // PICKADD 0 (#226): a plain marquee REPLACES
                         // the selection (empty results still leave it
@@ -4218,9 +4233,7 @@ impl OpenCADStudio {
                         if !selection_pick_add && !handles.is_empty() {
                             self.tabs[i].scene.deselect_all();
                         }
-                        for h in &handles {
-                            self.tabs[i].scene.select_entity(*h, false);
-                        }
+                        self.tabs[i].scene.select_entities(&handles);
                         self.tabs[i].scene.expand_selection_for_groups(&handles);
                     }
                     self.refresh_properties();
@@ -4454,6 +4467,10 @@ impl OpenCADStudio {
                                 aabb
                             },
                         );
+                    // This is the path a click-move-click window takes, as
+                    // opposed to a press-drag; it is the one a large selection
+                    // actually goes through.
+                    let t_sel = crate::perf::enabled().then(Instant::now);
                     let area_candidates = self.tabs[i].scene.interaction_candidates_in_aabb(
                         all_wires,
                         world_aabb,
@@ -4462,6 +4479,9 @@ impl OpenCADStudio {
                         eye,
                         bounds,
                     );
+                    let cand_ms =
+                        t_sel.map_or(0.0, |t| t.elapsed().as_secs_f64() * 1000.0);
+                    let t_hit = crate::perf::enabled().then(Instant::now);
                     let candidate_handles = self.tabs[i]
                         .scene
                         .interaction_candidate_handles(&area_candidates);
@@ -4517,27 +4537,39 @@ impl OpenCADStudio {
                         bounds,
                         candidate_handles.as_ref(),
                     ));
+                    let hit_ms = t_hit.map_or(0.0, |t| t.elapsed().as_secs_f64() * 1000.0);
+                    let t_filter = crate::perf::enabled().then(Instant::now);
                     // Selection filter: keep only allowed types.
                     handles.retain(|&h| self.tabs[i].scene.passes_selection_filter(h));
+                    let filter_ms =
+                        t_filter.map_or(0.0, |t| t.elapsed().as_secs_f64() * 1000.0);
+                    let t_apply = crate::perf::enabled().then(Instant::now);
                     // Accumulate (issue #83): a plain box adds to the
                     // current selection, Shift+box removes the boxed
                     // entities. An empty box leaves the selection alone
                     // so an accidental empty drag never discards it.
                     // PICKADD 0 (#226): a plain box REPLACES instead.
                     if self.shift_down || self.select_remove_mode {
-                        for h in &handles {
-                            self.tabs[i].scene.deselect_entity(*h);
-                        }
+                        self.tabs[i].scene.deselect_entities(&handles);
                     } else {
                         if !selection_pick_add && !handles.is_empty() {
                             self.tabs[i].scene.deselect_all();
                         }
-                        for h in &handles {
-                            self.tabs[i].scene.select_entity(*h, false);
-                        }
+                        self.tabs[i].scene.select_entities(&handles);
                         self.tabs[i].scene.expand_selection_for_groups(&handles);
                     }
+                    let apply_ms =
+                        t_apply.map_or(0.0, |t| t.elapsed().as_secs_f64() * 1000.0);
+                    let t_props = crate::perf::enabled().then(Instant::now);
                     self.refresh_properties();
+                    if crate::perf::enabled() {
+                        crate::perf_record!(
+                            "[perf] select-commit kind=window candidates={cand_ms:.1}ms \
+hit={hit_ms:.1}ms filter={filter_ms:.1}ms apply={apply_ms:.1}ms properties={:.1}ms picked={}",
+                            t_props.map_or(0.0, |t| t.elapsed().as_secs_f64() * 1000.0),
+                            handles.len(),
+                        );
+                    }
                     let mut sel = self.tabs[i].scene.selection.borrow_mut();
                     sel.box_last = Some((a, p));
                     sel.box_last_crossing = crossing;

--- a/src/app/update/viewport.rs
+++ b/src/app/update/viewport.rs
@@ -4186,8 +4186,9 @@ impl OpenCADStudio {
                         self.refresh_properties();
                         if crate::perf::enabled() {
                             crate::perf_record!(
-                                "[perf] select-commit kind=drag-box candidates={cand_ms:.1}ms \
-hit={hit_ms:.1}ms apply={apply_ms:.1}ms properties={:.1}ms picked={}",
+                                "[perf] select-commit kind=drag-box crossing={crossing} \
+candidates={cand_ms:.1}ms hit={hit_ms:.1}ms apply={apply_ms:.1}ms \
+properties={:.1}ms picked={}",
                                 t_props.map_or(0.0, |t| t.elapsed().as_secs_f64() * 1000.0),
                                 handles.len(),
                             );
@@ -4564,8 +4565,9 @@ hit={hit_ms:.1}ms apply={apply_ms:.1}ms properties={:.1}ms picked={}",
                     self.refresh_properties();
                     if crate::perf::enabled() {
                         crate::perf_record!(
-                            "[perf] select-commit kind=window candidates={cand_ms:.1}ms \
-hit={hit_ms:.1}ms filter={filter_ms:.1}ms apply={apply_ms:.1}ms properties={:.1}ms picked={}",
+                            "[perf] select-commit kind=window crossing={crossing} \
+candidates={cand_ms:.1}ms hit={hit_ms:.1}ms filter={filter_ms:.1}ms \
+apply={apply_ms:.1}ms properties={:.1}ms picked={}",
                             t_props.map_or(0.0, |t| t.elapsed().as_secs_f64() * 1000.0),
                             handles.len(),
                         );

--- a/src/scene/group_layer.rs
+++ b/src/scene/group_layer.rs
@@ -183,21 +183,22 @@ impl Scene {
         handles: &[Handle],
     ) -> HashSet<Handle> {
         let mut expanded: HashSet<Handle> = handles.iter().copied().collect();
-        expanded.extend(
-            self.document
-                .objects
-                .values()
-                .filter_map(|obj| match obj {
-                    ObjectType::Group(g)
-                        if g.selectable
-                            && handles.iter().any(|handle| g.contains(*handle)) =>
-                    {
-                        Some(g.entities.clone())
-                    }
-                    _ => None,
-                })
-                .flatten(),
-        );
+        // Asked the other way round, this was quadratic: for every group, scan
+        // every selected handle, and `Group::contains` is a linear scan of the
+        // group's own entity list. A box selection of 185 096 entities spent
+        // seconds here.
+        //
+        // The membership set is the *input* handles, not `expanded` — a group
+        // must match because something the user selected is in it, not because
+        // an earlier group already contributed one of its members.
+        let wanted: HashSet<Handle> = handles.iter().copied().collect();
+        for obj in self.document.objects.values() {
+            if let ObjectType::Group(g) = obj {
+                if g.selectable && g.entities.iter().any(|e| wanted.contains(e)) {
+                    expanded.extend(g.entities.iter().copied());
+                }
+            }
+        }
         expanded
     }
 
@@ -209,5 +210,53 @@ impl Scene {
         if self.selected.len() != previous_len {
             self.bump_selection_set();
         }
+    }
+}
+
+#[cfg(test)]
+mod group_expansion_tests {
+    use super::*;
+    use crate::scene::Scene;
+
+    /// Selecting one member of a selectable group selects the whole group, and
+    /// a group nobody touched stays out. The lookup was inverted for speed —
+    /// it asked every group about every selected handle, and `Group::contains`
+    /// scans the group's own list — so the answer has to be shown unchanged.
+    #[test]
+    fn group_expansion_pulls_in_siblings_and_nothing_else() {
+        use acadrust::entities::{EntityType, Line};
+        use acadrust::types::Vector3;
+
+        let mut scene = Scene::new();
+        let mut line = |x: f64| {
+            scene.add_entity(EntityType::Line(Line::from_points(
+                Vector3::new(x, 0.0, 0.0),
+                Vector3::new(x + 1.0, 0.0, 0.0),
+            )))
+        };
+        let (a, b, c) = (line(0.0), line(1.0), line(2.0));
+        let (d, e) = (line(3.0), line(4.0));
+        let lonely = line(9.0);
+        scene.create_group("GRUPPO".to_string(), vec![a, b, c]);
+        scene.create_group("ALTRO".to_string(), vec![d, e]);
+
+        // One member pulls in its siblings, and only its own group's.
+        let from_a = scene.handles_expanded_for_selectable_groups(&[a]);
+        assert_eq!(
+            from_a,
+            [a, b, c].into_iter().collect::<HashSet<_>>(),
+            "selecting a member must select that group and no other",
+        );
+
+        // An entity in no group expands to itself.
+        assert_eq!(
+            scene.handles_expanded_for_selectable_groups(&[lonely]),
+            [lonely].into_iter().collect::<HashSet<_>>(),
+        );
+
+        // Touching both groups pulls in both, and nothing outside them.
+        let both = scene.handles_expanded_for_selectable_groups(&[a, e]);
+        assert_eq!(both, [a, b, c, d, e].into_iter().collect::<HashSet<_>>());
+        assert!(!both.contains(&lonely));
     }
 }

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -1877,6 +1877,13 @@ pub struct Scene {
     entity_block_map_cache: RefCell<Option<(u64, HashMap<Handle, Handle>)>>,
     /// Candidate handles per block, in document order and keyed by geometry epoch.
     block_members_cache: RefCell<Option<BlockMembers>>,
+    /// Annotation handle -> the LEADERs that point at it, resolved once per
+    /// `geometry_epoch`.
+    ///
+    /// Selecting an entity has to pull in a LEADER whose annotation it is, and
+    /// that used to be answered by walking the whole document — per selected
+    /// handle. Selecting N entities cost N document walks.
+    leaders_by_annotation_cache: RefCell<Option<(u64, HashMap<Handle, Vec<Handle>>)>>,
     /// Insert/Viewport/Block/BlockEnd handles omitted by the spatial index.
     unindexable_cache: RefCell<Option<(u64, Vec<Handle>)>>,
     /// `(epoch, layout block, present type names, list exposed to the UI)`.
@@ -2128,6 +2135,7 @@ impl Scene {
             model_extents_cache: RefCell::new(None),
             entity_block_map_cache: RefCell::new(None),
             block_members_cache: RefCell::new(None),
+            leaders_by_annotation_cache: RefCell::new(None),
             unindexable_cache: RefCell::new(None),
             layout_type_names_cache: RefCell::new(None),
             dependency_index_cache: RefCell::new(None),
@@ -10797,6 +10805,8 @@ mod journal_tests {
         assert_eq!(folded.len(), before.len() + 1);
     }
 
+    // Differential oracle: the incrementally-patched entity index must always
+    // equal a from-scratch rebuild after any add / move / erase.
     #[test]
     fn block_member_index_matches_the_full_scan() {
         use acadrust::entities::Line;

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -7865,11 +7865,18 @@ impl Scene {
         (Arc::new(wires), base_slots, changed_slots)
     }
 
+    /// `area_only` skips the snap-only categories and gathers the rest without
+    /// sorting; see [`InteractionIndex::query_xy_area`]. Both the overlay path
+    /// and the plain indexed path honour it — the overlay runs whenever the
+    /// drawing has been edited since the index was built, which is most of a
+    /// working session, so a saving that stopped there would stop the first
+    /// time the user drew something.
     fn indexed_interaction_candidates_xy(
         &self,
         wires: Arc<Vec<WireModel>>,
         aabb: [f64; 4],
         allow_pending_empty: bool,
+        area_only: bool,
     ) -> crate::scene::pick::interaction_index::InteractionCandidates {
         if let Some((base_epoch, base, changes)) = self.interaction_overlay_base() {
             let perf = crate::perf::enabled();
@@ -7888,11 +7895,20 @@ impl Scene {
             );
             let local_ms = t_local.elapsed().as_secs_f64() * 1000.0;
             let t_remap = iced::time::Instant::now();
-            let mut result =
-                base.query_remapped_xy(Arc::clone(&local), &base_slots, aabb);
-            result.extend_indexed(
-                changed_index.query_remapped_xy(local, &changed_slots, aabb),
-            );
+            let mut result = if area_only {
+                base.query_remapped_xy_area(Arc::clone(&local), &base_slots, aabb)
+            } else {
+                base.query_remapped_xy(Arc::clone(&local), &base_slots, aabb)
+            };
+            if area_only {
+                result.extend_indexed_area(
+                    changed_index.query_remapped_xy_area(local, &changed_slots, aabb),
+                );
+            } else {
+                result.extend_indexed(
+                    changed_index.query_remapped_xy(local, &changed_slots, aabb),
+                );
+            }
             let remap_ms = t_remap.elapsed().as_secs_f64() * 1000.0;
             let total_ms = t0.elapsed().as_secs_f64() * 1000.0;
             if perf && total_ms >= 50.0 {
@@ -7910,7 +7926,11 @@ impl Scene {
             return result;
         }
         if let Some(index) = self.cached_interaction_index(&wires) {
-            index.query_xy(wires, aabb)
+            if area_only {
+                index.query_xy_area(wires, aabb)
+            } else {
+                index.query_xy(wires, aabb)
+            }
         } else if allow_pending_empty
             && self.interaction_index_pending_key.get()
             == Some((self.geometry_epoch, Arc::as_ptr(&wires) as usize))
@@ -8233,12 +8253,18 @@ impl Scene {
             cursor.x + radius,
             cursor.y + radius,
         ];
-        self.indexed_interaction_candidates_xy(wires, query, allow_pending_empty)
+        self.indexed_interaction_candidates_xy(wires, query, allow_pending_empty, false)
     }
 
     /// Shared rectangular broad phase for box/lasso/fence and command windows.
     /// Flat orthographic views query world XY; tilted/perspective views query
     /// projected 3D bounds using the supplied screen rectangle.
+    /// Candidates for an area selection: box, crossing, fence and lasso.
+    ///
+    /// Every caller feeds the result to the box/fence hit tests and to
+    /// `interaction_candidate_handles`, none of which snap, so the flat-ortho
+    /// path asks for the reduced category set. A caller that needs snapping
+    /// belongs on `interaction_candidates_near` instead.
     pub fn interaction_candidates_in_aabb(
         &self,
         wires: Arc<Vec<WireModel>>,
@@ -8275,6 +8301,7 @@ impl Scene {
                 wires,
                 [aabb[0] - pad, aabb[1] - pad, aabb[2] + pad, aabb[3] + pad],
                 false,
+                true,
             )
         } else {
             self.indexed_interaction_candidates_screen(
@@ -8330,7 +8357,7 @@ impl Scene {
 
     pub fn interaction_handles_in_world_aabb(&self, aabb: [f64; 4]) -> HashSet<Handle> {
         let wires = self.hit_test_wires();
-        let candidates = self.indexed_interaction_candidates_xy(wires, aabb, false);
+        let candidates = self.indexed_interaction_candidates_xy(wires, aabb, false, false);
         let mut handles: HashSet<Handle> = candidates
             .iter()
             .filter_map(|wire| Self::handle_from_wire_name(&wire.name))

--- a/src/scene/pick/hit_test.rs
+++ b/src/scene/pick/hit_test.rs
@@ -13,7 +13,7 @@ use iced::{Point, Rectangle};
 use crate::scene::model::hatch_model::HatchModel;
 use crate::scene::model::mesh_model::MeshModel;
 use crate::scene::model::wire_model::WireModel;
-use crate::scene::pick::interaction_index::WireSource;
+use crate::scene::pick::interaction_index::{SegmentRef, WireSource};
 
 /// Pick radius for one wire, in screen pixels.
 ///
@@ -1247,13 +1247,14 @@ fn indexed_box_crossing_hits<'a, W: WireSource + ?Sized>(
             || (0..4).any(|edge| segments_intersect(a, b, corners[edge], corners[(edge + 1) % 4]))
     };
 
-    for segment in wires.segments().unwrap_or_default() {
-        let Some(wire) = wires.source_wire(segment.wire) else {
-            continue;
-        };
+    // One projection pair per segment, reading nothing but the wire, the view
+    // and the box. Hoisted into a closure so the sequential and the parallel
+    // path below run identical code.
+    let hit_name = |segment: &SegmentRef| -> Option<&'a str> {
+        let wire = wires.source_wire(segment.wire)?;
         let start = segment.start as usize;
         if start + 1 >= wire.points.len() {
-            continue;
+            return None;
         }
         let a = world_to_screen(
             wire_point_world(wire, start, view_rot, eye),
@@ -1267,8 +1268,35 @@ fn indexed_box_crossing_hits<'a, W: WireSource + ?Sized>(
             eye,
             bounds,
         );
-        if segment_hits(a, b) && seen.insert(wire.name.as_str()) {
-            out.push(wire.name.as_str());
+        segment_hits(a, b).then_some(wire.name.as_str())
+    };
+
+    // A crossing selection over a whole drawing spends its time here, not in
+    // the window branch of `box_hit`: every measured `select-commit` line read
+    // `crossing=true`.
+    //
+    // The scan stops projecting a wire once that wire is in. A circle or a
+    // polyline contributes one segment per tessellated span, and every span
+    // after the first that hits can only re-add a name already present — at 24
+    // spans per wire that is 23 projection pairs out of 24 skipped, which took
+    // a 4.4 M-segment scan from ~1 s to 42 ms. The wire is keyed by index, an
+    // integer to hash rather than a string, and the name set still runs behind
+    // it because one entity can produce several wires sharing a name.
+    //
+    // Fanning this out across cores was tried and removed: with the early-out
+    // the remaining work is small enough that per-chunk sets, which cannot see
+    // wires already hit in another chunk, measured *slower* than one pass
+    // (45.6 ms against 42.4 ms at 186 468 wires).
+    let mut wire_hit: HashSet<u32> = HashSet::default();
+    for segment in wires.segments().unwrap_or_default() {
+        if wire_hit.contains(&segment.wire) {
+            continue;
+        }
+        if let Some(name) = hit_name(segment) {
+            wire_hit.insert(segment.wire);
+            if seen.insert(name) {
+                out.push(name);
+            }
         }
     }
     for wire in wires.iter().filter(|wire| wire.point_marker.is_some()) {
@@ -2712,3 +2740,90 @@ mod aabb_reject_tests {
     }
 }
 
+#[cfg(test)]
+mod parallel_selection_tests {
+    use super::*;
+    use crate::scene::pick::interaction_index::{InteractionCandidates, InteractionIndex};
+    use std::sync::Arc;
+
+    // Enough wires to clear the 4096 default several times over, laid on a
+    // diagonal so the selection box catches a known prefix of them rather than
+    // all or nothing — an "everything hits" case would not notice a reordering.
+    // A drawing is not made of single segments: a circle or an arc tessellates
+    // into dozens of spans, and a polyline carries as many as it has vertices.
+    // A one-segment-per-wire sample makes the per-wire early-out invisible and
+    // the whole measurement optimistic, so the benchmark uses `spans` per wire.
+    fn many_wires_with_spans(count: usize, spans: usize) -> Vec<WireModel> {
+        (0..count)
+            .map(|i| {
+                let t = i as f32 / count as f32;
+                let x = -0.95 + 1.9 * t;
+                let y = -0.95 + 1.9 * t;
+                let points: Vec<[f32; 3]> = (0..=spans)
+                    .map(|s| {
+                        let f = s as f32 / spans as f32;
+                        [x + 0.01 * f, y + 0.01 * f, 0.0]
+                    })
+                    .collect();
+                let mut w = WireModel::solid(
+                    (i as u64 + 1).to_string(),
+                    points,
+                    [1.0; 4],
+                    false,
+                );
+                w.aabb = [x, y, x + 0.01, y + 0.01];
+                w
+            })
+            .collect()
+    }
+
+    // Not a correctness test — a measurement, at the size the user's drawing
+    // actually is. Run it deliberately:
+    //
+    //     cargo test --release --lib selection_scaling -- --ignored --nocapture
+    #[test]
+    #[ignore = "measurement, not a check"]
+    fn selection_scaling_numbers() {
+        use std::time::Instant;
+        let wires = many_wires_with_spans(186_468, 24);
+        let index = InteractionIndex::build(&wires);
+        let arc = Arc::new(wires);
+        let aabb = [-2.0, -2.0, 2.0, 2.0];
+
+        let t = Instant::now();
+        let full = index.query_xy(Arc::clone(&arc), aabb);
+        let full_ms = t.elapsed().as_secs_f64() * 1000.0;
+
+        let t = Instant::now();
+        let area = index.query_xy_area(Arc::clone(&arc), aabb);
+        let area_ms = t.elapsed().as_secs_f64() * 1000.0;
+
+        let bounds = Rectangle {
+            x: 0.0,
+            y: 0.0,
+            width: 200.0,
+            height: 200.0,
+        };
+        let run = |candidates: &InteractionCandidates| {
+            let t = Instant::now();
+            let hits = box_hit(
+                Point::new(0.0, 0.0),
+                Point::new(200.0, 200.0),
+                true,
+                candidates,
+                Mat4::IDENTITY,
+                glam::DVec3::ZERO,
+                bounds,
+            );
+            (t.elapsed().as_secs_f64() * 1000.0, hits.len())
+        };
+        let (scan_ms, scan_n) = run(&area);
+
+        println!(
+            "candidates: full={full_ms:.1}ms ({} wires) area={area_ms:.1}ms ({} wires)",
+            full.len(),
+            area.len(),
+        );
+        println!("crossing scan: {scan_ms:.1}ms ({scan_n} hits)");
+    }
+}

--- a/src/scene/pick/interaction_index.rs
+++ b/src/scene/pick/interaction_index.rs
@@ -458,6 +458,76 @@ impl SpatialGrid {
         }
     }
 
+    /// The same set as [`SpatialGrid::query`], in cell order and with
+    /// duplicates left in.
+    ///
+    /// `query` sorts twice over the result — once to dedup the entry indices an
+    /// entry gets for spanning several cells, once to dedup the values — which
+    /// over a box covering the drawing is two O(n log n) passes across 4.4 M
+    /// elements to remove a handful of repeats. Everything an area selection
+    /// does with the result is order-independent and dedups anyway: the
+    /// crossing scan keys wires by index and names by string, and the box test
+    /// on a segment does not care when it runs.
+    ///
+    /// Click picking keeps [`SpatialGrid::query`]: it resolves ties between
+    /// overlapping geometry by scan order, so its order is part of which entity
+    /// a click selects.
+    fn query_unordered<T: Copy>(&self, entries: &[Entry3<T>], query: [f64; 4]) -> Vec<T> {
+        let mut indices = Vec::new();
+        self.oversized.query(entries, query, &mut indices);
+        let mut out: Vec<T> = indices
+            .into_iter()
+            .filter_map(|idx| {
+                let entry = entries.get(idx as usize)?;
+                aabb_overlaps(entry_aabb2(entry), query).then_some(entry.value)
+            })
+            .collect();
+
+        let grid_max_x = self.min[0] + self.cols as f64 * self.cell;
+        let grid_max_y = self.min[1] + self.rows as f64 * self.cell;
+        if query[2] < self.min[0]
+            || query[3] < self.min[1]
+            || query[0] > grid_max_x
+            || query[1] > grid_max_y
+        {
+            return out;
+        }
+        let col = |x: f64| {
+            (((x - self.min[0]) / self.cell).floor()).clamp(0.0, (self.cols - 1) as f64) as u32
+        };
+        let row = |y: f64| {
+            (((y - self.min[1]) / self.cell).floor()).clamp(0.0, (self.rows - 1) as f64) as u32
+        };
+        let (row_lo, row_hi) = (row(query[1]), row(query[3]));
+        let (col_lo, col_hi) = (col(query[0]), col(query[2]));
+
+        // One growth instead of a chain of reallocations: a box over the whole
+        // drawing lands nearly every entry here.
+        let spanned: usize = (row_lo..=row_hi)
+            .map(|r| {
+                let base = r as usize * self.cols as usize;
+                let start = self.cell_offsets[base + col_lo as usize] as usize;
+                let end = self.cell_offsets[base + col_hi as usize + 1] as usize;
+                end.saturating_sub(start)
+            })
+            .sum();
+        out.reserve(spanned);
+
+        for r in row_lo..=row_hi {
+            let base = r as usize * self.cols as usize;
+            for c in col_lo..=col_hi {
+                let cell_idx = base + c as usize;
+                let start = self.cell_offsets[cell_idx] as usize;
+                let end = self.cell_offsets[cell_idx + 1] as usize;
+                out.extend(self.cell_entries[start..end].iter().filter_map(|&idx| {
+                    let entry = entries.get(idx as usize)?;
+                    aabb_overlaps(entry_aabb2(entry), query).then_some(entry.value)
+                }));
+            }
+        }
+        out
+    }
+
     fn query<T: Copy + Ord>(&self, entries: &[Entry3<T>], query: [f64; 4]) -> Vec<T> {
         let mut entry_indices = Vec::new();
         self.oversized.query(entries, query, &mut entry_indices);
@@ -518,6 +588,11 @@ impl<T: Copy + Ord + Sync> SpatialSet<T> {
 
     fn query_xy(&self, aabb: [f64; 4]) -> Vec<T> {
         self.xy.query(&self.entries, aabb)
+    }
+
+    /// See [`SpatialGrid::query_unordered`] — same set, no sort, duplicates in.
+    fn query_xy_unordered(&self, aabb: [f64; 4]) -> Vec<T> {
+        self.xy.query_unordered(&self.entries, aabb)
     }
 
     fn prepare_screen(&self) {
@@ -1136,6 +1211,59 @@ impl InteractionIndex {
             .collect()
     }
 
+    /// [`InteractionIndex::query_remapped_xy`] for an area selection.
+    ///
+    /// The overlay path runs whenever the drawing has been edited since the
+    /// interaction index was built — that is, for most of a working session —
+    /// so leaving it on the full query would have meant the area selection got
+    /// its saving only until the user drew something. Same five categories,
+    /// same unordered gather.
+    pub(crate) fn query_remapped_xy_area(
+        &self,
+        wires: Arc<Vec<WireModel>>,
+        slots: &rustc_hash::FxHashMap<(u64, u32), u32>,
+        aabb: [f64; 4],
+    ) -> InteractionCandidates {
+        InteractionCandidates {
+            wires,
+            wire_indices: Some(self.remap_wire_indices(
+                self.wires.query_xy_unordered(aabb),
+                slots,
+                false,
+            )),
+            segments: Some(self.remap_refs(
+                self.segments.query_xy_unordered(aabb),
+                slots,
+                |value| value.wire,
+                |value, wire| value.wire = wire,
+            )),
+            snap_points: None,
+            key_vertices: None,
+            key_segments: None,
+            fill_triangles: Some(self.remap_refs(
+                self.fill_triangles.query_xy_unordered(aabb),
+                slots,
+                |value| value.wire,
+                |value, wire| value.wire = wire,
+            )),
+            pick_triangles: Some(self.remap_refs(
+                self.pick_triangles.query_xy_unordered(aabb),
+                slots,
+                |value| value.wire,
+                |value, wire| value.wire = wire,
+            )),
+            glyphs: Some(self.remap_refs(
+                self.glyphs.query_xy_unordered(aabb),
+                slots,
+                |value| value.wire,
+                |value, wire| value.wire = wire,
+            )),
+            query_aabb: Some(aabb),
+            screen_rect: None,
+            screen_view: None,
+        }
+    }
+
     pub(crate) fn query_remapped_xy(
         &self,
         wires: Arc<Vec<WireModel>>,
@@ -1266,6 +1394,76 @@ impl InteractionIndex {
             query_aabb: None,
             screen_rect: Some(screen_rect),
             screen_view: Some((view_rot, eye, bounds)),
+        }
+    }
+
+    /// Candidates for an area selection — box, crossing or fence.
+    ///
+    /// `query_xy` runs eight spatial queries because hover and snapping need
+    /// them all. An area selection needs five: the wires and their segments,
+    /// and — because `indexed_box_crossing_hits` reads them to catch hatches
+    /// and text inside the box — the fill triangles, pick triangles and
+    /// glyphs. Only the three that exist for snapping (`snap_points`,
+    /// `key_vertices`, `key_segments`, read solely by `pick::snap::snap`) go
+    /// unread, so only those are skipped.
+    ///
+    /// Over a box covering the whole drawing each query gathers nearly
+    /// everything, which is why this is worth splitting: gathering candidates
+    /// was 407 ms of an 825 ms selection of 186 468 entities.
+    ///
+    /// The skipped categories stay `None`. That is safe *only* for consumers
+    /// that never read them — `snap` would silently stop snapping rather than
+    /// fail, since the accessors treat `None` as "no index". Route anything
+    /// that snaps through `query_xy`.
+    pub fn query_xy_area(
+        &self,
+        wires: Arc<Vec<WireModel>>,
+        aabb: [f64; 4],
+    ) -> InteractionCandidates {
+        // The five are independent tree walks over the same box, and over a box
+        // covering the drawing each one gathers nearly everything — 259 ms
+        // together. Running them concurrently costs the largest instead of the
+        // sum. Each closure still calls the same query, so the results are
+        // identical to the sequential ones, order included.
+        let ((wire_indices, segments), ((fill_triangles, pick_triangles), glyphs)) =
+            rayon::join(
+                || {
+                    rayon::join(
+                        || {
+                            let mut indices = self.wires.query_xy_unordered(aabb);
+                            indices.extend_from_slice(&self.unbounded_wires);
+                            indices.sort_unstable();
+                            indices.dedup();
+                            indices
+                        },
+                        || self.segments.query_xy_unordered(aabb),
+                    )
+                },
+                || {
+                    rayon::join(
+                        || {
+                            rayon::join(
+                                || self.fill_triangles.query_xy_unordered(aabb),
+                                || self.pick_triangles.query_xy_unordered(aabb),
+                            )
+                        },
+                        || self.glyphs.query_xy_unordered(aabb),
+                    )
+                },
+            );
+        InteractionCandidates {
+            wires,
+            wire_indices: Some(wire_indices),
+            segments: Some(segments),
+            snap_points: None,
+            key_vertices: None,
+            key_segments: None,
+            fill_triangles: Some(fill_triangles),
+            pick_triangles: Some(pick_triangles),
+            glyphs: Some(glyphs),
+            query_aabb: Some(aabb),
+            screen_rect: None,
+            screen_view: None,
         }
     }
 
@@ -1503,6 +1701,39 @@ impl InteractionCandidates {
         self.screen_rect
             .zip(self.screen_view)
             .map(|(rect, (view, eye, bounds))| (rect, view, eye, bounds))
+    }
+
+    /// [`InteractionCandidates::extend_indexed`] for an area selection.
+    ///
+    /// `extend_indexed` sorts and dedups every category it merges, which over a
+    /// box covering the drawing would put back exactly the sorts the unordered
+    /// query exists to avoid.
+    ///
+    /// `wire_indices` keeps its dedup, and must: the window branch of `box_hit`
+    /// walks it directly, so a wire listed twice would be selected twice. The
+    /// other categories are read by scans that dedup by wire index and by name
+    /// already, so a repeat there costs one extra test and changes nothing.
+    pub(crate) fn extend_indexed_area(&mut self, other: Self) {
+        debug_assert!(Arc::ptr_eq(&self.wires, &other.wires));
+
+        fn append<T>(target: &mut Option<Vec<T>>, incoming: Option<Vec<T>>) {
+            let (Some(target), Some(incoming)) = (target.as_mut(), incoming) else {
+                return;
+            };
+            target.extend(incoming);
+        }
+
+        if let (Some(target), Some(incoming)) =
+            (self.wire_indices.as_mut(), other.wire_indices)
+        {
+            target.extend(incoming);
+            target.sort_unstable();
+            target.dedup();
+        }
+        append(&mut self.segments, other.segments);
+        append(&mut self.fill_triangles, other.fill_triangles);
+        append(&mut self.pick_triangles, other.pick_triangles);
+        append(&mut self.glyphs, other.glyphs);
     }
 
     pub(crate) fn extend_indexed(&mut self, other: Self) {
@@ -1829,4 +2060,156 @@ fn aabb3_projects_into(
 
 fn aabb_overlaps(a: [f64; 4], b: [f64; 4]) -> bool {
     a[2] >= b[0] && a[0] <= b[2] && a[3] >= b[1] && a[1] <= b[3]
+}
+
+#[cfg(test)]
+mod area_query_tests {
+    use super::*;
+    use iced::{Point, Rectangle};
+
+    fn wire(name: &str, pts: Vec<[f32; 3]>, aabb: [f32; 4]) -> WireModel {
+        let mut w = WireModel::solid(name.to_string(), pts, [1.0; 4], false);
+        w.aabb = aabb;
+        w
+    }
+
+    fn sample() -> Vec<WireModel> {
+        vec![
+            wire("5", vec![[-0.5, -0.5, 0.0], [0.5, 0.5, 0.0]], [-0.5, -0.5, 0.5, 0.5]),
+            wire("9", vec![[0.1, -0.9, 0.0], [0.9, -0.1, 0.0]], [0.1, -0.9, 0.9, -0.1]),
+            wire("13", vec![[-0.9, 0.2, 0.0], [-0.2, 0.9, 0.0]], [-0.9, 0.2, -0.2, 0.9]),
+        ]
+    }
+
+    // The area query drops the three snap-only categories and must leave every
+    // category an area selection reads untouched. `unwrap_or_default()` in
+    // `indexed_box_crossing_hits` would turn a wrongly-dropped category into a
+    // silent miss — a hatch or a text that stops being selectable — rather than
+    // a failure, so the equivalence is asserted rather than assumed.
+    #[test]
+    fn area_query_matches_full_query_where_it_is_read() {
+        let wires = sample();
+        let index = InteractionIndex::build(&wires);
+        let arc = Arc::new(wires);
+        let aabb = [-2.0, -2.0, 2.0, 2.0];
+
+        let full = index.query_xy(Arc::clone(&arc), aabb);
+        let area = index.query_xy_area(Arc::clone(&arc), aabb);
+
+        // The area query skips the sort and the dedup `query` pays for, so it
+        // returns the same *set* in cell order, with an entry repeated once per
+        // cell it spans. Every consumer on this path dedups already — the
+        // crossing scan by wire index and by name — so the set is the contract,
+        // and comparing sequences here would only pin down an order nothing
+        // reads. `wire_indices` is the exception: `query_xy_area` sorts and
+        // dedups it before returning, so it must match exactly.
+        fn normalise<T: Copy + Ord>(v: &Option<Vec<T>>) -> Option<Vec<T>> {
+            v.as_ref().map(|items| {
+                let mut items = items.clone();
+                items.sort_unstable();
+                items.dedup();
+                items
+            })
+        }
+        assert_eq!(area.wire_indices, full.wire_indices);
+        assert_eq!(normalise(&area.segments), normalise(&full.segments));
+        assert_eq!(
+            normalise(&area.fill_triangles),
+            normalise(&full.fill_triangles),
+        );
+        assert_eq!(
+            normalise(&area.pick_triangles),
+            normalise(&full.pick_triangles),
+        );
+        assert_eq!(normalise(&area.glyphs), normalise(&full.glyphs));
+        assert_eq!(area.query_aabb, full.query_aabb);
+
+        // The sample carries no hatches or text, so the equality above is
+        // thin for those three. What matters is that they stay indexed at all:
+        // dropping one to `None` is what would silently unselect a hatch.
+        assert!(area.fill_triangles.is_some());
+        assert!(area.pick_triangles.is_some());
+        assert!(area.glyphs.is_some());
+
+        assert!(area.snap_points.is_none());
+        assert!(area.key_vertices.is_none());
+        assert!(area.key_segments.is_none());
+        assert!(full.snap_points.is_some(), "the full query still snaps");
+    }
+
+    // The overlay merge drops the sort on every category but one. That one
+    // matters: the window branch of `box_hit` walks `wire_indices` directly, so
+    // a wire left in twice would be selected twice — a duplicate handle rather
+    // than an error, which is the kind of thing that surfaces as a wrong count
+    // somewhere far away.
+    #[test]
+    fn the_area_merge_dedups_wire_indices_and_nothing_else() {
+        let arc = Arc::new(sample());
+        let base = |indices: Vec<u32>, segments: Vec<SegmentRef>| InteractionCandidates {
+            wires: Arc::clone(&arc),
+            wire_indices: Some(indices),
+            segments: Some(segments),
+            snap_points: None,
+            key_vertices: None,
+            key_segments: None,
+            fill_triangles: Some(Vec::new()),
+            pick_triangles: Some(Vec::new()),
+            glyphs: Some(Vec::new()),
+            query_aabb: Some([-2.0, -2.0, 2.0, 2.0]),
+            screen_rect: None,
+            screen_view: None,
+        };
+        let seg = |wire: u32| SegmentRef { wire, start: 0 };
+
+        let mut merged = base(vec![2, 0], vec![seg(2), seg(0)]);
+        merged.extend_indexed_area(base(vec![1, 0], vec![seg(1), seg(0)]));
+
+        assert_eq!(merged.wire_indices, Some(vec![0, 1, 2]));
+        assert_eq!(
+            merged.segments,
+            Some(vec![seg(2), seg(0), seg(1), seg(0)]),
+            "the other categories are appended as they come",
+        );
+    }
+
+    // World (x,y) → screen ((x+1)*100, (1-y)*100) over a 200×200 viewport, the
+    // same identity ortho view the hit-test tests use.
+    #[test]
+    fn box_selection_picks_the_same_handles_from_either_query() {
+        let wires = sample();
+        let index = InteractionIndex::build(&wires);
+        let arc = Arc::new(wires);
+        let aabb = [-2.0, -2.0, 2.0, 2.0];
+        let bounds = Rectangle {
+            x: 0.0,
+            y: 0.0,
+            width: 200.0,
+            height: 200.0,
+        };
+        let eye = glam::DVec3::ZERO;
+
+        for crossing in [false, true] {
+            let full = index.query_xy(Arc::clone(&arc), aabb);
+            let area = index.query_xy_area(Arc::clone(&arc), aabb);
+            let hit = |c: &InteractionCandidates| {
+                let mut names = crate::scene::pick::hit_test::box_hit(
+                    Point::new(0.0, 0.0),
+                    Point::new(200.0, 200.0),
+                    crossing,
+                    c,
+                    glam::Mat4::IDENTITY,
+                    eye,
+                    bounds,
+                )
+                .into_iter()
+                .map(str::to_string)
+                .collect::<Vec<_>>();
+                names.sort();
+                names
+            };
+            let from_full = hit(&full);
+            assert!(!from_full.is_empty(), "the box covers the whole sample");
+            assert_eq!(hit(&area), from_full, "crossing={crossing}");
+        }
+    }
 }

--- a/src/scene/selection.rs
+++ b/src/scene/selection.rs
@@ -4,11 +4,110 @@ impl Scene {
     // ── Selection ─────────────────────────────────────────────────────────
     /// Treat a classic LEADER and its attached annotation as one logical object.
     /// Clicking/copying/deleting either side expands to the complete pair.
+    /// Every LEADER that points at `annotation`, resolved once per
+    /// `geometry_epoch` rather than by walking the document per handle.
+    fn leaders_by_annotation(
+        &self,
+    ) -> std::cell::Ref<'_, (u64, HashMap<Handle, Vec<Handle>>)> {
+        {
+            let cache = self.leaders_by_annotation_cache.borrow();
+            if cache.as_ref().is_some_and(|(epoch, _)| *epoch == self.geometry_epoch) {
+                drop(cache);
+                return std::cell::Ref::map(
+                    self.leaders_by_annotation_cache.borrow(),
+                    |c| c.as_ref().unwrap(),
+                );
+            }
+        }
+        let mut by_annotation: HashMap<Handle, Vec<Handle>> = HashMap::default();
+        for entity in self.document.entities() {
+            if let EntityType::Leader(leader) = entity {
+                if !leader.annotation_handle.is_null() {
+                    by_annotation
+                        .entry(leader.annotation_handle)
+                        .or_default()
+                        .push(entity.common().handle);
+                }
+            }
+        }
+        *self.leaders_by_annotation_cache.borrow_mut() =
+            Some((self.geometry_epoch, by_annotation));
+        std::cell::Ref::map(self.leaders_by_annotation_cache.borrow(), |c| {
+            c.as_ref().unwrap()
+        })
+    }
+
+    /// The handles plus their leader/annotation partners, in the order given.
+    ///
+    /// Kept separate from the sorted, deduplicated form because a bulk
+    /// selection has to preserve pick order — `selected_handles_in_order`
+    /// reports it — and because sorting per handle is what made selecting
+    /// 186 000 entities one call at a time expensive.
+    fn expanded_with_leaders(&self, handles: &[Handle]) -> Vec<Handle> {
+        let leaders = self.leaders_by_annotation();
+        let mut expanded = Vec::with_capacity(handles.len());
+        for &handle in handles {
+            expanded.push(handle);
+            if let Some(EntityType::Leader(leader)) = self.document.get_entity(handle) {
+                if !leader.annotation_handle.is_null() {
+                    expanded.push(leader.annotation_handle);
+                }
+            }
+            if let Some(pointing) = leaders.1.get(&handle) {
+                expanded.extend(pointing.iter().copied());
+            }
+        }
+        expanded
+    }
+
+    /// Select many handles in one pass.
+    ///
+    /// The single-handle path allocates, sorts and deduplicates for every
+    /// entity, and a box selection called it once per entity — most of the
+    /// remaining 786 ms of a 186 460-entity selection.
+    pub fn select_entities(&mut self, handles: &[Handle]) {
+        if handles.is_empty() {
+            return;
+        }
+        let expanded = self.expanded_with_leaders(handles);
+        let mut changed = false;
+        for handle in expanded {
+            if self.selected.insert(handle) {
+                self.selected_order.push(handle);
+                changed = true;
+            }
+        }
+        if changed {
+            self.bump_selection_set();
+        }
+    }
+
+    /// Deselect many handles in one pass.
+    ///
+    /// `deselect_entity` rebuilds `selected_order` with a `retain` per handle,
+    /// so removing N of M selected entities walked the order list N times.
+    pub fn deselect_entities(&mut self, handles: &[Handle]) {
+        if handles.is_empty() {
+            return;
+        }
+        let doomed: HashSet<Handle> =
+            self.expanded_with_leaders(handles).into_iter().collect();
+        let mut changed = false;
+        for handle in &doomed {
+            changed |= self.selected.remove(handle);
+        }
+        if changed {
+            self.selected_order.retain(|handle| !doomed.contains(handle));
+            self.bump_selection_set();
+        }
+    }
+
     pub(crate) fn handles_expanded_for_leader_annotations(
         &self,
         handles: &[Handle],
     ) -> Vec<Handle> {
         let mut expanded = handles.to_vec();
+        let leaders = self.leaders_by_annotation();
 
         for &handle in handles {
             // LEADER -> annotation.
@@ -19,15 +118,9 @@ impl Scene {
             }
 
             // Annotation -> LEADER.
-            expanded.extend(self.document.entities().filter_map(|entity| match entity {
-                EntityType::Leader(leader)
-                    if !leader.annotation_handle.is_null()
-                        && leader.annotation_handle == handle =>
-                {
-                    Some(entity.common().handle)
-                }
-                _ => None,
-            }));
+            if let Some(pointing) = leaders.1.get(&handle) {
+                expanded.extend(pointing.iter().copied());
+            }
         }
 
         expanded.sort_unstable_by_key(|handle| handle.value());
@@ -1003,6 +1096,135 @@ impl Scene {
 mod tests {
     use super::*;
 
+    /// A box selection used to call `select_entity` once per entity. The bulk
+    /// path has to land on the same selection, in the same pick order —
+    /// `selected_handles_in_order` is read by commands such as DIM, where the
+    /// order the user picked things in decides what they mean.
+    #[test]
+    fn bulk_selection_matches_selecting_one_at_a_time() {
+        use acadrust::entities::Line;
+        use acadrust::types::Vector3;
+
+        let build = || {
+            let mut scene = Scene::new();
+            let handles: Vec<_> = (0..40)
+                .map(|k| {
+                    let x = k as f64;
+                    scene.add_entity(EntityType::Line(Line::from_points(
+                        Vector3::new(x, 0.0, 0.0),
+                        Vector3::new(x + 1.0, 0.0, 0.0),
+                    )))
+                })
+                .collect();
+            (scene, handles)
+        };
+
+        // Picked in an order that is neither creation nor handle order.
+        let picked = |handles: &[Handle]| -> Vec<Handle> {
+            let mut order: Vec<_> = handles.iter().copied().collect();
+            order.reverse();
+            order.retain(|h| h.value() % 3 != 0);
+            order
+        };
+
+        let (mut one_at_a_time, handles) = build();
+        let order = picked(&handles);
+        for &handle in &order {
+            one_at_a_time.select_entity(handle, false);
+        }
+
+        let (mut in_bulk, handles) = build();
+        in_bulk.select_entities(&picked(&handles));
+
+        assert_eq!(
+            in_bulk.selected_handles_in_order(),
+            one_at_a_time.selected_handles_in_order(),
+            "the bulk path must select the same entities in the same order",
+        );
+
+        // And removing a subset must agree too.
+        let drop: Vec<_> = order.iter().copied().take(7).collect();
+        for &handle in &drop {
+            one_at_a_time.deselect_entity(handle);
+        }
+        in_bulk.deselect_entities(&drop);
+        assert_eq!(
+            in_bulk.selected_handles_in_order(),
+            one_at_a_time.selected_handles_in_order(),
+            "the bulk removal must leave the same selection in the same order",
+        );
+    }
+
+    /// Selecting an entity pulls in any LEADER pointing at it, and that was
+    /// answered by walking the whole document once per selected handle —
+    /// selecting 471 583 entities in a 585 786-entity drawing did not finish
+    /// inside eight minutes. The reverse index has to give exactly what the
+    /// walk gave.
+    #[test]
+    fn the_leader_index_matches_a_document_walk() {
+        use acadrust::entities::Leader;
+        use acadrust::types::Vector3;
+
+        let mut scene = Scene::new();
+        let line = |x: f64| {
+            EntityType::Line(acadrust::entities::Line::from_points(
+                Vector3::new(x, 0.0, 0.0),
+                Vector3::new(x + 1.0, 0.0, 0.0),
+            ))
+        };
+        let annotation = scene.add_entity(line(0.0));
+        let unrelated = scene.add_entity(line(5.0));
+        let mut leader_on = |target: Handle| {
+            let mut leader = Leader::default();
+            leader.annotation_handle = target;
+            scene.add_entity(EntityType::Leader(leader))
+        };
+        // Two leaders share one annotation; a third points nowhere.
+        let first = leader_on(annotation);
+        let second = leader_on(annotation);
+        let dangling = leader_on(Handle::NULL);
+
+        // The walk this replaced, written out so the index is compared against
+        // behaviour rather than against itself.
+        let by_walk = |handle: Handle| -> Vec<Handle> {
+            let mut out = vec![handle];
+            if let Some(EntityType::Leader(leader)) = scene.document.get_entity(handle) {
+                if !leader.annotation_handle.is_null() {
+                    out.push(leader.annotation_handle);
+                }
+            }
+            out.extend(scene.document.entities().filter_map(|entity| match entity {
+                EntityType::Leader(leader)
+                    if !leader.annotation_handle.is_null()
+                        && leader.annotation_handle == handle =>
+                {
+                    Some(entity.common().handle)
+                }
+                _ => None,
+            }));
+            out.sort_unstable_by_key(Handle::value);
+            out.dedup();
+            out
+        };
+
+        for handle in [annotation, unrelated, first, second, dangling] {
+            assert_eq!(
+                scene.handles_expanded_for_leader_annotations(&[handle]),
+                by_walk(handle),
+                "the index must answer exactly what the walk answered",
+            );
+        }
+        let expanded = scene.handles_expanded_for_leader_annotations(&[annotation]);
+        assert!(
+            expanded.contains(&first) && expanded.contains(&second),
+            "both leaders on one annotation must come back, not just one",
+        );
+    }
+
+    /// The reason the cache carries a set as well as a list: drawing into a
+    /// drawing that already has that type must not rebuild either, because the
+    /// rebuild walks every entity the layout owns — 444 937 of them on the
+    /// reproducer, ~100 ms, on every single drawn point.
     #[test]
     fn adding_a_type_already_present_reuses_the_list() {
         use acadrust::entities::{Circle, EntityType, Line};


### PR DESCRIPTION
Depends on #1098. Area selection queries only the wire, segment, fill-triangle, pick-triangle and glyph categories it consumes. Avoid repeated sorting and projection while retaining wire deduplication and hatch/text selection. Click picking keeps its ordered query path.