### PR TITLE
Add the Measure button to Draw

### DIFF
--- a/assets/icons/measure.svg
+++ b/assets/icons/measure.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-label="Measure" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3 20L21 4M4 7h11M4 4v6M15 4v6" stroke="#B4B6B9" stroke-width="1.4"/><path d="M6 14l4 4M12 9l4 4" stroke="#6DB7ED" stroke-width="2"/>
+</svg>

--- a/src/ui/ribbon/draw_tools/07_measure.rs
+++ b/src/ui/ribbon/draw_tools/07_measure.rs
@@ -1,0 +1,6 @@
+Tool {
+    command: "MEASURE",
+    label: "Measure",
+    icon: include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/assets/icons/measure.svg")),
+    options: &[],
+}


### PR DESCRIPTION
1) Add an ordered Measure contribution with a distinct theme-aware interval-marker icon.

2) Bind the button to MEASURE so users select an object and enter a segment length to place points at fixed distances along its curve.
