### PR TITLE
Add Delete Duplicate Objects to Modify extension

### DIFF
--- a/assets/icons/modify_overkill.svg
+++ b/assets/icons/modify_overkill.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#B4B6B9" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M3 4h12v12H3ZM8 9h12v12H8Z"/><path stroke="#6DB7ED" d="m16 2 6 6m0-6-6 6"/></svg>

--- a/src/app/commands/styleprops.rs
+++ b/src/app/commands/styleprops.rs
@@ -685,10 +685,17 @@ impl OpenCADStudio {
             // ── OVERKILL — delete duplicate (identical) objects ──────────
             // Removes objects that are identical in geometry AND properties to
             // another object (compared with the handle ignored). Operates on
-            // the current selection, or the whole drawing when nothing is
+            // the current selection, gathering objects first when nothing is
             // selected. Conservative: only exact duplicates are removed.
             "OVERKILL" => {
                 use acadrust::Handle;
+                if self.tabs[i].scene.selected.is_empty() {
+                    use crate::modules::draw::select::SelectObjectsCommand;
+                    let selection = SelectObjectsCommand::new("OVERKILL");
+                    self.command_line.push_info(&selection.prompt());
+                    self.tabs[i].active_cmd = Some(Box::new(selection));
+                    return Some(self.finish_dispatch(cmd));
+                }
                 let selected: std::collections::HashSet<u64> = self.tabs[i]
                     .scene
                     .selected_entities()
@@ -702,7 +709,7 @@ impl OpenCADStudio {
                     .document
                     .entities()
                     .filter(|e| {
-                        (selected.is_empty() || selected.contains(&e.common().handle.value()))
+                        selected.contains(&e.common().handle.value())
                             && !self.tabs[i].scene.is_layer_locked(e.common().handle)
                     })
                     .map(|e| {

--- a/src/ui/ribbon/modify_tools/12_overkill.rs
+++ b/src/ui/ribbon/modify_tools/12_overkill.rs
@@ -1,0 +1,6 @@
+Tool {
+    command: "OVERKILL",
+    label: "Delete Duplicate Objects",
+    icon: include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/assets/icons/modify_overkill.svg")),
+    options: &[],
+}


### PR DESCRIPTION
1) Add a themed Delete Duplicate Objects icon and an ordered Modify panel contribution that dispatches OVERKILL and displays the translated tool label and command tooltip.

2) Gather objects before duplicate cleanup when the selection is empty. Restrict removal candidates to the chosen objects instead of falling back to the whole drawing.
