### PR TITLE
Add the Divide button to Draw

### DIFF
--- a/assets/icons/divide.svg
+++ b/assets/icons/divide.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-label="Divide" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3 20L21 4" stroke="#B4B6B9" stroke-width="1.6"/><path d="M6 14l4 4M10 10l4 4M14 6l4 4" stroke="#6DB7ED" stroke-width="2"/>
+</svg>

--- a/src/ui/ribbon/draw_tools/06_divide.rs
+++ b/src/ui/ribbon/draw_tools/06_divide.rs
@@ -1,0 +1,6 @@
+Tool {
+    command: "DIVIDE",
+    label: "Divide",
+    icon: include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/assets/icons/divide.svg")),
+    options: &[],
+}


### PR DESCRIPTION
1) Add an ordered Divide contribution with a distinct theme-aware division-marker icon.

2) Bind the button to DIVIDE so users select an object and enter a segment count to place equally spaced points along its curve.
