### PR TITLE
Add Copy Nested Objects to Modify extension

### DIFF
--- a/assets/icons/modify_ncopy.svg
+++ b/assets/icons/modify_ncopy.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#B4B6B9" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M2 3h12v13H2Z"/><path stroke="#6DB7ED" d="M10 11h12v11H10ZM6 7h5v5H6Z"/></svg>

--- a/src/app/commands/blocks.rs
+++ b/src/app/commands/blocks.rs
@@ -659,6 +659,13 @@ impl OpenCADStudio {
             // every nested object is copied — the block is not exploded).
             "NCOPY" | "NCOPYALL" => {
                 use crate::modules::draw::modify::explode::explode_entity;
+                if cmd == "NCOPY" && self.tabs[i].scene.selected.is_empty() {
+                    use crate::modules::draw::select::SelectObjectsCommand;
+                    let selection = SelectObjectsCommand::new("NCOPY");
+                    self.command_line.push_info(&selection.prompt());
+                    self.tabs[i].active_cmd = Some(Box::new(selection));
+                    return Some(self.finish_dispatch(cmd));
+                }
                 let inserts: Vec<acadrust::Handle> = self.tabs[i]
                     .scene
                     .selected_entities()

--- a/src/ui/ribbon/modify_tools/11_ncopy.rs
+++ b/src/ui/ribbon/modify_tools/11_ncopy.rs
@@ -1,0 +1,6 @@
+Tool {
+    command: "NCOPY",
+    label: "Copy Nested Objects",
+    icon: include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/assets/icons/modify_ncopy.svg")),
+    options: &[],
+}


### PR DESCRIPTION
1) Add a themed Copy Nested Objects icon and an ordered Modify panel contribution that dispatches NCOPY and displays the translated tool label and command tooltip.

2) Gather block references when NCOPY starts without preselection, then copy their nested contents through the existing extraction handler while retaining the original blocks. Keep NCOPYALL behavior unchanged.
