### PR TITLE
Add the Ray button to Draw

### DIFF
--- a/assets/icons/ray.svg
+++ b/assets/icons/ray.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-label="Ray" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M4 20L21 3" stroke="#B4B6B9" stroke-width="1.6"/><path d="M16 3h5v5" stroke="#6DB7ED" stroke-width="1.6"/><path d="M2 18h4v4H2z" fill="#6DB7ED" stroke="none"/>
+</svg>

--- a/src/modules/draw/draw/ray.rs
+++ b/src/modules/draw/draw/ray.rs
@@ -61,9 +61,7 @@ impl CadCommand for RayCommand {
                 Vector3::new(base.x, base.y, base.z),
                 Vector3::new(dir_n.x, dir_n.y, dir_n.z),
             );
-            // Stay active: new base = same base (can keep clicking through points)
-            // Actually AutoCAD prompts for new start after each ray — reset base.
-            self.base = None;
+            // Repeated through points share the original start point.
             CmdResult::CommitEntity(EntityType::Ray(ray))
         } else {
             self.base = Some(pt);

--- a/src/ui/ribbon/draw_tools/04_ray.rs
+++ b/src/ui/ribbon/draw_tools/04_ray.rs
@@ -1,0 +1,6 @@
+Tool {
+    command: "RAY",
+    label: "Ray",
+    icon: include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/assets/icons/ray.svg")),
+    options: &[],
+}


### PR DESCRIPTION
1) Add an ordered Ray contribution with a distinct theme-aware directional icon and bind it to RAY.

2) Preserve the initial start point after each ray so successive through-point entries create rays from the same origin until completion.
