### PR TITLE
Add Align to Modify extension

### DIFF
--- a/assets/icons/modify_align.svg
+++ b/assets/icons/modify_align.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#B4B6B9" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M3 4h7v7H3ZM14 14h7v7h-7Z"/><path stroke="#6DB7ED" d="m8 15 5-5m-5 0h5v5M2 22h20"/></svg>

--- a/src/ui/ribbon/modify_tools/06_align.rs
+++ b/src/ui/ribbon/modify_tools/06_align.rs
@@ -1,0 +1,6 @@
+Tool {
+    command: "ALIGN",
+    label: "Align",
+    icon: include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/assets/icons/modify_align.svg")),
+    options: &[],
+}


### PR DESCRIPTION
1) Add a themed Align icon and an ordered Modify panel contribution that dispatches ALIGN and displays the translated tool label and command tooltip.
