### PR TITLE
Add the Wipeout button to Draw

### DIFF
--- a/src/ui/ribbon/draw_tools/09_wipeout.rs
+++ b/src/ui/ribbon/draw_tools/09_wipeout.rs
@@ -1,0 +1,6 @@
+Tool {
+    command: "WIPEOUT",
+    label: "Wipeout",
+    icon: include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/assets/icons/wipeout.svg")),
+    options: &[],
+}


### PR DESCRIPTION
1) Add an ordered Wipeout contribution using the existing theme-aware wipeout icon.

2) Bind the button to WIPEOUT, exposing the existing mask drawing workflow and its polygonal, polyline, rectangular, and frame options.
