### PR TITLE
Add Lengthen to Modify extension

### DIFF
--- a/assets/icons/modify_lengthen.svg
+++ b/assets/icons/modify_lengthen.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#B4B6B9" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M3 18 14 7"/><path stroke="#6DB7ED" d="m14 7 7-4-4 7m-3-3 5-2"/><path d="M3 14v4h4"/></svg>

--- a/src/ui/ribbon/modify_tools/02_lengthen.rs
+++ b/src/ui/ribbon/modify_tools/02_lengthen.rs
@@ -1,0 +1,6 @@
+Tool {
+    command: "LENGTHEN",
+    label: "Lengthen",
+    icon: include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/assets/icons/modify_lengthen.svg")),
+    options: &[],
+}


### PR DESCRIPTION
1) Add a themed Lengthen icon and an ordered Modify panel contribution that dispatches LENGTHEN and displays the translated tool label and command tooltip.
