### PR TITLE
Add Join to Modify extension

### DIFF
--- a/assets/icons/modify_join.svg
+++ b/assets/icons/modify_join.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#B4B6B9" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M2 16h8l4-8h8"/><path stroke="#6DB7ED" d="m5 5 5 3-5 3m14 2-5 3 5 3"/></svg>

--- a/src/ui/ribbon/modify_tools/09_join.rs
+++ b/src/ui/ribbon/modify_tools/09_join.rs
@@ -1,0 +1,6 @@
+Tool {
+    command: "JOIN",
+    label: "Join",
+    icon: include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/assets/icons/modify_join.svg")),
+    options: &[],
+}


### PR DESCRIPTION
1) Add a themed Join icon and an ordered Modify panel contribution that dispatches JOIN and displays the translated tool label and command tooltip.
