### PR TITLE
Add the Spline Fit button to Draw

### DIFF
--- a/src/ui/ribbon/draw_tools/01_spline_fit.rs
+++ b/src/ui/ribbon/draw_tools/01_spline_fit.rs
@@ -1,0 +1,6 @@
+Tool {
+    command: "SPLINE",
+    label: "Spline Fit",
+    icon: include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/assets/icons/spline.svg")),
+    options: &[],
+}


### PR DESCRIPTION
1) Add an ordered Spline Fit contribution to the Draw expansion, using the existing theme-aware spline icon and the SPLINE command.

2) Route the button to the existing fit-point drawing workflow, including point entry, Close, Undo, and completion.
