### PR TITLE
Add the Multiple Points split button to Draw

### DIFF
--- a/assets/icons/multipoint.svg
+++ b/assets/icons/multipoint.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-label="Multiple Points" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3 4h3v3H3zM16 2h3v3h-3zM10 11h3v3h-3zM3 19h3v3H3zM18 17h3v3h-3z" fill="#6DB7ED" stroke="none"/>
+</svg>

--- a/src/ui/ribbon/draw_tools/05_multipoint.rs
+++ b/src/ui/ribbon/draw_tools/05_multipoint.rs
@@ -1,0 +1,6 @@
+Tool {
+    command: "MULTIPOINT",
+    label: "Multiple Points",
+    icon: include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/assets/icons/multipoint.svg")),
+    options: &[("POINT", "Single Point"), ("MULTIPOINT", "Multiple Points"), ("DDPTYPE", "Point Style")],
+}


### PR DESCRIPTION
1) Add an ordered Multiple Points contribution and theme-aware point-cluster icon, bound to the repeating MULTIPOINT drawing command.

2) Add Single Point, Multiple Points, and Point Style options dispatching POINT, MULTIPOINT, and DDPTYPE respectively.
