### PR TITLE
Add the Boundary button to Draw

### DIFF
--- a/assets/icons/boundary.svg
+++ b/assets/icons/boundary.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-label="Boundary" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3 3h18v18H3z" stroke="#B4B6B9" stroke-dasharray="2 2"/><path d="M6 7h8v4h4v7H6z" stroke="#6DB7ED" stroke-width="1.7"/>
+</svg>

--- a/src/ui/ribbon/draw_tools/10_boundary.rs
+++ b/src/ui/ribbon/draw_tools/10_boundary.rs
@@ -1,0 +1,6 @@
+Tool {
+    command: "BOUNDARY",
+    label: "Boundary",
+    icon: include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/assets/icons/boundary.svg")),
+    options: &[],
+}


### PR DESCRIPTION
1) Add an ordered Boundary contribution with a distinct theme-aware boundary-outline icon.

2) Bind the button to BOUNDARY, exposing the existing boundary creation workflow, working-plane handling, selected boundary sources, and interactive options.
