### PR TITLE
Copy picked nested objects with placement and array options

### DIFF
--- a/src/app/command_driver.rs
+++ b/src/app/command_driver.rs
@@ -929,6 +929,12 @@ impl OpenCADStudio {
 
     fn apply_cmd_result_inner(&mut self, result: CmdResult) -> Task<Message> {
         let i = self.active_tab;
+        if let Some(bind) = self.tabs[i].active_cmd.as_ref().and_then(|command| command.nested_copy_bind_setting()) {
+            if self.ncopy_bind != bind {
+                self.ncopy_bind = bind;
+                self.persist_settings_if_changed();
+            }
+        }
         let preserve_commit_style = self.tabs[i].active_cmd.as_ref()
             .is_some_and(|command| command.preserve_commit_style());
         let preserve_commit_layer = self.tabs[i]
@@ -1054,7 +1060,7 @@ impl OpenCADStudio {
                     self.commit_undo_delta(i, pd);
                 }
             }
-            CmdResult::CommitEntities(entities) => {
+            CmdResult::CommitEntities(mut entities) => {
                 let locked_source = entities.iter().find_map(|entity| {
                     let handle = entity.common().handle;
                     (!handle.is_null()
@@ -1067,10 +1073,19 @@ impl OpenCADStudio {
                     return Task::none();
                 }
                 let label = self.history_label_from_active_cmd(i, "ENTITY");
-                let delta_safe = entities
+                let symbol_names = self.tabs[i].active_cmd.as_ref()
+                    .and_then(|command| command.nested_copy_symbol_names()).cloned();
+                let delta_safe = symbol_names.is_none() && entities
                     .iter()
                     .all(|entity| self.delta_add_safe(i, entity));
                 let pending = self.begin_undo(i, label, entities.len(), delta_safe);
+                if let Some(names) = symbol_names {
+                    let retained = self.tabs[i].scene.document.localize_nested_copy_symbols(&mut entities, &names);
+                    if retained > 0 {
+                        self.command_line.push_info(&format!("{} copied object(s) retain imported style references whose dependencies cannot be localized.", retained));
+                    }
+                    self.refresh_layer_panel();
+                }
                 for entity in entities {
                     if preserve_commit_style {
                         let _ = self.commit_entity_handle_preserve_style(entity);
@@ -1090,12 +1105,21 @@ impl OpenCADStudio {
                     self.commit_undo_delta(i, pd);
                 }
             }
-            CmdResult::CommitEntitiesAndExit(entities) => {
+            CmdResult::CommitEntitiesAndExit(mut entities) => {
                 let label = self.history_label_from_active_cmd(i, "ENTITY");
-                let delta_safe = entities
+                let symbol_names = self.tabs[i].active_cmd.as_ref()
+                    .and_then(|command| command.nested_copy_symbol_names()).cloned();
+                let delta_safe = symbol_names.is_none() && entities
                     .iter()
                     .all(|entity| self.delta_add_safe(i, entity));
                 let pending = self.begin_undo(i, label, entities.len(), delta_safe);
+                if let Some(names) = symbol_names {
+                    let retained = self.tabs[i].scene.document.localize_nested_copy_symbols(&mut entities, &names);
+                    if retained > 0 {
+                        self.command_line.push_info(&format!("{} copied object(s) retain imported style references whose dependencies cannot be localized.", retained));
+                    }
+                    self.refresh_layer_panel();
+                }
                 for entity in entities {
                     if preserve_commit_style {
                         let _ = self.commit_entity_handle_preserve_style(entity);

--- a/src/app/command_driver.rs
+++ b/src/app/command_driver.rs
@@ -929,6 +929,8 @@ impl OpenCADStudio {
 
     fn apply_cmd_result_inner(&mut self, result: CmdResult) -> Task<Message> {
         let i = self.active_tab;
+        let preserve_commit_style = self.tabs[i].active_cmd.as_ref()
+            .is_some_and(|command| command.preserve_commit_style());
         let preserve_commit_layer = self.tabs[i]
         .active_cmd
         .as_ref()
@@ -1070,7 +1072,9 @@ impl OpenCADStudio {
                     .all(|entity| self.delta_add_safe(i, entity));
                 let pending = self.begin_undo(i, label, entities.len(), delta_safe);
                 for entity in entities {
-                    if preserve_commit_layer {
+                    if preserve_commit_style {
+                        let _ = self.commit_entity_handle_preserve_style(entity);
+                    } else if preserve_commit_layer {
                         let _ = self.commit_entity_handle_preserve_layer(entity);
                     } else {
                         self.commit_entity(entity);
@@ -1093,7 +1097,13 @@ impl OpenCADStudio {
                     .all(|entity| self.delta_add_safe(i, entity));
                 let pending = self.begin_undo(i, label, entities.len(), delta_safe);
                 for entity in entities {
-                    self.commit_entity(entity);
+                    if preserve_commit_style {
+                        let _ = self.commit_entity_handle_preserve_style(entity);
+                    } else if preserve_commit_layer {
+                        let _ = self.commit_entity_handle_preserve_layer(entity);
+                    } else {
+                        self.commit_entity(entity);
+                    }
                 }
                 self.tabs[i].dirty = true;
                 self.tabs[i].scene.clear_preview_wire();

--- a/src/app/commands/blocks.rs
+++ b/src/app/commands/blocks.rs
@@ -656,7 +656,7 @@ impl OpenCADStudio {
 
             "NCOPY" | "NCOPYALL" => {
                 let command = crate::modules::draw::modify::ncopy::NcopyCommand::new(
-                    &self.tabs[i].scene.document,
+                    &self.tabs[i].scene.document, self.ncopy_bind,
                 );
                 self.command_line.push_info(&command.prompt());
                 self.tabs[i].active_cmd = Some(Box::new(command));

--- a/src/app/commands/blocks.rs
+++ b/src/app/commands/blocks.rs
@@ -654,42 +654,13 @@ impl OpenCADStudio {
                 }
             }
 
-            // NCOPY — copy the nested objects of the selected block reference(s)
-            // into model space, keeping the block (a non-destructive extraction;
-            // every nested object is copied — the block is not exploded).
             "NCOPY" | "NCOPYALL" => {
-                use crate::modules::draw::modify::explode::explode_entity;
-                let inserts: Vec<acadrust::Handle> = self.tabs[i]
-                    .scene
-                    .selected_entities()
-                    .iter()
-                    .filter(|(_, e)| matches!(e, acadrust::EntityType::Insert(_)))
-                    .map(|(h, _)| *h)
-                    .filter(|handle| !self.tabs[i].scene.is_layer_locked(*handle))
-                    .collect();
-                if inserts.is_empty() {
-                    self.command_line
-                        .push_error(crate::t!("NCOPY: select a block reference first.").as_ref());
-                    return Some(Task::none());
-                }
-                self.push_undo_snapshot(i, "NCOPY");
-                let mut n = 0usize;
-                for h in &inserts {
-                    let nested = match self.tabs[i].scene.document.get_entity(*h).cloned() {
-                        Some(ins) => explode_entity(&ins, &self.tabs[i].scene.document),
-                        None => Vec::new(),
-                    };
-                    for e in nested {
-                        self.tabs[i].scene.add_entity(e);
-                        n += 1;
-                    }
-                }
-                self.tabs[i].dirty = true;
-                self.command_line.push_output(crate::tf!(
-                    "NCOPY: copied {n} nested object(s) into model space (blocks kept)."
-                ).as_ref());
+                let command = crate::modules::draw::modify::ncopy::NcopyCommand::new(
+                    &self.tabs[i].scene.document,
+                );
+                self.command_line.push_info(&command.prompt());
+                self.tabs[i].active_cmd = Some(Box::new(command));
             }
-
             _ => return None,
         }
         Some(self.finish_dispatch(cmd))

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -511,6 +511,7 @@ pub(super) struct OpenCADStudio {
     /// Selected-object count past which grips stop being generated
     /// (GRIPOBJLIMIT, 0..=32767; 0 = no limit).
     grip_object_limit: i32,
+    ncopy_bind: bool,
     /// Drawing viewport cursor style (CURSORTYPE).
     cursor_type: settings::CursorType,
     /// Explicit crosshair colour; `None` retains automatic contrast.
@@ -3461,6 +3462,7 @@ impl OpenCADStudio {
             double_click_block_refedit: false,
             double_click_block_attedit: true,
             grip_object_limit: settings::DEFAULT_GRIP_OBJECT_LIMIT,
+            ncopy_bind: false,
             cursor_type: settings::CursorType::Crosshair,
             crosshair_color: None,
             crosshair_color_input: String::new(),

--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -203,6 +203,8 @@ pub struct UserSettings {
     /// GRIPOBJLIMIT: past this many selected objects, no grips are drawn at
     /// all. 0 means no limit. The drawing header carries no slot for it.
     pub grip_object_limit: i32,
+    /// Nested-copy symbol handling: false inserts, true binds.
+    pub ncopy_bind: bool,
     /// Last Options page; unknown saved names fall back without rejecting the config.
     #[serde(default, deserialize_with = "deserialize_options_tab")]
     pub options_tab: crate::ui::window::options::OptionsTab,
@@ -372,6 +374,7 @@ impl Default for UserSettings {
             double_click_block_refedit: false,
             double_click_block_attedit: true,
             grip_object_limit: DEFAULT_GRIP_OBJECT_LIMIT,
+            ncopy_bind: false,
             cursor_type: CursorType::Crosshair,
             crosshair_color: None,
             lineweight_display_scale: 100,

--- a/src/app/update/file.rs
+++ b/src/app/update/file.rs
@@ -404,6 +404,7 @@ impl OpenCADStudio {
             double_click_block_refedit: self.double_click_block_refedit,
             double_click_block_attedit: self.double_click_block_attedit,
             grip_object_limit: self.grip_object_limit,
+            ncopy_bind: self.ncopy_bind,
             cursor_type: self.cursor_type,
             crosshair_color: self.crosshair_color,
             lineweight_display_scale: self.lineweight_display_scale,
@@ -467,6 +468,7 @@ impl OpenCADStudio {
         self.double_click_block_refedit = s.double_click_block_refedit;
         self.double_click_block_attedit = s.double_click_block_attedit;
         self.grip_object_limit = s.grip_object_limit.clamp(0, 32767);
+        self.ncopy_bind = s.ncopy_bind;
         self.cursor_type = s.cursor_type;
         self.crosshair_color = s.crosshair_color;
         self.crosshair_color_input = s

--- a/src/command.rs
+++ b/src/command.rs
@@ -1942,6 +1942,9 @@ impl InputKind {
 pub trait CadCommand: Send {
     /// Preserve source appearance for commands that extract existing entities.
     fn preserve_commit_style(&self) -> bool { false }
+    fn nested_copy_bind_setting(&self) -> Option<bool> { None }
+    /// Symbol localization is committed together with the extracted entities.
+    fn nested_copy_symbol_names(&self) -> Option<&acadrust::nested_copy::NestedCopySymbolNames> { None }
     /// Keep the layer already carried by entities committed by this command
     /// instead of replacing it with the current drawing layer.
     fn preserve_commit_layer(&self) -> bool {

--- a/src/command.rs
+++ b/src/command.rs
@@ -1940,6 +1940,8 @@ impl InputKind {
 }
 
 pub trait CadCommand: Send {
+    /// Preserve source appearance for commands that extract existing entities.
+    fn preserve_commit_style(&self) -> bool { false }
     /// Keep the layer already carried by entities committed by this command
     /// instead of replacing it with the current drawing layer.
     fn preserve_commit_layer(&self) -> bool {

--- a/src/io/xref.rs
+++ b/src/io/xref.rs
@@ -347,6 +347,7 @@ fn merge_xref_into_block(
         let old = layer.name.clone();
         let new = format!("{}|{}", prefix, old);
         let mut cloned = layer.clone();
+        xref_doc.normalize_imported_layer_defaults(&mut cloned);
         cloned.name = new.clone();
         cloned.set_handle(doc.allocate_handle());
         doc.layers.add_or_replace(cloned);

--- a/src/modules/draw/modify/mod.rs
+++ b/src/modules/draw/modify/mod.rs
@@ -13,6 +13,7 @@ pub mod join;
 pub mod lengthen;
 pub mod mirror;
 pub mod mledit;
+pub mod ncopy;
 pub mod offset;
 pub mod pedit;
 pub mod block_edit;

--- a/src/modules/draw/modify/ncopy.rs
+++ b/src/modules/draw/modify/ncopy.rs
@@ -1,11 +1,12 @@
 use acadrust::{CadDocument, EntityType, Handle};
 use glam::DVec3;
+use acadrust::nested_copy::{NestedCopyMode, NestedCopySymbolNames};
 use std::collections::{HashMap, HashSet};
 use crate::command::{CadCommand, CmdOption, CmdResult, EntityTransform};
 use crate::entities::traits::EntityTypeOps;
 use crate::scene::convert::acad_to_render::RenderObject;
 
-enum Step { Select, Base, Target(DVec3), ArrayCount(DVec3), ArrayTarget(DVec3, usize, bool) }
+enum Step { Select, Settings, Base, Target(DVec3), ArrayCount(DVec3), ArrayTarget(DVec3, usize, bool) }
 pub struct NcopyCommand {
     nested: HashMap<Handle, Vec<EntityType>>,
     hit_paths: HashMap<Handle, Vec<Vec<[f64; 3]>>>,
@@ -13,9 +14,12 @@ pub struct NcopyCommand {
     step: Step,
     multiple: bool,
     placements: usize,
+    mode: NestedCopyMode,
+    insert_names: NestedCopySymbolNames,
+    bind_names: NestedCopySymbolNames,
 }
 impl NcopyCommand {
-    pub fn new(document: &CadDocument) -> Self {
+    pub fn new(document: &CadDocument, bind: bool) -> Self {
         fn leaves(entity: &EntityType, document: &CadDocument, path: &mut HashSet<String>, output: &mut Vec<EntityType>) {
             let EntityType::Insert(insert) = entity else { output.push(entity.clone()); return; };
             let name = insert.block_name.to_ascii_uppercase();
@@ -43,7 +47,11 @@ impl NcopyCommand {
             }).collect();
             (handle, paths)
         }).collect();
-        Self { nested, hit_paths, selected: Vec::new(), step: Step::Select, multiple: false, placements: 0 }
+        Self { nested, hit_paths, selected: Vec::new(), step: Step::Select, multiple: false, placements: 0,
+            mode: if bind { NestedCopyMode::Bind } else { NestedCopyMode::Insert },
+            insert_names: document.nested_copy_symbol_names(NestedCopyMode::Insert),
+            bind_names: document.nested_copy_symbol_names(NestedCopyMode::Bind),
+        }
     }
     fn place(&self, delta: DVec3) -> CmdResult {
         if !delta.is_finite() { return CmdResult::NeedPoint; }
@@ -61,7 +69,8 @@ impl CadCommand for NcopyCommand {
     fn name(&self) -> &'static str { "NCOPY" }
     fn prompt(&self) -> String {
         match self.step {
-            Step::Select => "Select nested objects:".into(),
+            Step::Select => format!("Current setting: {}. Select nested objects or [Settings]:", if self.mode == NestedCopyMode::Bind { "Bind" } else { "Insert" }),
+            Step::Settings => format!("Enter setting [Insert/Bind] <{}>:", if self.mode == NestedCopyMode::Bind { "Bind" } else { "Insert" }),
             Step::Base => "Specify base point or [Displacement/Multiple] <Displacement>:".into(),
             Step::Target(_) => "Specify second point or [Array] <use first point as displacement>:".into(),
             Step::ArrayCount(_) => "Enter number of items to array:".into(),
@@ -71,12 +80,18 @@ impl CadCommand for NcopyCommand {
     }
     fn options(&self) -> Vec<CmdOption> {
         match self.step {
+            Step::Select => vec![CmdOption::new("Settings", "S")],
+            Step::Settings => vec![CmdOption::new("Insert", "I"), CmdOption::new("Bind", "B")],
             Step::Base => vec![CmdOption::new("Displacement", "D"), CmdOption::new("Multiple", "M")],
             Step::Target(_) if self.multiple && self.placements > 0 => vec![CmdOption::new("Array", "A"), CmdOption::new("Exit", "E"), CmdOption::new("Undo", "U")],
             Step::Target(_) => vec![CmdOption::new("Array", "A")],
             Step::ArrayTarget(_, _, false) => vec![CmdOption::new("Fit", "F")],
             _ => Vec::new(),
         }
+    }
+    fn nested_copy_bind_setting(&self) -> Option<bool> { Some(self.mode == NestedCopyMode::Bind) }
+    fn nested_copy_symbol_names(&self) -> Option<&NestedCopySymbolNames> {
+        Some(if self.mode == NestedCopyMode::Bind { &self.bind_names } else { &self.insert_names })
     }
     fn preserve_commit_style(&self) -> bool { true }
     fn preserve_commit_layer(&self) -> bool { true }
@@ -109,7 +124,7 @@ impl CadCommand for NcopyCommand {
     }
     fn on_point(&mut self, point: DVec3) -> CmdResult {
         match self.step {
-            Step::Select => CmdResult::NeedPoint,
+            Step::Select | Step::Settings => CmdResult::NeedPoint,
             Step::Base => { self.step = Step::Target(point); CmdResult::NeedPoint }
             Step::Target(base) => {
                 if !point.is_finite() { return CmdResult::NeedPoint; }
@@ -132,15 +147,25 @@ impl CadCommand for NcopyCommand {
     }
     fn on_enter(&mut self) -> CmdResult {
         match self.step {
+            Step::Settings => { self.step = Step::Select; CmdResult::NeedPoint }
             Step::Select if !self.selected.is_empty() => { self.step = Step::Base; CmdResult::NeedPoint }
             Step::Base => { self.step = Step::Target(DVec3::ZERO); CmdResult::NeedPoint }
             Step::Target(base) if !self.multiple => self.place(base),
             _ => CmdResult::Cancel,
         }
     }
-    fn point_step_accepts_keywords(&self) -> bool { matches!(self.step, Step::Base | Step::Target(_) | Step::ArrayTarget(..)) }
-    fn wants_text_input(&self) -> bool { !matches!(self.step, Step::Select) }
+    fn point_step_accepts_keywords(&self) -> bool { matches!(self.step, Step::Select | Step::Settings | Step::Base | Step::Target(_) | Step::ArrayTarget(..)) }
+    fn wants_text_input(&self) -> bool { true }
     fn on_text_input(&mut self, text: &str) -> Option<CmdResult> {
+        if matches!(self.step, Step::Settings) {
+            match text.trim().to_uppercase().as_str() {
+                "I" | "INSERT" => self.mode = NestedCopyMode::Insert,
+                "B" | "BIND" => self.mode = NestedCopyMode::Bind,
+                _ => return Some(CmdResult::NeedPoint),
+            }
+            self.step = Step::Select;
+            return Some(CmdResult::NeedPoint);
+        }
         if let Step::ArrayCount(base) = self.step {
             if let Ok(count) = text.trim().parse::<usize>() {
                 if (2..=32767).contains(&count) { self.step = Step::ArrayTarget(base, count, false); }
@@ -148,6 +173,7 @@ impl CadCommand for NcopyCommand {
             return Some(CmdResult::NeedPoint);
         }
         match text.trim().to_uppercase().as_str() {
+            "S" | "SETTINGS" if matches!(self.step, Step::Select) => { self.step = Step::Settings; Some(CmdResult::NeedPoint) }
             "A" | "ARRAY" => {
                 if let Step::Target(base) = self.step { self.step = Step::ArrayCount(base); }
                 Some(CmdResult::NeedPoint)

--- a/src/modules/draw/modify/ncopy.rs
+++ b/src/modules/draw/modify/ncopy.rs
@@ -1,0 +1,169 @@
+use acadrust::{CadDocument, EntityType, Handle};
+use glam::DVec3;
+use std::collections::{HashMap, HashSet};
+use crate::command::{CadCommand, CmdOption, CmdResult, EntityTransform};
+use crate::entities::traits::EntityTypeOps;
+use crate::scene::convert::acad_to_render::RenderObject;
+
+enum Step { Select, Base, Target(DVec3), ArrayCount(DVec3), ArrayTarget(DVec3, usize, bool) }
+pub struct NcopyCommand {
+    nested: HashMap<Handle, Vec<EntityType>>,
+    hit_paths: HashMap<Handle, Vec<Vec<[f64; 3]>>>,
+    selected: Vec<(Handle, usize)>,
+    step: Step,
+    multiple: bool,
+    placements: usize,
+}
+impl NcopyCommand {
+    pub fn new(document: &CadDocument) -> Self {
+        fn leaves(entity: &EntityType, document: &CadDocument, path: &mut HashSet<String>, output: &mut Vec<EntityType>) {
+            let EntityType::Insert(insert) = entity else { output.push(entity.clone()); return; };
+            let name = insert.block_name.to_ascii_uppercase();
+            if !path.insert(name.clone()) { return; }
+            for child in super::explode::explode_entity(entity, document) {
+                leaves(&child, document, path, output);
+            }
+            path.remove(&name);
+        }
+        let nested: HashMap<_, _> = document.entities().filter(|e| matches!(e, EntityType::Insert(_)))
+            .map(|e| {
+                let mut entities = Vec::new();
+                leaves(e, document, &mut HashSet::new(), &mut entities);
+                (e.common().handle, entities)
+            }).collect();
+        let hit_paths = nested.iter().map(|(&handle, entities)| {
+            let paths = entities.iter().map(|entity| {
+                if crate::entities::curve::entity_curve(entity).is_some() { return Vec::new(); }
+                match entity.to_render_entity(document).map(|render| render.object) {
+                    Some(RenderObject::Dot(point)) => vec![point],
+                    Some(RenderObject::Lines(points) | RenderObject::SegmentedLines(points)
+                        | RenderObject::TaperedLines(points, _) | RenderObject::BoundaryLines { points, .. }) => points,
+                    _ => Vec::new(),
+                }
+            }).collect();
+            (handle, paths)
+        }).collect();
+        Self { nested, hit_paths, selected: Vec::new(), step: Step::Select, multiple: false, placements: 0 }
+    }
+    fn place(&self, delta: DVec3) -> CmdResult {
+        if !delta.is_finite() { return CmdResult::NeedPoint; }
+        let copies = self.selected.iter().filter_map(|(h, index)| self.nested.get(h)?.get(*index)).cloned()
+            .map(|mut entity| {
+                crate::scene::view::dispatch::apply_transform(&mut entity, &EntityTransform::Translate(delta));
+                entity.common_mut().handle = Handle::NULL;
+                entity
+            }).collect();
+        if self.multiple { CmdResult::CommitEntities(copies) }
+        else { CmdResult::CommitEntitiesAndExit(copies) }
+    }
+}
+impl CadCommand for NcopyCommand {
+    fn name(&self) -> &'static str { "NCOPY" }
+    fn prompt(&self) -> String {
+        match self.step {
+            Step::Select => "Select nested objects:".into(),
+            Step::Base => "Specify base point or [Displacement/Multiple] <Displacement>:".into(),
+            Step::Target(_) => "Specify second point or [Array] <use first point as displacement>:".into(),
+            Step::ArrayCount(_) => "Enter number of items to array:".into(),
+            Step::ArrayTarget(_, _, false) => "Specify second point or [Fit]:".into(),
+            Step::ArrayTarget(_, _, true) => "Specify last point:".into(),
+        }
+    }
+    fn options(&self) -> Vec<CmdOption> {
+        match self.step {
+            Step::Base => vec![CmdOption::new("Displacement", "D"), CmdOption::new("Multiple", "M")],
+            Step::Target(_) if self.multiple && self.placements > 0 => vec![CmdOption::new("Array", "A"), CmdOption::new("Exit", "E"), CmdOption::new("Undo", "U")],
+            Step::Target(_) => vec![CmdOption::new("Array", "A")],
+            Step::ArrayTarget(_, _, false) => vec![CmdOption::new("Fit", "F")],
+            _ => Vec::new(),
+        }
+    }
+    fn preserve_commit_style(&self) -> bool { true }
+    fn preserve_commit_layer(&self) -> bool { true }
+    fn needs_entity_pick(&self) -> bool { matches!(self.step, Step::Select) }
+    fn on_entity_pick(&mut self, handle: Handle, point: DVec3) -> CmdResult {
+        if let Some(entities) = self.nested.get(&handle) {
+            let nearest = entities.iter().enumerate().filter_map(|(index, entity)| {
+                let distance = if let Some(curve) = crate::entities::curve::entity_curve(entity) {
+                    let projected = curve.plane.project([point.x, point.y, point.z])?;
+                    cadkernel::geom2d::closest_point(&curve.curve, projected).distance
+                        .hypot(curve.plane.distance_to(point.to_array())?)
+                } else {
+                    let path = self.hit_paths.get(&handle)?.get(index)?;
+                    let point = cadkernel::space::Vec3::from(point.to_array());
+                    if path.len() == 1 {
+                        point.distance(cadkernel::space::Vec3::from(path[0]))
+                    } else {
+                        path.windows(2).filter(|segment| segment.iter().flatten().all(|v| v.is_finite()))
+                            .map(|segment| point.distance_to_segment(segment[0].into(), segment[1].into()))
+                            .min_by(f64::total_cmp)?
+                    }
+                };
+                Some((index, distance))
+            }).min_by(|a, b| a.1.total_cmp(&b.1));
+            if let Some((index, _)) = nearest {
+                if !self.selected.contains(&(handle, index)) { self.selected.push((handle, index)); }
+            }
+        }
+        CmdResult::NeedPoint
+    }
+    fn on_point(&mut self, point: DVec3) -> CmdResult {
+        match self.step {
+            Step::Select => CmdResult::NeedPoint,
+            Step::Base => { self.step = Step::Target(point); CmdResult::NeedPoint }
+            Step::Target(base) => {
+                if !point.is_finite() { return CmdResult::NeedPoint; }
+                self.placements += 1;
+                self.place(point - base)
+            }
+            Step::ArrayCount(_) => CmdResult::NeedPoint,
+            Step::ArrayTarget(base, count, fit) => {
+                let delta = (point - base) / if fit { (count - 1) as f64 } else { 1.0 };
+                if !delta.is_finite() { return CmdResult::NeedPoint; }
+                let mut copies = Vec::new();
+                for index in 0..count {
+                    if let CmdResult::CommitEntities(mut entities) | CmdResult::CommitEntitiesAndExit(mut entities) = self.place(delta * index as f64) {
+                        copies.append(&mut entities);
+                    }
+                }
+                CmdResult::CommitEntitiesAndExit(copies)
+            }
+        }
+    }
+    fn on_enter(&mut self) -> CmdResult {
+        match self.step {
+            Step::Select if !self.selected.is_empty() => { self.step = Step::Base; CmdResult::NeedPoint }
+            Step::Base => { self.step = Step::Target(DVec3::ZERO); CmdResult::NeedPoint }
+            Step::Target(base) if !self.multiple => self.place(base),
+            _ => CmdResult::Cancel,
+        }
+    }
+    fn point_step_accepts_keywords(&self) -> bool { matches!(self.step, Step::Base | Step::Target(_) | Step::ArrayTarget(..)) }
+    fn wants_text_input(&self) -> bool { !matches!(self.step, Step::Select) }
+    fn on_text_input(&mut self, text: &str) -> Option<CmdResult> {
+        if let Step::ArrayCount(base) = self.step {
+            if let Ok(count) = text.trim().parse::<usize>() {
+                if (2..=32767).contains(&count) { self.step = Step::ArrayTarget(base, count, false); }
+            }
+            return Some(CmdResult::NeedPoint);
+        }
+        match text.trim().to_uppercase().as_str() {
+            "A" | "ARRAY" => {
+                if let Step::Target(base) = self.step { self.step = Step::ArrayCount(base); }
+                Some(CmdResult::NeedPoint)
+            }
+            "F" | "FIT" => {
+                if let Step::ArrayTarget(base, count, _) = self.step { self.step = Step::ArrayTarget(base, count, true); }
+                Some(CmdResult::NeedPoint)
+            }
+            "U" | "UNDO" if self.multiple && self.placements > 0 => {
+                self.placements -= 1;
+                Some(CmdResult::UndoDocument)
+            }
+            "E" | "EXIT" if self.multiple => Some(CmdResult::Cancel),
+            "M" | "MULTIPLE" if matches!(self.step, Step::Base) => { self.multiple = true; Some(CmdResult::NeedPoint) }
+            "D" | "DISPLACEMENT" if matches!(self.step, Step::Base) => { self.step = Step::Target(DVec3::ZERO); Some(CmdResult::NeedPoint) }
+            _ => None,
+        }
+    }
+}


### PR DESCRIPTION
1) Replace copying every block child in place with picking individual nested objects, collecting multiple picks, and choosing a base point and destination.

2) Resolve recursively nested block transforms with cycle detection and select supported curve, line, and point geometry using existing geometry and rendering APIs.

3) Add displacement, repeated placement, array count, Fit spacing, Exit, and guarded Undo inputs.

4) Preserve source layers, colors, linetypes, lineweights, and creation styles when committing extracted objects; retain the original block references.

5) Commit a completed single placement or array as one undoable operation and reject nonfinite displacement input.

6) Add Settings with Insert and Bind choices, current-setting prompts, Enter to retain the setting, and persistent user configuration across application sessions.

7) Localize extracted layer and simple-linetype symbols through the codec API. Insert reuses host definitions; Bind creates collision-free numbered definitions with stable names across repeated placements.

8) Capture symbol-table and entity changes together for undo and refresh layer controls after imports. Report retained imported references when style dependencies cannot be localized.

9) Normalize dictionary-identified default layer material and plotstyle dependencies when resolving external references, preserving nondefault references.