### PR TITLE
Create regions from closed profiles and connected edges

### DIFF
--- a/src/app/commands/draw.rs
+++ b/src/app/commands/draw.rs
@@ -1153,7 +1153,9 @@ impl OpenCADStudio {
                     .filter(|(handle, _)| !sources.contains(handle))
                     .filter_map(|(_, entity)| crate::entities::curve::entity_curve(entity))
                     .collect();
-                if let Some(plane) = cadkernel::space::common_curve_plane(&open_curves, 1.0e-6) {
+                let open_plane = cadkernel::space::common_curve_plane(&open_curves, 1.0e-6);
+                let open_plane_rejected = !open_curves.is_empty() && open_plane.is_none();
+                if let Some(plane) = open_plane {
                 let working_plane = crate::command::WorkingPlane::new(
                     glam::DVec3::from_array(plane.origin),
                     glam::DVec3::from_array(plane.x_axis),
@@ -1184,12 +1186,14 @@ impl OpenCADStudio {
                     regions.push((region, body));
                     sources.extend(crate::scene::ring_source_handles(&ring, &boundary_sources));
                 }
-                } else if !open_curves.is_empty() {
-                    self.command_line.push_error("REGION: open objects must form coplanar, noncollinear boundaries.");
+                } else if open_plane_rejected {
+                    self.command_line.push_error("Open objects must be coplanar.");
                 }
                 if regions.is_empty() {
-                    self.command_line
-                        .push_error(crate::t!("REGION: select closed polylines or circles.").as_ref());
+                    if !open_plane_rejected {
+                        self.command_line
+                            .push_error(crate::t!("REGION: select closed polylines or circles.").as_ref());
+                    }
                 } else {
                     self.push_undo_snapshot(i, "REGION");
                     let count = regions.len();

--- a/src/app/commands/draw.rs
+++ b/src/app/commands/draw.rs
@@ -1114,8 +1114,7 @@ impl OpenCADStudio {
                 return Some(self.fit_spline());
             }
 
-            // REGION — convert selected closed boundaries (closed polylines /
-            // circles) into Region entities (one wire loop each).
+            // REGION — convert exact closed planar profiles into regions.
             "REGION" | "REG" => {
                 if self.tabs[i].scene.selected_entities().is_empty() {
                     use crate::modules::draw::select::SelectObjectsCommand;
@@ -1129,12 +1128,7 @@ impl OpenCADStudio {
                 let mut regions = Vec::new();
                 let mut sources = Vec::new();
                 for (handle, e) in self.tabs[i].scene.selected_entities().iter() {
-                    let supported = matches!(
-                        e,
-                        acadrust::EntityType::LwPolyline(pl)
-                            if pl.is_closed && pl.vertices.len() >= 3
-                    ) || matches!(e, acadrust::EntityType::Circle(_));
-                    if supported {
+                    if !matches!(e, acadrust::EntityType::Region(_)) {
                         let Some((plane, loops, true)) =
                             crate::scene::model::presspull_model::profile_geometry(e)
                         else {
@@ -1153,6 +1147,40 @@ impl OpenCADStudio {
                         regions.push((region, body));
                         sources.push(*handle);
                     }
+                }
+                // Assemble remaining selected open edges on the active plane.
+                // Face discovery and exact curve reconstruction reuse the
+                // same kernel-backed boundary path used by area selection.
+                let working_plane = self.tabs[i].ucs_xform().working_plane();
+                let selected_handles: rustc_hash::FxHashSet<_> = self.tabs[i].scene
+                    .selected_entities().iter().map(|(handle, _)| *handle).collect();
+                let mut boundary_sources = self.tabs[i].scene
+                    .boundary_sources_on_plane(working_plane, 1.0e-6);
+                boundary_sources.retain(|handle, _| {
+                    selected_handles.contains(handle) && !sources.contains(handle)
+                });
+                let plane = cadkernel::space::Plane::from_axes(
+                    working_plane.origin.to_array(),
+                    working_plane.x.to_array(),
+                    working_plane.y.to_array(),
+                );
+                for ring in crate::scene::boundary_faces(&boundary_sources, 1.0e-6) {
+                    let paths = crate::scene::exact_hatch_paths(
+                        std::slice::from_ref(&ring), &[true], &boundary_sources, 1.0e-6,
+                    );
+                    let Some(path) = paths.first() else { continue; };
+                    let Some(curves) = path.edges.iter()
+                        .map(crate::entities::hatch::edge_curve).collect::<Option<Vec<_>>>()
+                    else { continue; };
+                    let Some(body) = cadkernel::brep::planar_region(plane, &[curves])
+                    else { continue; };
+                    let mut region = Region::new();
+                    region.point_of_reference = Vector3::new(
+                        plane.origin[0], plane.origin[1], plane.origin[2],
+                    );
+                    region.common.layer = self.tabs[i].active_layer.clone();
+                    regions.push((region, body));
+                    sources.extend(crate::scene::ring_source_handles(&ring, &boundary_sources));
                 }
                 if regions.is_empty() {
                     self.command_line

--- a/src/app/commands/draw.rs
+++ b/src/app/commands/draw.rs
@@ -1148,10 +1148,17 @@ impl OpenCADStudio {
                         sources.push(*handle);
                     }
                 }
-                // Assemble remaining selected open edges on the active plane.
-                // Face discovery and exact curve reconstruction reuse the
-                // same kernel-backed boundary path used by area selection.
-                let working_plane = self.tabs[i].ucs_xform().working_plane();
+                // Open inputs must share one geometric plane, independently of the UCS.
+                let open_curves: Vec<_> = self.tabs[i].scene.selected_entities().iter()
+                    .filter(|(handle, _)| !sources.contains(handle))
+                    .filter_map(|(_, entity)| crate::entities::curve::entity_curve(entity))
+                    .collect();
+                if let Some(plane) = cadkernel::space::common_curve_plane(&open_curves, 1.0e-6) {
+                let working_plane = crate::command::WorkingPlane::new(
+                    glam::DVec3::from_array(plane.origin),
+                    glam::DVec3::from_array(plane.x_axis),
+                    glam::DVec3::from_array(plane.y_axis),
+                );
                 let selected_handles: rustc_hash::FxHashSet<_> = self.tabs[i].scene
                     .selected_entities().iter().map(|(handle, _)| *handle).collect();
                 let mut boundary_sources = self.tabs[i].scene
@@ -1159,11 +1166,6 @@ impl OpenCADStudio {
                 boundary_sources.retain(|handle, _| {
                     selected_handles.contains(handle) && !sources.contains(handle)
                 });
-                let plane = cadkernel::space::Plane::from_axes(
-                    working_plane.origin.to_array(),
-                    working_plane.x.to_array(),
-                    working_plane.y.to_array(),
-                );
                 for ring in crate::scene::boundary_faces(&boundary_sources, 1.0e-6) {
                     let paths = crate::scene::exact_hatch_paths(
                         std::slice::from_ref(&ring), &[true], &boundary_sources, 1.0e-6,
@@ -1181,6 +1183,9 @@ impl OpenCADStudio {
                     region.common.layer = self.tabs[i].active_layer.clone();
                     regions.push((region, body));
                     sources.extend(crate::scene::ring_source_handles(&ring, &boundary_sources));
+                }
+                } else if !open_curves.is_empty() {
+                    self.command_line.push_error("REGION: open objects must form coplanar, noncollinear boundaries.");
                 }
                 if regions.is_empty() {
                     self.command_line


### PR DESCRIPTION
1) Convert every supported exact closed planar profile into a region instead of restricting conversion to circles and closed lightweight polylines with at least three vertices.

2) Infer the shared geometric plane of selected open curves through the kernel API, independently of the current work plane. Reconstruct disconnected coplanar loops through existing boundary discovery and exact planar region geometry.

3) Reject noncoplanar or collinear open inputs with a command message while retaining their original geometry.

4) Create resulting regions on the active layer and collect only source handles belonging to successfully reconstructed boundaries for source removal.

5) Preserve the specific open-object coplanarity error instead of replacing it with a generic closed-profile message, while still converting independently valid closed profiles in mixed selections.