### PR TITLE
Align live section wireframes and SECTIONPLANE grips

### DIFF
--- a/src/app/update/viewport.rs
+++ b/src/app/update/viewport.rs
@@ -3049,7 +3049,11 @@ impl OpenCADStudio {
                         return Task::none();
                     };
                     let grip_shape = self.tabs[i].selected_grips[grip_index].shape;
-                    if grip_shape == crate::scene::model::object::GripShape::Dropdown {
+                    if matches!(
+                        grip_shape,
+                        crate::scene::model::object::GripShape::Dropdown
+                            | crate::scene::model::object::GripShape::DropdownAdjacent
+                    ) {
                         use crate::entities::traits::EntityTypeOps;
                         let items = self.tabs[i]
                             .scene

--- a/src/entities/extended.rs
+++ b/src/entities/extended.rs
@@ -1610,10 +1610,10 @@ fn grips(entity: &ExtendedEntity) -> Vec<GripDef> {
                 grips.push(GripDef {
                     id: SECTION_GRIP_NORMAL,
                     world: glam::DVec3::new(center.x, center.y, center.z)
-                        + normal_world * offset,
+                        - normal_world * offset,
                     is_midpoint: false,
                     shape: crate::scene::model::object::GripShape::Triangle,
-                    dir: Some(normal_world),
+                    dir: Some(-normal_world),
                     axis: Some(normal_world),
                 });
             }
@@ -1709,7 +1709,7 @@ fn apply_grip(entity: &mut ExtendedEntity, grip_id: usize, apply: GripApply) {
                     .zip(data.vertices.last())
                     .map_or(1.0, |(first, last)| (*last - *first).length());
                 let offset = (span * 0.08).max(1.0e-6);
-                let current = center + normal * offset;
+                let current = center - normal * offset;
                 let delta = match apply {
                     GripApply::Translate(delta) => Vector3::new(delta.x, delta.y, delta.z),
                     GripApply::Absolute(position) => {

--- a/src/entities/extended.rs
+++ b/src/entities/extended.rs
@@ -13,7 +13,7 @@ use crate::entities::common::{
 use crate::entities::traits::{Grippable, PropertyEditable, Transformable, RenderConvertible};
 use crate::scene::convert::acad_to_render::{RenderEntity, RenderObject};
 use crate::scene::model::object::{
-    GripApply, GripDef, PropSection, PropValue, Property,
+    GripApply, GripDef, GripMenuAction, GripMenuItem, PropSection, PropValue, Property,
 };
 use crate::scene::model::wire_model::SnapHint;
 
@@ -25,6 +25,7 @@ const SECTION_GRIP_RIGHT: usize = 100_001;
 const SECTION_GRIP_TOP: usize = 100_002;
 const SECTION_GRIP_BOTTOM: usize = 100_003;
 const SECTION_GRIP_NORMAL: usize = 100_004;
+const SECTION_GRIP_STATE: usize = 100_005;
 
 pub(crate) fn section_is_slice(entity: &ExtendedEntity) -> bool {
     entity
@@ -1584,6 +1585,19 @@ fn grips(entity: &ExtendedEntity) -> Vec<GripDef> {
                     })
                     .collect()
             };
+            if let Some(right) = data.vertices.last() {
+                let vertical = normalized(data.vertical_direction, Vector3::UNIT_Z);
+                let edge_center_offset = (data.top_height - data.bottom_height) * 0.5;
+                let anchor = *right + vertical * edge_center_offset;
+                grips.push(GripDef {
+                    id: SECTION_GRIP_STATE,
+                    world: glam::DVec3::new(anchor.x, anchor.y, anchor.z),
+                    is_midpoint: false,
+                    shape: crate::scene::model::object::GripShape::DropdownAdjacent,
+                    dir: None,
+                    axis: None,
+                });
+            }
             if let Some(center) = section_center(data) {
                 let normal = section_viewing_direction(data);
                 let span = data
@@ -1789,25 +1803,25 @@ fn section_plane_edge_grips(data: &SectionObjectData) -> Vec<GripDef> {
             SECTION_GRIP_LEFT,
             *first + vertical * edge_center_offset,
             vertical,
-            tangent,
+            None,
         ),
         (
             SECTION_GRIP_RIGHT,
             *last + vertical * edge_center_offset,
             vertical,
-            tangent,
+            None,
         ),
         (
             SECTION_GRIP_TOP,
             center + vertical * data.top_height,
             tangent,
-            vertical,
+            Some(vertical),
         ),
         (
             SECTION_GRIP_BOTTOM,
             center - vertical * data.bottom_height,
             tangent,
-            vertical,
+            Some(vertical),
         ),
     ];
     definitions
@@ -1818,7 +1832,7 @@ fn section_plane_edge_grips(data: &SectionObjectData) -> Vec<GripDef> {
             is_midpoint: false,
             shape: crate::scene::model::object::GripShape::Rectangle,
             dir: Some(glam::DVec3::new(edge.x, edge.y, edge.z)),
-            axis: Some(glam::DVec3::new(axis.x, axis.y, axis.z)),
+            axis: axis.map(|axis| glam::DVec3::new(axis.x, axis.y, axis.z)),
         })
         .collect()
 }
@@ -1850,19 +1864,25 @@ fn apply_section_plane_edge_grip(
     };
     let span = (*last - *first).length();
     let minimum_span = 1.0e-6;
+    let in_plane_vertical = normalized(
+        vertical - tangent * vertical.dot(&tangent),
+        vertical,
+    );
+    let vertical_change = in_plane_vertical * delta.dot(&in_plane_vertical);
     match grip_id {
         SECTION_GRIP_LEFT => {
-            let change = delta
+            let tangent_change = delta
                 .dot(&tangent)
                 .min((span - minimum_span).max(0.0));
-            data.vertices[0] = data.vertices[0] + tangent * change;
+            data.vertices[0] = data.vertices[0] + tangent * tangent_change + vertical_change;
         }
         SECTION_GRIP_RIGHT => {
             let last = data.vertices.len() - 1;
-            let change = delta
+            let tangent_change = delta
                 .dot(&tangent)
                 .max((-span + minimum_span).min(0.0));
-            data.vertices[last] = data.vertices[last] + tangent * change;
+            data.vertices[last] =
+                data.vertices[last] + tangent * tangent_change + vertical_change;
         }
         SECTION_GRIP_TOP => {
             data.top_height = (data.top_height + delta.dot(&vertical)).max(0.0);
@@ -2112,6 +2132,54 @@ impl Grippable for ExtendedEntity {
 
     fn apply_grip(&mut self, grip_id: usize, apply: GripApply) {
         apply_grip(self, grip_id, apply);
+    }
+
+    fn grip_menu(&self, grip_id: usize) -> Vec<GripMenuItem> {
+        if grip_id != SECTION_GRIP_STATE {
+            return Vec::new();
+        }
+        let ExtendedEntityData::SectionObject(data) = &self.data else {
+            return Vec::new();
+        };
+        let current = section_kind(self, data);
+        vec![
+            GripMenuItem {
+                label: if current == "Plane" { "✓ Plane" } else { "Plane" },
+                action: GripMenuAction::SectionPlane,
+            },
+            GripMenuItem {
+                label: if current == "Slice" { "✓ Slice" } else { "Slice" },
+                action: GripMenuAction::SectionSlice,
+            },
+            GripMenuItem {
+                label: if current == "Boundary" {
+                    "✓ Boundary"
+                } else {
+                    "Boundary"
+                },
+                action: GripMenuAction::SectionBoundary,
+            },
+            GripMenuItem {
+                label: if current == "Volume" { "✓ Volume" } else { "Volume" },
+                action: GripMenuAction::SectionVolume,
+            },
+        ]
+    }
+
+    fn apply_grip_menu(&mut self, grip_id: usize, action: GripMenuAction) {
+        if grip_id != SECTION_GRIP_STATE
+            || !matches!(self.data, ExtendedEntityData::SectionObject(_))
+        {
+            return;
+        }
+        let value = match action {
+            GripMenuAction::SectionPlane => "Plane",
+            GripMenuAction::SectionSlice => "Slice",
+            GripMenuAction::SectionBoundary => "Boundary",
+            GripMenuAction::SectionVolume => "Volume",
+            _ => return,
+        };
+        apply_section_prop(self, "ext_section_state", value);
     }
 }
 

--- a/src/entities/extended.rs
+++ b/src/entities/extended.rs
@@ -20,6 +20,11 @@ use crate::scene::model::wire_model::SnapHint;
 const NAN: [f64; 3] = [f64::NAN; 3];
 const SECTION_SLICE_APP: &str = "IsSlice";
 const SECTION_THICKNESS_APP: &str = "ThicknessDepth";
+const SECTION_GRIP_LEFT: usize = 100_000;
+const SECTION_GRIP_RIGHT: usize = 100_001;
+const SECTION_GRIP_TOP: usize = 100_002;
+const SECTION_GRIP_BOTTOM: usize = 100_003;
+const SECTION_GRIP_NORMAL: usize = 100_004;
 
 pub(crate) fn section_is_slice(entity: &ExtendedEntity) -> bool {
     entity
@@ -1563,15 +1568,43 @@ fn move_extents(
 
 fn grips(entity: &ExtendedEntity) -> Vec<GripDef> {
     match &entity.data {
-        ExtendedEntityData::SectionObject(data) => data
-            .vertices
-            .iter()
-            .chain(data.back_line_vertices.iter())
-            .enumerate()
-            .map(|(index, point)| {
-                square_grip(index, glam::DVec3::new(point.x, point.y, point.z))
-            })
-            .collect(),
+        ExtendedEntityData::SectionObject(data) => {
+            let mut grips: Vec<GripDef> = if section_kind(entity, data) == "Plane"
+                && data.vertices.len() == 2
+                && data.back_line_vertices.is_empty()
+            {
+                section_plane_edge_grips(data)
+            } else {
+                data.vertices
+                    .iter()
+                    .chain(data.back_line_vertices.iter())
+                    .enumerate()
+                    .map(|(index, point)| {
+                        square_grip(index, glam::DVec3::new(point.x, point.y, point.z))
+                    })
+                    .collect()
+            };
+            if let Some(center) = section_center(data) {
+                let normal = section_viewing_direction(data);
+                let span = data
+                    .vertices
+                    .first()
+                    .zip(data.vertices.last())
+                    .map_or(1.0, |(first, last)| (*last - *first).length());
+                let offset = (span * 0.08).max(1.0e-6);
+                let normal_world = glam::DVec3::new(normal.x, normal.y, normal.z);
+                grips.push(GripDef {
+                    id: SECTION_GRIP_NORMAL,
+                    world: glam::DVec3::new(center.x, center.y, center.z)
+                        + normal_world * offset,
+                    is_midpoint: false,
+                    shape: crate::scene::model::object::GripShape::Triangle,
+                    dir: Some(normal_world),
+                    axis: Some(normal_world),
+                });
+            }
+            grips
+        }
         ExtendedEntityData::ArcAlignedText(data) => vec![center_grip(
             0,
             glam::DVec3::new(data.center.x, data.center.y, data.center.z),
@@ -1643,7 +1676,41 @@ fn grips(entity: &ExtendedEntity) -> Vec<GripDef> {
 fn apply_grip(entity: &mut ExtendedEntity, grip_id: usize, apply: GripApply) {
     match &mut entity.data {
         ExtendedEntityData::SectionObject(data) => {
-            if grip_id < data.vertices.len() {
+            if matches!(
+                grip_id,
+                SECTION_GRIP_LEFT
+                    | SECTION_GRIP_RIGHT
+                    | SECTION_GRIP_TOP
+                    | SECTION_GRIP_BOTTOM
+            ) {
+                apply_section_plane_edge_grip(data, grip_id, apply);
+            } else if grip_id == SECTION_GRIP_NORMAL {
+                let Some(center) = section_center(data) else {
+                    return;
+                };
+                let normal = section_viewing_direction(data);
+                let span = data
+                    .vertices
+                    .first()
+                    .zip(data.vertices.last())
+                    .map_or(1.0, |(first, last)| (*last - *first).length());
+                let offset = (span * 0.08).max(1.0e-6);
+                let current = center + normal * offset;
+                let delta = match apply {
+                    GripApply::Translate(delta) => Vector3::new(delta.x, delta.y, delta.z),
+                    GripApply::Absolute(position) => {
+                        Vector3::new(position.x, position.y, position.z) - current
+                    }
+                };
+                let constrained = normal * delta.dot(&normal);
+                for point in data
+                    .vertices
+                    .iter_mut()
+                    .chain(data.back_line_vertices.iter_mut())
+                {
+                    *point = *point + constrained;
+                }
+            } else if grip_id < data.vertices.len() {
                 apply_point(&mut data.vertices[grip_id], apply);
             } else if let Some(point) = data
                 .back_line_vertices
@@ -1699,6 +1766,109 @@ fn apply_grip(entity: &mut ExtendedEntity, grip_id: usize, apply: GripApply) {
                     }
                 }
             }
+        }
+        _ => {}
+    }
+}
+
+fn section_center(data: &SectionObjectData) -> Option<Vector3> {
+    let (first, last) = data.vertices.first().zip(data.vertices.last())?;
+    Some((*first + *last) * 0.5)
+}
+
+fn section_plane_edge_grips(data: &SectionObjectData) -> Vec<GripDef> {
+    let Some((first, last)) = data.vertices.first().zip(data.vertices.last()) else {
+        return Vec::new();
+    };
+    let center = (*first + *last) * 0.5;
+    let tangent = section_tangent(data);
+    let vertical = normalized(data.vertical_direction, Vector3::UNIT_Z);
+    let edge_center_offset = (data.top_height - data.bottom_height) * 0.5;
+    let definitions = [
+        (
+            SECTION_GRIP_LEFT,
+            *first + vertical * edge_center_offset,
+            vertical,
+            tangent,
+        ),
+        (
+            SECTION_GRIP_RIGHT,
+            *last + vertical * edge_center_offset,
+            vertical,
+            tangent,
+        ),
+        (
+            SECTION_GRIP_TOP,
+            center + vertical * data.top_height,
+            tangent,
+            vertical,
+        ),
+        (
+            SECTION_GRIP_BOTTOM,
+            center - vertical * data.bottom_height,
+            tangent,
+            vertical,
+        ),
+    ];
+    definitions
+        .into_iter()
+        .map(|(id, world, edge, axis)| GripDef {
+            id,
+            world: glam::DVec3::new(world.x, world.y, world.z),
+            is_midpoint: false,
+            shape: crate::scene::model::object::GripShape::Rectangle,
+            dir: Some(glam::DVec3::new(edge.x, edge.y, edge.z)),
+            axis: Some(glam::DVec3::new(axis.x, axis.y, axis.z)),
+        })
+        .collect()
+}
+
+fn apply_section_plane_edge_grip(
+    data: &mut SectionObjectData,
+    grip_id: usize,
+    apply: GripApply,
+) {
+    let Some((first, last)) = data.vertices.first().zip(data.vertices.last()) else {
+        return;
+    };
+    let center = (*first + *last) * 0.5;
+    let tangent = section_tangent(data);
+    let vertical = normalized(data.vertical_direction, Vector3::UNIT_Z);
+    let edge_center_offset = (data.top_height - data.bottom_height) * 0.5;
+    let current = match grip_id {
+        SECTION_GRIP_LEFT => *first + vertical * edge_center_offset,
+        SECTION_GRIP_RIGHT => *last + vertical * edge_center_offset,
+        SECTION_GRIP_TOP => center + vertical * data.top_height,
+        SECTION_GRIP_BOTTOM => center - vertical * data.bottom_height,
+        _ => return,
+    };
+    let delta = match apply {
+        GripApply::Translate(delta) => Vector3::new(delta.x, delta.y, delta.z),
+        GripApply::Absolute(position) => {
+            Vector3::new(position.x, position.y, position.z) - current
+        }
+    };
+    let span = (*last - *first).length();
+    let minimum_span = 1.0e-6;
+    match grip_id {
+        SECTION_GRIP_LEFT => {
+            let change = delta
+                .dot(&tangent)
+                .min((span - minimum_span).max(0.0));
+            data.vertices[0] = data.vertices[0] + tangent * change;
+        }
+        SECTION_GRIP_RIGHT => {
+            let last = data.vertices.len() - 1;
+            let change = delta
+                .dot(&tangent)
+                .max((-span + minimum_span).min(0.0));
+            data.vertices[last] = data.vertices[last] + tangent * change;
+        }
+        SECTION_GRIP_TOP => {
+            data.top_height = (data.top_height + delta.dot(&vertical)).max(0.0);
+        }
+        SECTION_GRIP_BOTTOM => {
+            data.bottom_height = (data.bottom_height - delta.dot(&vertical)).max(0.0);
         }
         _ => {}
     }

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -5410,8 +5410,12 @@ impl Scene {
         // changed entities into it, instead of re-cloning + re-sorting the whole
         // set. Falls back to the full build below when it can't (no cache entry,
         // journal un-replayable, or a structural assumption violated).
-        if let Some(arc) =
-            self.try_resident_patch(
+        // A live section changes the displayed wires of every intersected
+        // solid, even when the delta journal contains only the section entity.
+        // Rebuild the resident set in that case so an incremental patch cannot
+        // retain the source solid's uncut edge cache.
+        if self.active_live_section(block).is_none() {
+            if let Some(arc) = self.try_resident_patch(
                 key,
                 block,
                 bg,
@@ -5420,9 +5424,9 @@ impl Scene {
                 all_visible,
                 frozen_layers,
                 style_viewport,
-            )
-        {
-            return arc;
+            ) {
+                return arc;
+            }
         }
         // Build once: full tessellation, no cull, no zoom LOD — the resident
         // set is zoom-independent (GPU analytical circles/arcs/ellipses).
@@ -6994,6 +6998,48 @@ impl Scene {
     ) -> Result<Option<cadkernel::brep::Body>, ()> {
         let body = self.section_source_body(handle).ok_or(())?;
         Self::section_body(&body, &section.data, section.slice_depth, None)
+    }
+
+    /// Build a temporary entity whose wire data matches the live-section body.
+    /// The document entity stays unchanged so disabling the section restores
+    /// the complete source geometry and saving never persists the clipped body.
+    fn sectioned_wire_entity(
+        &self,
+        handle: Handle,
+        section: &LiveSection,
+    ) -> Result<Option<EntityType>, ()> {
+        let Some(body) = self.sectioned_body(handle, section)? else {
+            return Ok(None);
+        };
+        let (_, wires, center) = self
+            .prepare_solid_model_display(handle, &body)
+            .ok_or(())?;
+        let mut entity = self.document.get_entity(handle).cloned().ok_or(())?;
+        let reference = acadrust::types::Vector3::new(center[0], center[1], center[2]);
+        match &mut entity {
+            EntityType::Solid3D(solid) => {
+                solid.point_of_reference = reference;
+                solid.wires = wires;
+                solid.silhouettes.clear();
+            }
+            EntityType::Surface(surface) => {
+                surface.point_of_reference = reference;
+                surface.wires = wires;
+                surface.silhouettes.clear();
+            }
+            EntityType::Region(region) => {
+                region.point_of_reference = reference;
+                region.wires = wires;
+                region.silhouettes.clear();
+            }
+            EntityType::Body(body) => {
+                body.point_of_reference = reference;
+                body.wires = wires;
+                body.silhouettes.clear();
+            }
+            _ => return Err(()),
+        }
+        Ok(Some(entity))
     }
 
     fn section_source_body(
@@ -9709,6 +9755,45 @@ impl Scene {
             memo_misses = visible_count;
             out
         };
+
+        // Normal Wireframe renders the persisted entity wires, whereas shaded
+        // and 3D Wireframe modes render the temporary sectioned mesh. Replace
+        // only the displayed wire run with one tessellated from that same
+        // temporary body so every visual style shows the identical live cut.
+        if let Some(section) = self.active_live_section(block_handle) {
+            let handles: Vec<Handle> = self.meshes.keys().copied().collect();
+            for handle in handles {
+                let Some(source) = self.document.get_entity(handle) else {
+                    continue;
+                };
+                if !visibility_ok(source) {
+                    continue;
+                }
+                let replacement = match self.sectioned_wire_entity(handle, &section) {
+                    Ok(Some(entity)) => Some(tessellate_entity(
+                        doc,
+                        sel,
+                        avp,
+                        bg,
+                        anno,
+                        annotation_scale_handle,
+                        &entity,
+                        Some(blk_ref),
+                        view_aabb,
+                        wpp,
+                        paper,
+                    )),
+                    Ok(None) => Some(Vec::new()),
+                    Err(()) => None,
+                };
+                let Some(replacement) = replacement else {
+                    continue;
+                };
+                let name = handle.value().to_string();
+                wires.retain(|wire| wire.name != name);
+                wires.extend(replacement);
+            }
+        }
         let build_ms = crate::perf::elapsed_ms(t_build);
 
         // Resolve display colours for the live background. Memo hits were

--- a/src/scene/model/object.rs
+++ b/src/scene/model/object.rs
@@ -98,6 +98,8 @@ pub enum GripShape {
     Circle,
     /// Screen-offset menu selector.
     Dropdown,
+    /// Menu selector placed immediately beside its anchor grip.
+    DropdownAdjacent,
 }
 
 /// Describes one grip point for an entity.
@@ -180,6 +182,10 @@ pub enum GripMenuAction {
     RefineVertices,
     ShowFit,
     ShowControlVertices,
+    SectionPlane,
+    SectionSlice,
+    SectionBoundary,
+    SectionVolume,
     MoveWithText,
     StackText,
     UnstackText,

--- a/src/scene/pick/grip.rs
+++ b/src/scene/pick/grip.rs
@@ -13,11 +13,18 @@ pub const GRIP_HALF_PX: f32 = 5.0;
 /// Screen offset for dropdown selectors anchored to a vertex.
 pub const GRIP_DROPDOWN_OFFSET_X_PX: f32 = 24.0;
 pub const GRIP_DROPDOWN_OFFSET_Y_PX: f32 = 27.0;
+pub const GRIP_ADJACENT_DROPDOWN_OFFSET_X_PX: f32 = 12.0;
 
 fn marker_screen_position(mut point: Point, shape: GripShape) -> Point {
-    if shape == GripShape::Dropdown {
-        point.x += GRIP_DROPDOWN_OFFSET_X_PX;
-        point.y += GRIP_DROPDOWN_OFFSET_Y_PX;
+    match shape {
+        GripShape::Dropdown => {
+            point.x += GRIP_DROPDOWN_OFFSET_X_PX;
+            point.y += GRIP_DROPDOWN_OFFSET_Y_PX;
+        }
+        GripShape::DropdownAdjacent => {
+            point.x += GRIP_ADJACENT_DROPDOWN_OFFSET_X_PX;
+        }
+        _ => {}
     }
     point
 }

--- a/src/ui/overlay.rs
+++ b/src/ui/overlay.rs
@@ -781,7 +781,7 @@ fn draw_grip_marker(
             b.close();
         }),
         GripShape::Circle => canvas::Path::circle(Point::new(sp.x, sp.y), h),
-        GripShape::Dropdown => canvas::Path::new(|b| {
+        GripShape::Dropdown | GripShape::DropdownAdjacent => canvas::Path::new(|b| {
             b.move_to(Point::new(sp.x - h, sp.y - h * 0.5));
             b.line_to(Point::new(sp.x + h, sp.y - h * 0.5));
             b.line_to(Point::new(sp.x, sp.y + h));
@@ -831,7 +831,10 @@ fn draw_grip_marker(
         } else {
             palette.primary.base.color
         };
-        let fill = if grip.shape == GripShape::Dropdown {
+        let fill = if matches!(
+            grip.shape,
+            GripShape::Dropdown | GripShape::DropdownAdjacent
+        ) {
             color
         } else {
             palette.background.base.color.scale_alpha(0.7)
@@ -3797,4 +3800,3 @@ mod selection_visual_color_tests {
         assert!((selection_fill_alpha(100.0, true) - 0.45).abs() < 1e-5);
     }
 }
-


### PR DESCRIPTION
1) Normal Wireframe rebuilds solid, surface, region, and body edges from the same temporary sectioned B-rep used by mesh visual styles, so every visual style displays the same live cut.

2) Fully clipped entities are removed from the displayed wire set, while clipping or tessellation failures preserve the original display instead of dropping geometry.

3) Resident wire sets bypass incremental entity patching while a live section is active, preventing a section edit from retaining stale uncut solid edges.

4) Plane section objects expose four independent edge-center stretch grips for the left, right, top, and bottom edges.

5) Left and right edge grips accept both the section tangent and in-plane vertical components of a drag, ignore movement normal to the plane, keep the opposite endpoint fixed, and prevent the endpoints from crossing.

6) Top and bottom edge grips change only their corresponding height along the section vertical and prevent negative height values.

7) A separate directional grip is placed above the section plane, points away from the plane, and moves the complete section object only along the cutting-plane normal while keeping every section vertex and back-line vertex synchronized.

8) A dropdown selector is placed immediately beside the right edge grip and remains available in every section state.

9) The dropdown lists Plane, Slice, Boundary, and Volume in state order and marks the current state with a check.

10) Dropdown actions use the same section-state write path as Properties: Plane clears depth data, Slice stores its shallow depth metadata, and Boundary or Volume create the corresponding back-line depth while removing Slice metadata.

11) Dropdown state changes are undoable, refresh the scene, selected grips, and Properties immediately, and persist through the section object's existing serialized state.

12) Live clipping and grip previews leave the stored source solid unchanged, so disabling the live section restores the complete geometry and saving does not persist a clipped replacement body.
