### PR TITLE
Add the Construction Line button to Draw

### DIFF
--- a/assets/icons/xline.svg
+++ b/assets/icons/xline.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-label="Construction Line" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M2 22L22 2" stroke="#B4B6B9" stroke-width="1.6"/><path d="M2 17v5h5M17 2h5v5" stroke="#6DB7ED" stroke-width="1.6"/><path d="M10 10h4v4h-4z" fill="#6DB7ED" stroke="none"/>
+</svg>

--- a/src/modules/draw/draw/ray.rs
+++ b/src/modules/draw/draw/ray.rs
@@ -167,7 +167,6 @@ impl CadCommand for XLineCommand {
                 Vector3::new(base.x, base.y, base.z),
                 Vector3::new(dir_n.x, dir_n.y, dir_n.z),
             );
-            self.base = None;
             CmdResult::CommitEntity(EntityType::XLine(xline))
         } else {
             self.base = Some(pt);

--- a/src/ui/ribbon/draw_tools/03_xline.rs
+++ b/src/ui/ribbon/draw_tools/03_xline.rs
@@ -1,0 +1,6 @@
+Tool {
+    command: "XLINE",
+    label: "Construction Line",
+    icon: include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/assets/icons/xline.svg")),
+    options: &[],
+}


### PR DESCRIPTION
1) Add an ordered Construction Line contribution with a distinct theme-aware infinite-line icon and bind it to XLINE.

2) Keep the original base point after creating an XLine so repeated through-point entries create construction lines from the same origin until completion.
