### PR TITLE
Add the Region button and object-selection entry

### DIFF
--- a/assets/icons/region.svg
+++ b/assets/icons/region.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-label="Region" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3 8L11 3L21 8V21H3Z" fill="#B4B6B9" stroke="none"/><circle cx="12" cy="13" r="4" fill="#6DB7ED" stroke="none"/>
+</svg>

--- a/src/app/commands/draw.rs
+++ b/src/app/commands/draw.rs
@@ -1110,6 +1110,13 @@ impl OpenCADStudio {
             // REGION — convert selected closed boundaries (closed polylines /
             // circles) into Region entities (one wire loop each).
             "REGION" | "REG" => {
+                if self.tabs[i].scene.selected_entities().is_empty() {
+                    use crate::modules::draw::select::SelectObjectsCommand;
+                    let command = SelectObjectsCommand::new("REGION");
+                    self.command_line.push_info(&command.prompt());
+                    self.tabs[i].active_cmd = Some(Box::new(command));
+                    return Some(iced::Task::none());
+                }
                 use acadrust::entities::Region;
                 use acadrust::types::Vector3;
                 let mut regions = Vec::new();

--- a/src/ui/ribbon/draw_tools/08_region.rs
+++ b/src/ui/ribbon/draw_tools/08_region.rs
@@ -1,0 +1,6 @@
+Tool {
+    command: "REGION",
+    label: "Region",
+    icon: include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/assets/icons/region.svg")),
+    options: &[],
+}


### PR DESCRIPTION
1) Add an ordered Region contribution with a theme-aware region icon and bind it to REGION.

2) Start the existing object-selection gather phase when REGION is invoked without a preselection. Run region conversion after selection is confirmed, while retaining direct conversion for preselected supported boundaries.
