### PR TITLE
Add Break at Point to Modify extension

### DIFF
--- a/assets/icons/modify_breakatpoint.svg
+++ b/assets/icons/modify_breakatpoint.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#B4B6B9" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="m2 21 9-9m2-2 9-9"/><circle stroke="#6DB7ED" cx="12" cy="11" r="3"/></svg>

--- a/src/ui/ribbon/modify_tools/08_breakatpoint.rs
+++ b/src/ui/ribbon/modify_tools/08_breakatpoint.rs
@@ -1,0 +1,6 @@
+Tool {
+    command: "BREAKATPOINT",
+    label: "Break at Point",
+    icon: include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/assets/icons/modify_breakatpoint.svg")),
+    options: &[],
+}


### PR DESCRIPTION
1) Add a themed Break at Point icon and an ordered Modify panel contribution that dispatches BREAKATPOINT and displays the translated tool label and command tooltip.
