### PR TITLE
Add the Donut button to Draw

### DIFF
--- a/assets/icons/donut.svg
+++ b/assets/icons/donut.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-label="Donut" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="8" stroke="#B4B6B9" stroke-width="5"/><circle cx="12" cy="12" r="5.5" stroke="#6DB7ED" stroke-width="1"/>
+</svg>

--- a/src/ui/ribbon/draw_tools/12_donut.rs
+++ b/src/ui/ribbon/draw_tools/12_donut.rs
@@ -1,0 +1,6 @@
+Tool {
+    command: "DONUT",
+    label: "Donut",
+    icon: include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/assets/icons/donut.svg")),
+    options: &[],
+}


### PR DESCRIPTION
1) Add an ordered Donut contribution with a distinct theme-aware ring icon.

2) Bind the button to DONUT, exposing inner and outer diameter entry and repeated placement of ring-shaped polylines.
