### PR TITLE
Add Set to ByLayer to Modify extension

### DIFF
--- a/assets/icons/modify_setbylayer.svg
+++ b/assets/icons/modify_setbylayer.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#B4B6B9" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18M3 12h18M3 18h18"/><path stroke="#6DB7ED" d="m8 3-3 3 3 3m8 0 3 3-3 3m-8 0-3 3 3 3"/></svg>

--- a/src/app/commands/styleprops.rs
+++ b/src/app/commands/styleprops.rs
@@ -646,6 +646,13 @@ impl OpenCADStudio {
             // Resets the selected entities' direct property overrides back to
             // ByLayer so they follow their layer again.
             "SETBYLAYER" => {
+                if self.tabs[i].scene.selected.is_empty() {
+                    use crate::modules::draw::select::SelectObjectsCommand;
+                    let selection = SelectObjectsCommand::new("SETBYLAYER");
+                    self.command_line.push_info(&selection.prompt());
+                    self.tabs[i].active_cmd = Some(Box::new(selection));
+                    return Some(self.finish_dispatch(cmd));
+                }
                 let handles: Vec<_> = self.tabs[i]
                     .scene
                     .selected_entities()

--- a/src/ui/ribbon/modify_tools/01_setbylayer.rs
+++ b/src/ui/ribbon/modify_tools/01_setbylayer.rs
@@ -1,0 +1,6 @@
+Tool {
+    command: "SETBYLAYER",
+    label: "Set to ByLayer",
+    icon: include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/assets/icons/modify_setbylayer.svg")),
+    options: &[],
+}


### PR DESCRIPTION
1) Add a themed Set to ByLayer icon and an ordered Modify panel contribution that dispatches SETBYLAYER and displays the translated tool label and command tooltip.

2) Start object selection when Set to ByLayer is invoked without preselection, then apply the existing property reset to the chosen objects.
