### PR TITLE
Add the Revision Cloud split button to Draw

### DIFF
--- a/src/app/commands/draw.rs
+++ b/src/app/commands/draw.rs
@@ -62,7 +62,7 @@ impl OpenCADStudio {
                 return Some(Task::done(Message::ImagePick));
             }
 
-            "REVCLOUD" => {
+            "REVCLOUD" | "REVCLOUD_RECTANGULAR" | "REVCLOUD_POLYGONAL" | "REVCLOUD_FREEHAND" => {
                 use crate::modules::draw::draw::revcloud::RevCloudCommand;
                 let view_height = self.tabs[i].scene.camera.borrow().ortho_size() as f64 * 2.0;
                 let default_arc_length = (view_height * 0.0125).max(1.0e-6);
@@ -72,9 +72,12 @@ impl OpenCADStudio {
                     .entities()
                     .map(|entity| (entity.common().handle, entity.clone()))
                     .collect();
-                let cmd = RevCloudCommand::new(default_arc_length, sources);
-                self.command_line.push_info(&cmd.prompt());
-                self.tabs[i].active_cmd = Some(Box::new(cmd));
+                let mut command = RevCloudCommand::new(default_arc_length, sources);
+                if let Some(mode) = cmd.strip_prefix("REVCLOUD_") {
+                    command.on_text_input(mode);
+                }
+                self.command_line.push_info(&command.prompt());
+                self.tabs[i].active_cmd = Some(Box::new(command));
             }
 
             "ATTDEF" => {

--- a/src/modules/draw/draw/revcloud.rs
+++ b/src/modules/draw/draw/revcloud.rs
@@ -933,4 +933,6 @@ fn style_from_entity(entity: &EntityType) -> Option<CloudStyle> {
     })
 }
 
-inventory::submit!(crate::command::CommandRegistration { names: &["REVCLOUD"] });
+inventory::submit!(crate::command::CommandRegistration {
+    names: &["REVCLOUD", "REVCLOUD_RECTANGULAR", "REVCLOUD_POLYGONAL", "REVCLOUD_FREEHAND"]
+});

--- a/src/ui/ribbon/draw_tools/13_revcloud.rs
+++ b/src/ui/ribbon/draw_tools/13_revcloud.rs
@@ -1,0 +1,10 @@
+Tool {
+    command: "REVCLOUD",
+    label: "Revision Cloud",
+    icon: include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/assets/icons/revcloud.svg")),
+    options: &[
+        ("REVCLOUD_RECTANGULAR", "Rectangular"),
+        ("REVCLOUD_POLYGONAL", "Polygonal"),
+        ("REVCLOUD_FREEHAND", "Freehand"),
+    ],
+}


### PR DESCRIPTION
1) Add an ordered Revision Cloud contribution using the existing theme-aware cloud icon and bind its main button to REVCLOUD.

2) Add Rectangular, Polygonal, and Freehand menu options, each dispatching a registered command that initializes the corresponding creation mode through the existing revision-cloud command handler.

3) Register the three creation-mode commands for command completion while retaining the existing arc length, style, object conversion, modification, and reverse workflows.
