### PR TITLE
Add Break to Modify extension

### DIFF
--- a/assets/icons/modify_break.svg
+++ b/assets/icons/modify_break.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#B4B6B9" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="m2 20 7-7m6-6 7-7"/><path stroke="#6DB7ED" d="m6 9 6 6m0-12 6 6"/></svg>

--- a/src/ui/ribbon/modify_tools/07_break.rs
+++ b/src/ui/ribbon/modify_tools/07_break.rs
@@ -1,0 +1,6 @@
+Tool {
+    command: "BREAK",
+    label: "Break",
+    icon: include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/assets/icons/modify_break.svg")),
+    options: &[],
+}


### PR DESCRIPTION
1) Add a themed Break icon and an ordered Modify panel contribution that dispatches BREAK and displays the translated tool label and command tooltip.
