### PR TITLE
Add Edit Hatch to Modify extension

### DIFF
--- a/assets/icons/modify_hatchedit.svg
+++ b/assets/icons/modify_hatchedit.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#B4B6B9" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M3 4h15v16H3ZM3 10l6-6M3 16 15 4M6 20l12-12M12 20l6-6"/><path stroke="#6DB7ED" d="m14 12 6-6 3 3-6 6-4 1Z"/></svg>

--- a/src/ui/ribbon/modify_tools/05_hatchedit.rs
+++ b/src/ui/ribbon/modify_tools/05_hatchedit.rs
@@ -1,0 +1,6 @@
+Tool {
+    command: "HATCHEDIT",
+    label: "Edit Hatch",
+    icon: include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/assets/icons/modify_hatchedit.svg")),
+    options: &[],
+}


### PR DESCRIPTION
1) Add a themed Edit Hatch icon and an ordered Modify panel contribution that dispatches HATCHEDIT and displays the translated tool label and command tooltip.
