### PR TITLE
Add Edit Polyline to Modify extension

### DIFF
--- a/assets/icons/modify_pedit.svg
+++ b/assets/icons/modify_pedit.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#B4B6B9" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M3 18V7h8v10h9"/><path stroke="#6DB7ED" d="m12 11 7-7 3 3-7 7-4 1Z"/></svg>

--- a/src/ui/ribbon/modify_tools/03_pedit.rs
+++ b/src/ui/ribbon/modify_tools/03_pedit.rs
@@ -1,0 +1,6 @@
+Tool {
+    command: "PEDIT",
+    label: "Edit Polyline",
+    icon: include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/assets/icons/modify_pedit.svg")),
+    options: &[],
+}


### PR DESCRIPTION
1) Add a themed Edit Polyline icon and an ordered Modify panel contribution that dispatches PEDIT and displays the translated tool label and command tooltip.
