### PR TITLE
Add spline refinement and repeatable editing workflows

### DIFF
--- a/src/app/command_driver.rs
+++ b/src/app/command_driver.rs
@@ -312,6 +312,33 @@ impl OpenCADStudio {
         true
     }
 
+    /// Refresh screen-space feature picking immediately before point dispatch.
+    pub(super) fn refresh_command_point_pick_context(&mut self, i: usize) {
+        if self.tabs[i].active_cmd.as_ref()
+            .is_some_and(|command| command.wants_point_pick_context())
+        {
+            let scene = &self.tabs[i].scene;
+            let size = scene.selection.borrow().vp_size;
+            let edit = scene.viewport_edit_frame(size);
+            let tile = edit.as_ref().map(|(_, rect)| *rect)
+                .unwrap_or_else(|| scene.active_model_tile_bounds(size.0, size.1));
+            let bounds = iced::Rectangle { x: 0.0, y: 0.0, width: tile.width, height: tile.height };
+            let context = if bounds.width > 0.0 && bounds.height > 0.0 {
+                let (view, eye) = if let Some((camera, _)) = edit {
+                    (camera.view_proj_rte(bounds), camera.eye())
+                } else {
+                    let camera = scene.camera.borrow();
+                    (camera.view_proj_rte(bounds), camera.eye())
+                };
+                Some(crate::command::PointPickContext { view, eye, bounds,
+                    aperture_px: crate::ui::overlay::pick_box_aperture_px(self.pick_box) })
+            } else { None };
+            if let Some(command) = self.tabs[i].active_cmd.as_mut() {
+                command.set_point_pick_context(context);
+            }
+        }
+    }
+
     /// Drive the active command's step machine with one [`StepInput`], then
     /// apply the result. This is the single entry point every input source
     /// (command line, headless, dynamic input, plugin API, viewport) funnels
@@ -414,6 +441,7 @@ impl OpenCADStudio {
                 command.inject_selection_entities(entities);
             }
         }
+        if matches!(&input, StepInput::Point(_)) { self.refresh_command_point_pick_context(i); }
         let ctrl = self.ctrl_down;
         let shift = self.shift_down;
         let result: Option<CmdResult> = {

--- a/src/app/command_driver.rs
+++ b/src/app/command_driver.rs
@@ -417,10 +417,13 @@ impl OpenCADStudio {
             }
         }
         if let StepInput::SelectionComplete(handles) = &input {
+            let exclude_locked = self.tabs[i].active_cmd.as_ref()
+                .is_some_and(|command| command.selection_entities_exclude_locked());
             let entities = {
                 let scene = &self.tabs[i].scene;
                 handles
                     .iter()
+                    .filter(|handle| !exclude_locked || !scene.is_layer_locked(**handle))
                     .filter_map(|handle| {
                         scene.document.get_entity(*handle).cloned().map(|entity| {
                             let surface_area = scene

--- a/src/app/commands/inquiry.rs
+++ b/src/app/commands/inquiry.rs
@@ -329,7 +329,7 @@ impl OpenCADStudio {
 
             "SPLINEDIT" => {
                 use crate::modules::draw::modify::splinedit::SplineditCommand;
-                let mut cmd_obj = SplineditCommand::new();
+                let mut cmd_obj = SplineditCommand::new().with_delete_source(self.delete_objects != 0);
                 let selected: Vec<_> = self.tabs[i].scene.selected.iter().copied().collect();
                 if let [handle] = selected.as_slice() {
                     if let Some(entity @ acadrust::EntityType::Spline(_)) =

--- a/src/app/commands/inquiry.rs
+++ b/src/app/commands/inquiry.rs
@@ -329,7 +329,17 @@ impl OpenCADStudio {
 
             "SPLINEDIT" => {
                 use crate::modules::draw::modify::splinedit::SplineditCommand;
-                let cmd_obj = SplineditCommand::new();
+                let mut cmd_obj = SplineditCommand::new();
+                let selected: Vec<_> = self.tabs[i].scene.selected.iter().copied().collect();
+                if let [handle] = selected.as_slice() {
+                    if let Some(entity @ acadrust::EntityType::Spline(_)) =
+                        self.tabs[i].scene.document.get_entity(*handle).cloned()
+                    {
+                        if self.reject_locked_edit(i, *handle) { return Some(Task::none()); }
+                        cmd_obj.inject_picked_entity(entity);
+                        cmd_obj.on_entity_pick(*handle, glam::DVec3::ZERO);
+                    }
+                }
                 self.command_line.push_info(&cmd_obj.prompt());
                 self.tabs[i].active_cmd = Some(Box::new(cmd_obj));
             }

--- a/src/app/update/viewport.rs
+++ b/src/app/update/viewport.rs
@@ -3887,6 +3887,7 @@ impl OpenCADStudio {
                 } else if self.tabs[i].active_cmd.as_ref()
                     .is_some_and(|command| command.entity_pick_accepts_points())
                 {
+                    self.refresh_command_point_pick_context(i);
                     self.tabs[i].active_cmd.as_mut().map(|command| command.on_point(pick_wcs))
                 } else if self.tabs[i]
                     .active_cmd
@@ -3963,6 +3964,7 @@ impl OpenCADStudio {
                 // (LINE tangent to two circles, which needs both). When
                 // it does, sync last_point to the command's resolved
                 // anchor since it replaced the picked coordinate.
+                self.refresh_command_point_pick_context(i);
                 let handled = self.tabs[i]
                     .active_cmd
                     .as_mut()

--- a/src/command.rs
+++ b/src/command.rs
@@ -1939,6 +1939,15 @@ impl InputKind {
     }
 }
 
+/// Current screen projection and configured aperture for point-feature picking.
+#[derive(Clone, Copy)]
+pub struct PointPickContext {
+    pub view: glam::Mat4,
+    pub eye: DVec3,
+    pub bounds: iced::Rectangle,
+    pub aperture_px: f32,
+}
+
 pub trait CadCommand: Send {
     /// Keep the layer already carried by entities committed by this command
     /// instead of replacing it with the current drawing layer.
@@ -2005,6 +2014,12 @@ pub trait CadCommand: Send {
 
     /// Called when the user left-clicks in the viewport (point pick).
     fn on_point(&mut self, pt: DVec3) -> CmdResult;
+
+    /// Opt in only while a point input selects an existing point feature.
+    fn wants_point_pick_context(&self) -> bool { false }
+
+    /// Refreshed for each point input so zoom and viewport changes are reflected.
+    fn set_point_pick_context(&mut self, _context: Option<PointPickContext>) {}
 
     /// Called when the user presses Enter (finalize / next option).
     fn on_enter(&mut self) -> CmdResult;

--- a/src/command.rs
+++ b/src/command.rs
@@ -2301,6 +2301,9 @@ pub trait CadCommand: Send {
         CmdResult::Cancel
     }
 
+    /// Exclude locked-layer entities from injected selection geometry.
+    fn selection_entities_exclude_locked(&self) -> bool { false }
+
     fn inject_selection_entities(&mut self, _entities: Vec<SelectionEntity>) {}
 
     fn area_preview_regions(&self) -> Option<Vec<AreaPreviewRegion>> {

--- a/src/modules/draw/modify/reverse.rs
+++ b/src/modules/draw/modify/reverse.rs
@@ -176,9 +176,8 @@ fn reverse_polyline2d(pl: &acadrust::entities::Polyline2D) -> acadrust::entities
     out
 }
 
-/// Reverse a Spline: flip control points and fit points, regenerate the
-/// clamped knot vector. Mirrors `splinedit::apply_spline_op`'s REVERSE branch.
-fn reverse_spline(sp: &Spline) -> Spline {
+/// Reverse stored coordinates in 3D and let the kernel mirror the knot domain.
+pub(super) fn reverse_spline(sp: &Spline) -> Spline {
     let mut out = sp.clone();
     out.control_points.reverse();
     out.fit_points.reverse();
@@ -186,8 +185,11 @@ fn reverse_spline(sp: &Spline) -> Spline {
     if out.weights.len() == out.control_points.len() {
         out.weights.reverse();
     }
-    out.knots =
-        Spline::generate_clamped_knots(out.degree as usize, out.control_points.len());
+    if let Some(curve) = super::spline_ops::spline_to_nurbs(sp) {
+        out.knots = curve.reversed().knots().to_vec();
+    }
+    out.begin_tangent = acadrust::types::Vector3::new(-sp.end_tangent.x, -sp.end_tangent.y, -sp.end_tangent.z);
+    out.end_tangent = acadrust::types::Vector3::new(-sp.begin_tangent.x, -sp.begin_tangent.y, -sp.begin_tangent.z);
     out
 }
 

--- a/src/modules/draw/modify/splinedit.rs
+++ b/src/modules/draw/modify/splinedit.rs
@@ -109,10 +109,24 @@ impl SplineditCommand {
             let current = usize::try_from(source.degree).ok()?;
             if degree <= current || degree > 25 { return None; }
             let weights = if source.weights.is_empty() { vec![1.0; source.control_points.len()] } else { source.weights.clone() };
-            let curve = cadkernel::space::NurbsCurve3::new_strict(current,
-                source.control_points.iter().map(|point| [point.x, point.y, point.z]).collect(),
-                source.knots.clone(), weights)?
-                .with_periodicity(source.flags.closed || source.flags.periodic)
+            let curve = if source.control_points.is_empty() && source.fit_points.len() >= 2 {
+                use cadkernel::space::{NurbsCurve3, Parameterization};
+                let points: Vec<_> = source.fit_points.iter().map(|point| [point.x, point.y, point.z]).collect();
+                let parameterization = match source.knot_parameterization {
+                    1 => Parameterization::Centripetal, 2 => Parameterization::Uniform, _ => Parameterization::Chord,
+                };
+                let tangent = |point: &Vector3| (point.x != 0.0 || point.y != 0.0 || point.z != 0.0).then_some([point.x, point.y, point.z]);
+                if source.flags.closed || source.flags.periodic {
+                    NurbsCurve3::interpolate_periodic(&points, parameterization)?
+                } else {
+                    NurbsCurve3::interpolate_fit(&points, tangent(&source.begin_tangent), tangent(&source.end_tangent), parameterization)?
+                }
+            } else {
+                cadkernel::space::NurbsCurve3::new_strict(current,
+                    source.control_points.iter().map(|point| [point.x, point.y, point.z]).collect(),
+                    source.knots.clone(), weights)?
+            };
+            let curve = curve.with_periodicity(source.flags.closed || source.flags.periodic)
                 .elevated(degree - current)?
                 .compact_knots(source.control_tolerance.max(1e-9))?;
             let mut result = source.clone();

--- a/src/modules/draw/modify/splinedit.rs
+++ b/src/modules/draw/modify/splinedit.rs
@@ -34,6 +34,7 @@ enum Step {
     Options,
     Refine,
     Add,
+    Delete,
     Elevate,
     Move { index: usize, refine: bool },
     Weight { index: usize },
@@ -89,8 +90,9 @@ impl CadCommand for SplineditCommand {
         match self.step {
             Step::SelectSpline => crate::t!("SPLINEDIT  Select spline:").into_owned(),
             Step::Options => crate::t!("SPLINEDIT  [Close/Open/Move vertex/Refine/rEverse/Undo/eXit] <eXit>:").into_owned(),
-            Step::Refine => crate::t!("SPLINEDIT  [Add/Elevate order/Move/Weight/eXit] <eXit>:").into_owned(),
+            Step::Refine => crate::t!("SPLINEDIT  [Add/Delete/Elevate order/Move/Weight/eXit] <eXit>:").into_owned(),
             Step::Add => crate::t!("SPLINEDIT  Specify a point on the spline <exit>:").into_owned(),
+            Step::Delete => crate::t!("SPLINEDIT  Specify control vertex to delete:").into_owned(),
             Step::Elevate => format!("SPLINEDIT  Enter new order <{}>:", self.spline.as_ref().map_or(4, |s| s.degree + 1)),
             Step::Move { index, .. } => format!("SPLINEDIT  Vertex {}: specify new location or [Next/Previous/Select point/eXit] <Next>:", index + 1),
             Step::SelectVertex { .. } => crate::t!("SPLINEDIT  Specify control vertex:").into_owned(),
@@ -101,7 +103,7 @@ impl CadCommand for SplineditCommand {
         use crate::command::CmdOption;
         match self.step {
             Step::Options => vec![CmdOption::new("Close", "C"), CmdOption::new("Open", "O"), CmdOption::new("Move vertex", "M"), CmdOption::new("Refine", "R"), CmdOption::new("Reverse", "E"), CmdOption::new("Undo", "U"), CmdOption::new("Exit", "X")],
-            Step::Refine => vec![CmdOption::new("Add", "A"), CmdOption::new("Elevate order", "E"), CmdOption::new("Move", "M"), CmdOption::new("Weight", "W"), CmdOption::new("Exit", "X")],
+            Step::Refine => vec![CmdOption::new("Add", "A"), CmdOption::new("Delete", "D"), CmdOption::new("Elevate order", "E"), CmdOption::new("Move", "M"), CmdOption::new("Weight", "W"), CmdOption::new("Exit", "X")],
             Step::Move { .. } | Step::Weight { .. } => vec![CmdOption::new("Next", "N"), CmdOption::new("Previous", "P"), CmdOption::new("Select point", "S"), CmdOption::new("Exit", "X")],
             _ => Vec::new(),
         }
@@ -125,7 +127,7 @@ impl CadCommand for SplineditCommand {
             }
         }
     }
-    fn wants_text_input(&self) -> bool { !matches!(self.step, Step::SelectSpline | Step::Add | Step::Move { .. } | Step::SelectVertex { .. }) }
+    fn wants_text_input(&self) -> bool { !matches!(self.step, Step::SelectSpline | Step::Add | Step::Delete | Step::Move { .. } | Step::SelectVertex { .. }) }
     fn on_text_input(&mut self, text: &str) -> Option<CmdResult> {
         let upper = text.trim().to_uppercase();
         if upper.is_empty() { return Some(self.on_enter()); }
@@ -151,6 +153,7 @@ impl CadCommand for SplineditCommand {
             },
             Step::Refine => match upper.as_str() {
                 "A" | "ADD" => self.step = Step::Add,
+                "D" | "DELETE" => self.step = Step::Delete,
                 "E" | "ELEVATE" => self.step = Step::Elevate,
                 "M" | "MOVE" => self.step = Step::Move { index: 0, refine: true },
                 "W" | "WEIGHT" => self.step = Step::Weight { index: 0 },
@@ -204,6 +207,26 @@ impl CadCommand for SplineditCommand {
                 }
                 CmdResult::NeedPoint
             }
+            Step::Delete => {
+                let Some(source) = self.spline.as_ref() else { return CmdResult::NeedPoint; };
+                let Some(index) = source.control_points.iter().enumerate().min_by(|(_, a), (_, b)| {
+                    let distance = |p: &Vector3| point.distance_squared(DVec3::new(p.x, p.y, p.z));
+                    distance(a).total_cmp(&distance(b))
+                }).map(|(index, _)| index) else { return CmdResult::NeedPoint; };
+                let controls = source.control_points.iter().map(|point| [point.x, point.y, point.z]).collect();
+                let weights = if source.weights.is_empty() { vec![1.0; source.control_points.len()] }
+                    else { source.weights.clone() };
+                let curve = cadkernel::space::NurbsCurve3::new_strict(source.degree as usize, controls,
+                    source.knots.clone(), weights).map(|curve| curve.with_periodicity(source.flags.periodic));
+                let Some(curve) = curve.and_then(|curve| curve.without_control_vertex(index)) else { return CmdResult::NeedPoint; };
+                let mut spline = source.clone();
+                spline.degree = curve.degree() as i32;
+                spline.control_points = curve.control_points().iter().map(|point| Vector3::new(point[0], point[1], point[2])).collect();
+                spline.weights = curve.weights().to_vec();
+                spline.knots = curve.knots().to_vec();
+                spline.fit_points.clear();
+                self.replace(spline)
+            }
             Step::Add => self.refined(Some(point), None).map_or(CmdResult::NeedPoint, |spline| self.replace(spline)),
             Step::Move { index, .. } => {
                 let Some(mut spline) = self.spline.clone() else { return CmdResult::NeedPoint; };
@@ -219,7 +242,7 @@ impl CadCommand for SplineditCommand {
         match self.step {
             Step::SelectSpline | Step::Options => CmdResult::Cancel,
             Step::Refine => { self.step = Step::Options; CmdResult::NeedPoint }
-            Step::Add | Step::SelectVertex { .. } => { self.step = Step::Refine; CmdResult::NeedPoint }
+            Step::Add | Step::Delete | Step::SelectVertex { .. } => { self.step = Step::Refine; CmdResult::NeedPoint }
             Step::Elevate => {
                 let degree = self.spline.as_ref().map_or(4, |s| s.degree as usize + 1);
                 self.on_text_input(&degree.to_string()).unwrap_or(CmdResult::NeedPoint)

--- a/src/modules/draw/modify/splinedit.rs
+++ b/src/modules/draw/modify/splinedit.rs
@@ -47,11 +47,31 @@ pub struct SplineditCommand {
     spline: Option<acadrust::entities::Spline>,
     pending: Option<acadrust::entities::Spline>,
     history: Vec<(acadrust::Handle, acadrust::entities::Spline)>,
+    pick_context: Option<crate::command::PointPickContext>,
 }
 
 impl SplineditCommand {
     pub fn new() -> Self {
-        Self { step: Step::SelectSpline, handle: acadrust::Handle::NULL, spline: None, pending: None, history: Vec::new() }
+        Self { step: Step::SelectSpline, handle: acadrust::Handle::NULL, spline: None, pending: None, history: Vec::new(), pick_context: None }
+    }
+
+    fn picked_vertex(&self, point: DVec3) -> Option<usize> {
+        let context = self.pick_context?;
+        let project = |point: DVec3| {
+            let clip = context.view * (point - context.eye).as_vec3().extend(1.0);
+            if !clip.is_finite() || clip.w <= 0.0 { return None; }
+            let screen = crate::scene::pick::hit_test::world_to_screen(
+                point, context.view, context.eye, context.bounds);
+            (screen.x.is_finite() && screen.y.is_finite()
+                && screen.x >= 0.0 && screen.x <= context.bounds.width
+                && screen.y >= 0.0 && screen.y <= context.bounds.height).then_some(screen)
+        };
+        let cursor = project(point)?;
+        self.spline.as_ref()?.control_points.iter().enumerate().filter_map(|(index, vertex)| {
+            let screen = project(DVec3::new(vertex.x, vertex.y, vertex.z))?;
+            let distance = (screen.x - cursor.x).hypot(screen.y - cursor.y);
+            (distance.is_finite() && distance <= context.aperture_px).then_some((index, distance))
+        }).min_by(|a, b| a.1.total_cmp(&b.1)).map(|(index, _)| index)
     }
 
     fn replace(&mut self, spline: acadrust::entities::Spline) -> CmdResult {
@@ -194,25 +214,24 @@ impl CadCommand for SplineditCommand {
         }
         Some(CmdResult::NeedPoint)
     }
+    fn wants_point_pick_context(&self) -> bool {
+        matches!(self.step, Step::Delete | Step::SelectVertex { .. })
+    }
+    fn set_point_pick_context(&mut self, context: Option<crate::command::PointPickContext>) {
+        self.pick_context = context;
+    }
     fn on_point(&mut self, point: DVec3) -> CmdResult {
         if !point.is_finite() { return CmdResult::NeedPoint; }
         match self.step {
             Step::SelectVertex { weight, refine } => {
-                if let Some(index) = self.spline.as_ref().and_then(|spline| spline.control_points.iter().enumerate()
-                    .min_by(|(_, a), (_, b)| {
-                        let distance = |p: &Vector3| point.distance_squared(DVec3::new(p.x, p.y, p.z));
-                        distance(a).total_cmp(&distance(b))
-                    }).map(|(index, _)| index)) {
+                if let Some(index) = self.picked_vertex(point) {
                     self.step = if weight { Step::Weight { index } } else { Step::Move { index, refine } };
                 }
                 CmdResult::NeedPoint
             }
             Step::Delete => {
                 let Some(source) = self.spline.as_ref() else { return CmdResult::NeedPoint; };
-                let Some(index) = source.control_points.iter().enumerate().min_by(|(_, a), (_, b)| {
-                    let distance = |p: &Vector3| point.distance_squared(DVec3::new(p.x, p.y, p.z));
-                    distance(a).total_cmp(&distance(b))
-                }).map(|(index, _)| index) else { return CmdResult::NeedPoint; };
+                let Some(index) = self.picked_vertex(point) else { return CmdResult::NeedPoint; };
                 let controls = source.control_points.iter().map(|point| [point.x, point.y, point.z]).collect();
                 let weights = if source.weights.is_empty() { vec![1.0; source.control_points.len()] }
                     else { source.weights.clone() };

--- a/src/modules/draw/modify/splinedit.rs
+++ b/src/modules/draw/modify/splinedit.rs
@@ -33,6 +33,7 @@ enum Step {
     SelectSpline,
     Options,
     Refine,
+    Join,
     Add,
     Delete,
     Elevate,
@@ -48,11 +49,12 @@ pub struct SplineditCommand {
     pending: Option<acadrust::entities::Spline>,
     history: Vec<(acadrust::Handle, acadrust::entities::Spline)>,
     pick_context: Option<crate::command::PointPickContext>,
+    join_candidates: Vec<crate::command::SelectionEntity>,
 }
 
 impl SplineditCommand {
     pub fn new() -> Self {
-        Self { step: Step::SelectSpline, handle: acadrust::Handle::NULL, spline: None, pending: None, history: Vec::new(), pick_context: None }
+        Self { step: Step::SelectSpline, handle: acadrust::Handle::NULL, spline: None, pending: None, history: Vec::new(), pick_context: None, join_candidates: Vec::new() }
     }
 
     fn picked_vertex(&self, point: DVec3) -> Option<usize> {
@@ -81,6 +83,24 @@ impl SplineditCommand {
     fn replace(&mut self, spline: acadrust::entities::Spline) -> CmdResult {
         self.pending = Some(spline.clone());
         CmdResult::ReplaceManyContinue(vec![(self.handle, vec![EntityType::Spline(spline)])])
+    }
+
+    fn finish_join(&mut self) -> CmdResult {
+        self.step = Step::Options;
+        let candidates = std::mem::take(&mut self.join_candidates);
+        let Some(source) = self.spline.as_ref() else { return CmdResult::NeedPoint; };
+        let selected: Vec<_> = candidates.iter().filter(|item| item.handle != self.handle)
+            .map(|item| (item.handle, &item.entity)).collect();
+        let Some((EntityType::Spline(mut spline), consumed)) = super::join::join_to_source(
+            &EntityType::Spline(source.clone()), &selected) else { return CmdResult::NeedPoint; };
+        spline.dwg_flags1 &= !1;
+        spline.dxf_flags &= !(32 | 1024);
+        self.pending = Some(spline.clone());
+        let mut replacements = vec![(self.handle, vec![EntityType::Spline(spline)])];
+        replacements.extend(consumed.into_iter().map(|handle| (handle, Vec::new())));
+        // The host stores one document snapshot, including every consumed curve.
+        // The existing command-local Undo restores that snapshot and the source cache.
+        CmdResult::ReplaceManyContinue(replacements)
     }
 
     fn refined(&self, point: Option<DVec3>, degree: Option<usize>) -> Option<acadrust::entities::Spline> {
@@ -114,7 +134,8 @@ impl CadCommand for SplineditCommand {
         match self.step {
             Step::SelectSpline => crate::t!("SPLINEDIT  Select spline:").into_owned(),
             Step::Options if self.closed() => crate::t!("SPLINEDIT  [Open/Move vertex/Refine/rEverse/Undo/eXit] <eXit>:").into_owned(),
-            Step::Options => crate::t!("SPLINEDIT  [Close/Move vertex/Refine/rEverse/Undo/eXit] <eXit>:").into_owned(),
+            Step::Options => crate::t!("SPLINEDIT  [Close/Join/Move vertex/Refine/rEverse/Undo/eXit] <eXit>:").into_owned(),
+            Step::Join => crate::t!("SPLINEDIT  Select any open curves to join to source:").into_owned(),
             Step::Refine => crate::t!("SPLINEDIT  [Add/Delete/Elevate order/Move/Weight/eXit] <eXit>:").into_owned(),
             Step::Add => crate::t!("SPLINEDIT  Specify a point on the spline <exit>:").into_owned(),
             Step::Delete => crate::t!("SPLINEDIT  Specify control vertex to delete:").into_owned(),
@@ -127,11 +148,25 @@ impl CadCommand for SplineditCommand {
     fn options(&self) -> Vec<crate::command::CmdOption> {
         use crate::command::CmdOption;
         match self.step {
-            Step::Options => vec![if self.closed() { CmdOption::new("Open", "O") } else { CmdOption::new("Close", "C") }, CmdOption::new("Move vertex", "M"), CmdOption::new("Refine", "R"), CmdOption::new("Reverse", "E"), CmdOption::new("Undo", "U"), CmdOption::new("Exit", "X")],
+            Step::Options => {
+                let mut options = vec![if self.closed() { CmdOption::new("Open", "O") } else { CmdOption::new("Close", "C") }];
+                if !self.closed() { options.push(CmdOption::new("Join", "J")); }
+                options.extend([CmdOption::new("Move vertex", "M"), CmdOption::new("Refine", "R"), CmdOption::new("Reverse", "E"), CmdOption::new("Undo", "U"), CmdOption::new("Exit", "X")]);
+                options
+            },
             Step::Refine => vec![CmdOption::new("Add", "A"), CmdOption::new("Delete", "D"), CmdOption::new("Elevate order", "E"), CmdOption::new("Move", "M"), CmdOption::new("Weight", "W"), CmdOption::new("Exit", "X")],
             Step::Move { .. } | Step::Weight { .. } => vec![CmdOption::new("Next", "N"), CmdOption::new("Previous", "P"), CmdOption::new("Select point", "S"), CmdOption::new("Exit", "X")],
             _ => Vec::new(),
         }
+    }
+    fn is_selection_gathering(&self) -> bool { matches!(self.step, Step::Join) }
+    fn selection_entities_exclude_locked(&self) -> bool { matches!(self.step, Step::Join) }
+    fn inject_selection_entities(&mut self, entities: Vec<crate::command::SelectionEntity>) {
+        if matches!(self.step, Step::Join) { self.join_candidates = entities; }
+    }
+    fn on_selection_complete(&mut self, handles: Vec<acadrust::Handle>) -> CmdResult {
+        self.join_candidates.retain(|item| handles.contains(&item.handle) && item.handle != self.handle);
+        CmdResult::NeedPoint
     }
     fn needs_entity_pick(&self) -> bool { matches!(self.step, Step::SelectSpline) }
     fn inject_before_entity_pick(&self) -> bool { true }
@@ -152,12 +187,13 @@ impl CadCommand for SplineditCommand {
             }
         }
     }
-    fn wants_text_input(&self) -> bool { !matches!(self.step, Step::SelectSpline | Step::Add | Step::Delete | Step::Move { .. } | Step::SelectVertex { .. }) }
+    fn wants_text_input(&self) -> bool { !matches!(self.step, Step::SelectSpline | Step::Join | Step::Add | Step::Delete | Step::Move { .. } | Step::SelectVertex { .. }) }
     fn on_text_input(&mut self, text: &str) -> Option<CmdResult> {
         let upper = text.trim().to_uppercase();
         if upper.is_empty() { return Some(self.on_enter()); }
         match self.step {
             Step::Options => match upper.as_str() {
+                "J" | "JOIN" if !self.closed() => { self.join_candidates.clear(); self.step = Step::Join; },
                 "R" | "REFINE" => self.step = Step::Refine,
                 "M" | "MOVE" => self.step = Step::Move { index: 0, refine: false },
                 "X" | "EXIT" => return Some(CmdResult::Cancel),
@@ -277,6 +313,7 @@ impl CadCommand for SplineditCommand {
     fn on_enter(&mut self) -> CmdResult {
         match self.step {
             Step::SelectSpline | Step::Options => CmdResult::Cancel,
+            Step::Join => self.finish_join(),
             Step::Refine => { self.step = Step::Options; CmdResult::NeedPoint }
             Step::Add | Step::Delete | Step::SelectVertex { .. } => { self.step = Step::Refine; CmdResult::NeedPoint }
             Step::Elevate => {
@@ -285,6 +322,13 @@ impl CadCommand for SplineditCommand {
             }
             Step::Move { .. } | Step::Weight { .. } => self.on_text_input("N").unwrap_or(CmdResult::NeedPoint),
         }
+    }
+    fn on_escape(&mut self) -> CmdResult {
+        if matches!(self.step, Step::Join) {
+            self.join_candidates.clear();
+            self.step = Step::Options;
+            CmdResult::NeedPoint
+        } else { CmdResult::Cancel }
     }
     fn on_preview_wires(&mut self, _pt: DVec3) -> Vec<WireModel> { vec![] }
 }

--- a/src/modules/draw/modify/splinedit.rs
+++ b/src/modules/draw/modify/splinedit.rs
@@ -34,6 +34,7 @@ enum Step {
     Options,
     Refine,
     Join,
+    PolylinePrecision,
     Add,
     Delete,
     Elevate,
@@ -50,11 +51,49 @@ pub struct SplineditCommand {
     history: Vec<(acadrust::Handle, acadrust::entities::Spline)>,
     pick_context: Option<crate::command::PointPickContext>,
     join_candidates: Vec<crate::command::SelectionEntity>,
+    delete_source: bool,
 }
 
 impl SplineditCommand {
     pub fn new() -> Self {
-        Self { step: Step::SelectSpline, handle: acadrust::Handle::NULL, spline: None, pending: None, history: Vec::new(), pick_context: None, join_candidates: Vec::new() }
+        Self { step: Step::SelectSpline, handle: acadrust::Handle::NULL, spline: None, pending: None, history: Vec::new(), pick_context: None, join_candidates: Vec::new(), delete_source: true }
+    }
+
+    pub fn with_delete_source(mut self, delete: bool) -> Self { self.delete_source = delete; self }
+
+    fn convert_polyline(&mut self, precision: u8) -> CmdResult {
+        let result = self.spline.as_ref().and_then(|source| {
+            let curve = spatial_spline(source)?;
+            let approximation = curve.to_polyline_precision(precision)?;
+            let mut points = approximation.points;
+            if self.closed() {
+                if points.first() != points.last() { return None; }
+                points.pop();
+            }
+            if points.len() < 2 { return None; }
+            let entity = if let Some(planar) = crate::entities::curve::entity_curve(&EntityType::Spline(source.clone())) {
+                let normal = planar.plane.normal()?;
+                let elevation = cadkernel::space::Vec3::from(points[0]).dot(cadkernel::space::Vec3::from(normal));
+                let normal = Vector3::new(normal[0], normal[1], normal[2]);
+                let plane = crate::entities::curve::ocs_plane(normal.clone(), elevation);
+                let mut polyline = acadrust::LwPolyline::new();
+                polyline.common = source.common.clone();
+                polyline.elevation = elevation; polyline.normal = normal; polyline.is_closed = self.closed();
+                polyline.vertices = points.iter().map(|point| {
+                    let uv = plane.project(*point)?;
+                    Some(acadrust::entities::LwVertex::new(acadrust::types::Vector2::new(uv[0], uv[1])))
+                }).collect::<Option<Vec<_>>>()?;
+                EntityType::LwPolyline(polyline)
+            } else {
+                let mut polyline = acadrust::entities::Polyline3D::from_points(points.iter().map(|p| Vector3::new(p[0],p[1],p[2])).collect());
+                polyline.common = source.common.clone(); polyline.flags.closed = self.closed();
+                EntityType::Polyline3D(polyline)
+            };
+            Some(entity)
+        });
+        let Some(mut entity) = result else { return CmdResult::ReportError(crate::t!("Spline cannot be converted within the requested precision.").into_owned()); };
+        if self.delete_source { CmdResult::ReplaceMany(vec![(self.handle,vec![entity])], Vec::new()) }
+        else { entity.common_mut().handle = acadrust::Handle::NULL; CmdResult::ReplaceMany(Vec::new(), vec![entity]) }
     }
 
     fn picked_vertex(&self, point: DVec3) -> Option<usize> {
@@ -108,24 +147,7 @@ impl SplineditCommand {
         if let Some(degree) = degree {
             let current = usize::try_from(source.degree).ok()?;
             if degree <= current || degree > 25 { return None; }
-            let weights = if source.weights.is_empty() { vec![1.0; source.control_points.len()] } else { source.weights.clone() };
-            let curve = if source.control_points.is_empty() && source.fit_points.len() >= 2 {
-                use cadkernel::space::{NurbsCurve3, Parameterization};
-                let points: Vec<_> = source.fit_points.iter().map(|point| [point.x, point.y, point.z]).collect();
-                let parameterization = match source.knot_parameterization {
-                    1 => Parameterization::Centripetal, 2 => Parameterization::Uniform, _ => Parameterization::Chord,
-                };
-                let tangent = |point: &Vector3| (point.x != 0.0 || point.y != 0.0 || point.z != 0.0).then_some([point.x, point.y, point.z]);
-                if source.flags.closed || source.flags.periodic {
-                    NurbsCurve3::interpolate_periodic(&points, parameterization)?
-                } else {
-                    NurbsCurve3::interpolate_fit(&points, tangent(&source.begin_tangent), tangent(&source.end_tangent), parameterization)?
-                }
-            } else {
-                cadkernel::space::NurbsCurve3::new_strict(current,
-                    source.control_points.iter().map(|point| [point.x, point.y, point.z]).collect(),
-                    source.knots.clone(), weights)?
-            };
+            let curve = spatial_spline(source)?;
             let curve = curve.with_periodicity(source.flags.closed || source.flags.periodic)
                 .elevated(degree - current)?
                 .compact_knots(source.control_tolerance.max(1e-9))?;
@@ -167,8 +189,9 @@ impl CadCommand for SplineditCommand {
     fn prompt(&self) -> String {
         match self.step {
             Step::SelectSpline => crate::t!("SPLINEDIT  Select spline:").into_owned(),
-            Step::Options if self.closed() => crate::t!("SPLINEDIT  [Open/Move vertex/Refine/rEverse/Undo/eXit] <eXit>:").into_owned(),
+            Step::Options if self.closed() => crate::t!("SPLINEDIT  [Open/Move vertex/Refine/rEverse/convert to Polyline/Undo/eXit] <eXit>:").into_owned(),
             Step::Options => crate::t!("SPLINEDIT  [Close/Join/Move vertex/Refine/rEverse/Undo/eXit] <eXit>:").into_owned(),
+            Step::PolylinePrecision => crate::t!("SPLINEDIT  Specify precision 0-99 <10> (straight segments):").into_owned(),
             Step::Join => crate::t!("SPLINEDIT  Select any open curves to join to source:").into_owned(),
             Step::Refine => crate::t!("SPLINEDIT  [Add/Delete/Elevate order/Move/Weight/eXit] <eXit>:").into_owned(),
             Step::Add => crate::t!("SPLINEDIT  Specify a point on the spline <exit>:").into_owned(),
@@ -185,7 +208,7 @@ impl CadCommand for SplineditCommand {
             Step::Options => {
                 let mut options = vec![if self.closed() { CmdOption::new("Open", "O") } else { CmdOption::new("Close", "C") }];
                 if !self.closed() { options.push(CmdOption::new("Join", "J")); }
-                options.extend([CmdOption::new("Move vertex", "M"), CmdOption::new("Refine", "R"), CmdOption::new("Reverse", "E"), CmdOption::new("Undo", "U"), CmdOption::new("Exit", "X")]);
+                options.extend([CmdOption::new("Move vertex", "M"), CmdOption::new("Refine", "R"), CmdOption::new("Reverse", "E"), CmdOption::new("Polyline (lines)", "P"), CmdOption::new("Undo", "U"), CmdOption::new("Exit", "X")]);
                 options
             },
             Step::Refine => vec![CmdOption::new("Add", "A"), CmdOption::new("Delete", "D"), CmdOption::new("Elevate order", "E"), CmdOption::new("Move", "M"), CmdOption::new("Weight", "W"), CmdOption::new("Exit", "X")],
@@ -227,6 +250,7 @@ impl CadCommand for SplineditCommand {
         if upper.is_empty() { return Some(self.on_enter()); }
         match self.step {
             Step::Options => match upper.as_str() {
+                "P" | "POLYLINE" => self.step = Step::PolylinePrecision,
                 "J" | "JOIN" if !self.closed() => { self.join_candidates.clear(); self.step = Step::Join; },
                 "R" | "REFINE" => self.step = Step::Refine,
                 "M" | "MOVE" => self.step = Step::Move { index: 0, refine: false },
@@ -251,6 +275,11 @@ impl CadCommand for SplineditCommand {
                 }
                 _ => {}
             },
+            Step::PolylinePrecision => {
+                let Ok(precision) = upper.parse::<u8>() else { return Some(CmdResult::ReportError(crate::t!("Requires an integer between 0 and 99.").into_owned())); };
+                if precision > 99 { return Some(CmdResult::ReportError(crate::t!("Requires an integer between 0 and 99.").into_owned())); }
+                return Some(self.convert_polyline(precision));
+            }
             Step::Refine => match upper.as_str() {
                 "A" | "ADD" => self.step = Step::Add,
                 "D" | "DELETE" => self.step = Step::Delete,
@@ -348,6 +377,7 @@ impl CadCommand for SplineditCommand {
         match self.step {
             Step::SelectSpline | Step::Options => CmdResult::Cancel,
             Step::Join => self.finish_join(),
+            Step::PolylinePrecision => self.convert_polyline(10),
             Step::Refine => { self.step = Step::Options; CmdResult::NeedPoint }
             Step::Add | Step::Delete | Step::SelectVertex { .. } => { self.step = Step::Refine; CmdResult::NeedPoint }
             Step::Elevate => {
@@ -358,7 +388,7 @@ impl CadCommand for SplineditCommand {
         }
     }
     fn on_escape(&mut self) -> CmdResult {
-        if matches!(self.step, Step::Join) {
+        if matches!(self.step, Step::Join | Step::PolylinePrecision) {
             self.join_candidates.clear();
             self.step = Step::Options;
             CmdResult::NeedPoint
@@ -445,3 +475,26 @@ fn change_closure(source: &acadrust::entities::Spline, closed: bool) -> Option<a
 
 // ── Autocomplete registry ─────────────────────────────────
 inventory::submit!(crate::command::CommandRegistration { names: &["SPLINEDIT"] });  // SplineditCommand
+
+fn spatial_spline(source: &acadrust::entities::Spline) -> Option<cadkernel::space::NurbsCurve3> {
+    let current = usize::try_from(source.degree).ok()?;
+    let weights = if source.weights.is_empty() { vec![1.0; source.control_points.len()] } else { source.weights.clone() };
+    let curve = if source.control_points.is_empty() && source.fit_points.len() >= 2 {
+        use cadkernel::space::{NurbsCurve3, Parameterization};
+        let points: Vec<_> = source.fit_points.iter().map(|point| [point.x, point.y, point.z]).collect();
+        let parameterization = match source.knot_parameterization {
+            1 => Parameterization::Centripetal, 2 => Parameterization::Uniform, _ => Parameterization::Chord,
+        };
+        let tangent = |point: &Vector3| (point.x != 0.0 || point.y != 0.0 || point.z != 0.0).then_some([point.x, point.y, point.z]);
+        if source.flags.closed || source.flags.periodic {
+            NurbsCurve3::interpolate_periodic(&points, parameterization)?
+        } else {
+            NurbsCurve3::interpolate_fit(&points, tangent(&source.begin_tangent), tangent(&source.end_tangent), parameterization)?
+        }
+    } else {
+        cadkernel::space::NurbsCurve3::new_strict(current,
+            source.control_points.iter().map(|point| [point.x, point.y, point.z]).collect(),
+            source.knots.clone(), weights)?
+    };
+    Some(curve.with_periodicity(source.flags.closed || source.flags.periodic))
+}

--- a/src/modules/draw/modify/splinedit.rs
+++ b/src/modules/draw/modify/splinedit.rs
@@ -105,6 +105,29 @@ impl SplineditCommand {
 
     fn refined(&self, point: Option<DVec3>, degree: Option<usize>) -> Option<acadrust::entities::Spline> {
         let source = self.spline.as_ref()?;
+        if let Some(degree) = degree {
+            let current = usize::try_from(source.degree).ok()?;
+            if degree <= current || degree > 25 { return None; }
+            let weights = if source.weights.is_empty() { vec![1.0; source.control_points.len()] } else { source.weights.clone() };
+            let curve = cadkernel::space::NurbsCurve3::new_strict(current,
+                source.control_points.iter().map(|point| [point.x, point.y, point.z]).collect(),
+                source.knots.clone(), weights)?
+                .with_periodicity(source.flags.closed || source.flags.periodic)
+                .elevated(degree - current)?;
+            let mut result = source.clone();
+            result.degree = curve.degree() as i32;
+            result.control_points = curve.control_points().iter().map(|point| Vector3::new(point[0], point[1], point[2])).collect();
+            result.knots = curve.knots().to_vec();
+            result.weights = curve.weights().to_vec();
+            result.fit_points.clear();
+            result.begin_tangent = Vector3::ZERO;
+            result.end_tangent = Vector3::ZERO;
+            result.dwg_flags1 &= !1;
+            result.dxf_flags &= !(32 | 1024);
+            result.flags.rational = curve.is_rational();
+            result.flags.planar = crate::entities::curve::spline_is_planar(&result);
+            return Some(result);
+        }
         let planar = crate::entities::curve::entity_curve(&EntityType::Spline(source.clone()))?;
         let cadkernel::geom2d::Curve::Nurbs(mut curve) = planar.curve else { return None; };
         if let Some(point) = point {
@@ -114,10 +137,6 @@ impl SplineditCommand {
             let parameter = start + nearest.t * (end - start);
             if parameter <= start || parameter >= end { return None; }
             curve.insert_knot(parameter);
-        }
-        if let Some(degree) = degree {
-            if degree <= curve.degree() || degree > 25 { return None; }
-            curve = curve.elevated(degree - curve.degree())?;
         }
         let mut result = crate::modules::draw::modify::spline_ops::nurbs_to_spline(&curve, source);
         result.control_points = curve.control_points().iter().map(|point| {

--- a/src/modules/draw/modify/splinedit.rs
+++ b/src/modules/draw/modify/splinedit.rs
@@ -92,7 +92,7 @@ impl SplineditCommand {
             curve.insert_knot(parameter);
         }
         if let Some(degree) = degree {
-            if degree <= curve.degree() || degree > 26 { return None; }
+            if degree <= curve.degree() || degree > 25 { return None; }
             curve = curve.elevated(degree - curve.degree())?;
         }
         let mut result = crate::modules::draw::modify::spline_ops::nurbs_to_spline(&curve, source);
@@ -181,7 +181,13 @@ impl CadCommand for SplineditCommand {
                 _ => {}
             },
             Step::Elevate => {
-                if let Some(spline) = upper.parse::<usize>().ok().and_then(|degree| self.refined(None, Some(degree))) {
+                let current_order = self.spline.as_ref()?.degree.max(1) as usize + 1;
+                let order = upper.parse::<usize>().ok().filter(|order| *order >= current_order && *order <= 26)?;
+                if order == current_order {
+                    self.step = Step::Refine;
+                    return Some(CmdResult::NeedPoint);
+                }
+                if let Some(spline) = self.refined(None, Some(order - 1)) {
                     self.step = Step::Refine;
                     return Some(self.replace(spline));
                 }
@@ -264,8 +270,8 @@ impl CadCommand for SplineditCommand {
             Step::Refine => { self.step = Step::Options; CmdResult::NeedPoint }
             Step::Add | Step::Delete | Step::SelectVertex { .. } => { self.step = Step::Refine; CmdResult::NeedPoint }
             Step::Elevate => {
-                let degree = self.spline.as_ref().map_or(4, |s| s.degree as usize + 1);
-                self.on_text_input(&degree.to_string()).unwrap_or(CmdResult::NeedPoint)
+                let order = self.spline.as_ref().map_or(4, |s| s.degree as usize + 1);
+                self.on_text_input(&order.to_string()).unwrap_or(CmdResult::NeedPoint)
             }
             Step::Move { .. } | Step::Weight { .. } => self.on_text_input("N").unwrap_or(CmdResult::NeedPoint),
         }

--- a/src/modules/draw/modify/splinedit.rs
+++ b/src/modules/draw/modify/splinedit.rs
@@ -190,7 +190,7 @@ impl CadCommand for SplineditCommand {
         match self.step {
             Step::SelectSpline => crate::t!("SPLINEDIT  Select spline:").into_owned(),
             Step::Options if self.closed() => crate::t!("SPLINEDIT  [Open/Move vertex/Refine/rEverse/convert to Polyline/Undo/eXit] <eXit>:").into_owned(),
-            Step::Options => crate::t!("SPLINEDIT  [Close/Join/Move vertex/Refine/rEverse/Undo/eXit] <eXit>:").into_owned(),
+            Step::Options => crate::t!("SPLINEDIT  [Close/Join/Move vertex/Refine/rEverse/convert to Polyline/Undo/eXit] <eXit>:").into_owned(),
             Step::PolylinePrecision => crate::t!("SPLINEDIT  Specify precision 0-99 <10> (straight segments):").into_owned(),
             Step::Join => crate::t!("SPLINEDIT  Select any open curves to join to source:").into_owned(),
             Step::Refine => crate::t!("SPLINEDIT  [Add/Delete/Elevate order/Move/Weight/eXit] <eXit>:").into_owned(),

--- a/src/modules/draw/modify/splinedit.rs
+++ b/src/modules/draw/modify/splinedit.rs
@@ -13,7 +13,6 @@ use acadrust::types::Vector3;
 use acadrust::EntityType;
 use glam::DVec3;
 
-use crate::modules::draw::modify::spline_ops::spline_to_nurbs;
 
 use crate::command::{CadCommand, CmdResult};
 use crate::modules::{IconKind, ModuleEvent, ToolDef};
@@ -29,138 +28,217 @@ pub fn tool() -> ToolDef {
     }
 }
 
+#[derive(Clone, Copy)]
 enum Step {
-    /// Waiting for the user to pick a spline entity.
     SelectSpline,
-    /// Spline selected; waiting for sub-command text input.
-    SubCommand { handle: acadrust::Handle },
+    Options,
+    Refine,
+    Add,
+    Elevate,
+    Move { index: usize, refine: bool },
+    Weight { index: usize },
+    SelectVertex { weight: bool, refine: bool },
 }
 
 pub struct SplineditCommand {
     step: Step,
+    handle: acadrust::Handle,
+    spline: Option<acadrust::entities::Spline>,
+    pending: Option<acadrust::entities::Spline>,
+    history: Vec<(acadrust::Handle, acadrust::entities::Spline)>,
 }
 
 impl SplineditCommand {
     pub fn new() -> Self {
-        Self {
-            step: Step::SelectSpline,
+        Self { step: Step::SelectSpline, handle: acadrust::Handle::NULL, spline: None, pending: None, history: Vec::new() }
+    }
+
+    fn replace(&mut self, spline: acadrust::entities::Spline) -> CmdResult {
+        self.pending = Some(spline.clone());
+        CmdResult::ReplaceManyContinue(vec![(self.handle, vec![EntityType::Spline(spline)])])
+    }
+
+    fn refined(&self, point: Option<DVec3>, degree: Option<usize>) -> Option<acadrust::entities::Spline> {
+        let source = self.spline.as_ref()?;
+        let planar = crate::entities::curve::entity_curve(&EntityType::Spline(source.clone()))?;
+        let cadkernel::geom2d::Curve::Nurbs(mut curve) = planar.curve else { return None; };
+        if let Some(point) = point {
+            let projected = planar.plane.project([point.x, point.y, point.z])?;
+            let nearest = cadkernel::geom2d::closest_point(&cadkernel::geom2d::Curve::Nurbs(curve.clone()), projected);
+            let (start, end) = curve.domain();
+            let parameter = start + nearest.t * (end - start);
+            if parameter <= start || parameter >= end { return None; }
+            curve.insert_knot(parameter);
         }
+        if let Some(degree) = degree {
+            if degree <= curve.degree() || degree > 26 { return None; }
+            curve = curve.elevated(degree - curve.degree())?;
+        }
+        let mut result = crate::modules::draw::modify::spline_ops::nurbs_to_spline(&curve, source);
+        result.control_points = curve.control_points().iter().map(|point| {
+            let world = planar.plane.point_at(*point);
+            Vector3::new(world[0], world[1], world[2])
+        }).collect();
+        Some(result)
     }
 }
 
 impl CadCommand for SplineditCommand {
-    fn name(&self) -> &'static str {
-        "SPLINEDIT"
-    }
-
+    fn name(&self) -> &'static str { "SPLINEDIT" }
     fn prompt(&self) -> String {
-        match &self.step {
+        match self.step {
             Step::SelectSpline => crate::t!("SPLINEDIT  Select spline:").into_owned(),
-            Step::SubCommand { .. } => crate::t!("SPLINEDIT  [CLOSE/OPEN/REVERSE/EXIT]:").into_owned(),
+            Step::Options => crate::t!("SPLINEDIT  [Close/Open/Move vertex/Refine/rEverse/Undo/eXit] <eXit>:").into_owned(),
+            Step::Refine => crate::t!("SPLINEDIT  [Add/Elevate order/Move/Weight/eXit] <eXit>:").into_owned(),
+            Step::Add => crate::t!("SPLINEDIT  Specify a point on the spline <exit>:").into_owned(),
+            Step::Elevate => format!("SPLINEDIT  Enter new order <{}>:", self.spline.as_ref().map_or(4, |s| s.degree + 1)),
+            Step::Move { index, .. } => format!("SPLINEDIT  Vertex {}: specify new location or [Next/Previous/Select point/eXit] <Next>:", index + 1),
+            Step::SelectVertex { .. } => crate::t!("SPLINEDIT  Specify control vertex:").into_owned(),
+            Step::Weight { index } => format!("SPLINEDIT  Vertex {}: enter new weight or [Next/Previous/Select point/eXit] <Next>:", index + 1),
         }
     }
-
-    fn needs_entity_pick(&self) -> bool {
-        matches!(self.step, Step::SelectSpline)
+    fn options(&self) -> Vec<crate::command::CmdOption> {
+        use crate::command::CmdOption;
+        match self.step {
+            Step::Options => vec![CmdOption::new("Close", "C"), CmdOption::new("Open", "O"), CmdOption::new("Move vertex", "M"), CmdOption::new("Refine", "R"), CmdOption::new("Reverse", "E"), CmdOption::new("Undo", "U"), CmdOption::new("Exit", "X")],
+            Step::Refine => vec![CmdOption::new("Add", "A"), CmdOption::new("Elevate order", "E"), CmdOption::new("Move", "M"), CmdOption::new("Weight", "W"), CmdOption::new("Exit", "X")],
+            Step::Move { .. } | Step::Weight { .. } => vec![CmdOption::new("Next", "N"), CmdOption::new("Previous", "P"), CmdOption::new("Select point", "S"), CmdOption::new("Exit", "X")],
+            _ => Vec::new(),
+        }
     }
-
+    fn needs_entity_pick(&self) -> bool { matches!(self.step, Step::SelectSpline) }
+    fn inject_before_entity_pick(&self) -> bool { true }
+    fn inject_picked_entity(&mut self, entity: EntityType) {
+        self.spline = match entity { EntityType::Spline(spline) => Some(spline), _ => None };
+    }
     fn on_entity_pick(&mut self, handle: acadrust::Handle, _pt: DVec3) -> CmdResult {
-        if handle.is_null() {
-            return CmdResult::NeedPoint;
-        }
-        self.step = Step::SubCommand { handle };
+        if handle.is_null() || self.spline.is_none() { return CmdResult::NeedPoint; }
+        self.handle = handle;
+        self.step = Step::Options;
         CmdResult::NeedPoint
     }
-
-    fn wants_text_input(&self) -> bool {
-        matches!(self.step, Step::SubCommand { .. })
+    fn on_entity_replaced(&mut self, old: acadrust::Handle, new: &[acadrust::Handle]) {
+        if old == self.handle {
+            if let (Some(&handle), Some(replacement)) = (new.first(), self.pending.take()) {
+                if let Some(previous) = self.spline.replace(replacement) { self.history.push((old, previous)); }
+                self.handle = handle;
+            }
+        }
     }
-
+    fn wants_text_input(&self) -> bool { !matches!(self.step, Step::SelectSpline | Step::Add | Step::Move { .. } | Step::SelectVertex { .. }) }
     fn on_text_input(&mut self, text: &str) -> Option<CmdResult> {
-        let Step::SubCommand { handle } = &self.step else {
-            return None;
-        };
-        let handle = *handle;
-        match text.trim().to_uppercase().as_str() {
-            "CLOSE" | "C" => Some(CmdResult::ReplaceEntity(
-                handle,
-                vec![SplineOp::Close.into_marker(handle)],
-            )),
-            "OPEN" | "O" => Some(CmdResult::ReplaceEntity(
-                handle,
-                vec![SplineOp::Open.into_marker(handle)],
-            )),
-            "REVERSE" | "R" | "REV" => Some(CmdResult::ReplaceEntity(
-                handle,
-                vec![SplineOp::Reverse.into_marker(handle)],
-            )),
-            "EXIT" | "X" | "" => Some(CmdResult::Cancel),
-            _ => None,
+        let upper = text.trim().to_uppercase();
+        if upper.is_empty() { return Some(self.on_enter()); }
+        match self.step {
+            Step::Options => match upper.as_str() {
+                "R" | "REFINE" => self.step = Step::Refine,
+                "M" | "MOVE" => self.step = Step::Move { index: 0, refine: false },
+                "X" | "EXIT" => return Some(CmdResult::Cancel),
+                "U" | "UNDO" => {
+                    if let Some((handle, spline)) = self.history.pop() {
+                        self.handle = handle;
+                        self.spline = Some(spline);
+                        return Some(CmdResult::UndoDocument);
+                    }
+                }
+                "C" | "CLOSE" | "O" | "OPEN" | "E" | "REVERSE" | "REV" => {
+                    let mut spline = self.spline.clone()?;
+                    let op = match upper.as_str() { "C" | "CLOSE" => "__SPLINEDIT_CLOSE__", "O" | "OPEN" => "__SPLINEDIT_OPEN__", _ => "__SPLINEDIT_REVERSE__" };
+                    apply_to_spline(&mut spline, op);
+                    return Some(self.replace(spline));
+                }
+                _ => {}
+            },
+            Step::Refine => match upper.as_str() {
+                "A" | "ADD" => self.step = Step::Add,
+                "E" | "ELEVATE" => self.step = Step::Elevate,
+                "M" | "MOVE" => self.step = Step::Move { index: 0, refine: true },
+                "W" | "WEIGHT" => self.step = Step::Weight { index: 0 },
+                "X" | "EXIT" => self.step = Step::Options,
+                _ => {}
+            },
+            Step::Elevate => {
+                if let Some(spline) = upper.parse::<usize>().ok().and_then(|degree| self.refined(None, Some(degree))) {
+                    self.step = Step::Refine;
+                    return Some(self.replace(spline));
+                }
+            }
+            Step::Move { index, .. } | Step::Weight { index } => {
+                let count = self.spline.as_ref().map_or(0, |s| s.control_points.len());
+                if count == 0 { return Some(CmdResult::NeedPoint); }
+                let next = match upper.as_str() { "N" | "NEXT" => Some((index + 1) % count), "P" | "PREVIOUS" => Some((index + count - 1) % count), _ => None };
+                if let Some(next) = next {
+                    self.step = match self.step { Step::Move { refine, .. } => Step::Move { index: next, refine }, _ => Step::Weight { index: next } };
+                } else if matches!(upper.as_str(), "S" | "SELECT") {
+                    self.step = match self.step {
+                        Step::Move { refine, .. } => Step::SelectVertex { weight: false, refine },
+                        _ => Step::SelectVertex { weight: true, refine: true },
+                    };
+                } else if matches!(upper.as_str(), "X" | "EXIT") {
+                    self.step = match self.step { Step::Move { refine: false, .. } => Step::Options, _ => Step::Refine };
+                } else if matches!(self.step, Step::Weight { .. }) {
+                    if let Some(weight) = upper.replace(',', ".").parse::<f64>().ok().filter(|weight| weight.is_finite() && *weight > 0.0) {
+                        let mut spline = self.spline.clone()?;
+                        spline.weights.resize(count, 1.0);
+                        spline.weights[index] = weight;
+                        spline.flags.rational = true;
+                        spline.fit_points.clear();
+                        return Some(self.replace(spline));
+                    }
+                }
+            }
+            _ => {}
         }
+        Some(CmdResult::NeedPoint)
     }
-
-    fn on_point(&mut self, _pt: DVec3) -> CmdResult {
-        CmdResult::NeedPoint
+    fn on_point(&mut self, point: DVec3) -> CmdResult {
+        if !point.is_finite() { return CmdResult::NeedPoint; }
+        match self.step {
+            Step::SelectVertex { weight, refine } => {
+                if let Some(index) = self.spline.as_ref().and_then(|spline| spline.control_points.iter().enumerate()
+                    .min_by(|(_, a), (_, b)| {
+                        let distance = |p: &Vector3| point.distance_squared(DVec3::new(p.x, p.y, p.z));
+                        distance(a).total_cmp(&distance(b))
+                    }).map(|(index, _)| index)) {
+                    self.step = if weight { Step::Weight { index } } else { Step::Move { index, refine } };
+                }
+                CmdResult::NeedPoint
+            }
+            Step::Add => self.refined(Some(point), None).map_or(CmdResult::NeedPoint, |spline| self.replace(spline)),
+            Step::Move { index, .. } => {
+                let Some(mut spline) = self.spline.clone() else { return CmdResult::NeedPoint; };
+                let Some(vertex) = spline.control_points.get_mut(index) else { return CmdResult::NeedPoint; };
+                *vertex = Vector3::new(point.x, point.y, point.z);
+                spline.fit_points.clear();
+                self.replace(spline)
+            }
+            _ => CmdResult::NeedPoint,
+        }
     }
     fn on_enter(&mut self) -> CmdResult {
-        CmdResult::Cancel
+        match self.step {
+            Step::SelectSpline | Step::Options => CmdResult::Cancel,
+            Step::Refine => { self.step = Step::Options; CmdResult::NeedPoint }
+            Step::Add | Step::SelectVertex { .. } => { self.step = Step::Refine; CmdResult::NeedPoint }
+            Step::Elevate => {
+                let degree = self.spline.as_ref().map_or(4, |s| s.degree as usize + 1);
+                self.on_text_input(&degree.to_string()).unwrap_or(CmdResult::NeedPoint)
+            }
+            Step::Move { .. } | Step::Weight { .. } => self.on_text_input("N").unwrap_or(CmdResult::NeedPoint),
+        }
     }
-    fn on_preview_wires(&mut self, _pt: DVec3) -> Vec<WireModel> {
-        vec![]
-    }
+    fn on_preview_wires(&mut self, _pt: DVec3) -> Vec<WireModel> { vec![] }
 }
-
-// ── Spline operation helpers ───────────────────────────────────────────────
-//
-// Because `CmdResult::ReplaceEntity` takes `Vec<EntityType>` and we need the
-// host to apply it to the actual document, we use a small "deferred op" trick:
-// the host applies the spline transform in `apply_cmd_result` by detecting
-// that we replaced an entity with zero new entities (delete) or one new one.
-//
-// Here we actually build the modified entity without accessing the document —
-// we only have the handle.  The real transformation (close/open/reverse) is
-// applied in the Scene via `apply_spline_op`.
-
-enum SplineOp {
-    Close,
-    Open,
-    Reverse,
-}
-
-impl SplineOp {
-    /// Return a placeholder that encodes the op in a comment field.
-    /// The host `cmd_result.rs` detects SPLINEDIT replaces and calls
-    /// `Scene::apply_spline_op`.
-    fn into_marker(self, _handle: acadrust::Handle) -> EntityType {
-        // We can't build the modified spline here without the document.
-        // Return a sentinel — the actual transformation is handled by the
-        // apply_spline_op path in Scene.  We use an XLine as a sentinel
-        // that the host will never actually commit (it detects the SPLINEDIT
-        // replace path and calls apply_spline_op instead).
-        //
-        // In practice: use ReplaceMany with empty new entities + a SplineOp
-        // side-channel via the xattach_path mechanism isn't clean.
-        //
-        // Simpler: encode op in the sentinel entity's layer field.
-        let mut sentinel = acadrust::entities::XLine::new(
-            acadrust::types::Vector3::zero(),
-            acadrust::types::Vector3::new(1.0, 0.0, 0.0),
-        );
-        sentinel.common.layer = match self {
-            SplineOp::Close => "__SPLINEDIT_CLOSE__".to_string(),
-            SplineOp::Open => "__SPLINEDIT_OPEN__".to_string(),
-            SplineOp::Reverse => "__SPLINEDIT_REVERSE__".to_string(),
-        };
-        EntityType::XLine(sentinel)
-    }
-}
-
 /// Apply a spline operation (CLOSE/OPEN/REVERSE) to a spline entity.
 /// Called from `cmd_result.rs` when the ReplaceEntity sentinel is detected.
 pub fn apply_spline_op(doc: &mut acadrust::CadDocument, handle: acadrust::Handle, op: &str) {
     let Some(EntityType::Spline(spline)) = doc.get_entity_mut(handle) else {
         return;
     };
+    apply_to_spline(spline, op);
+}
+
+fn apply_to_spline(spline: &mut acadrust::entities::Spline, op: &str) {
     match op {
         "__SPLINEDIT_CLOSE__" => {
             if spline.control_points.len() >= 2 {
@@ -193,40 +271,7 @@ pub fn apply_spline_op(doc: &mut acadrust::CadDocument, handle: acadrust::Handle
             }
         }
         "__SPLINEDIT_REVERSE__" => {
-            spline.fit_points.reverse();
-            let begin = spline.begin_tangent;
-            spline.begin_tangent = spline.end_tangent;
-            spline.end_tangent = begin;
-            // The knots mirror within the domain rather than being
-            // regenerated. Rebuilding a clamped *uniform* vector here changed
-            // the shape of any spline whose knots were unevenly spaced —
-            // which is most of them once a modeller has been near one.
-            match spline_to_nurbs(spline).map(|curve| curve.reversed()) {
-                Some(reversed) => {
-                    let elevation = spline
-                        .control_points
-                        .first()
-                        .or_else(|| spline.fit_points.first())
-                        .map(|p| p.z)
-                        .unwrap_or(0.0);
-                    spline.degree = reversed.degree() as i32;
-                    spline.knots = reversed.knots().to_vec();
-                    spline.control_points = reversed
-                        .control_points()
-                        .iter()
-                        .map(|p| Vector3::new(p[0], p[1], elevation))
-                        .collect();
-                    spline.weights = if reversed.is_rational() {
-                        reversed.weights().to_vec()
-                    } else {
-                        Vec::new()
-                    };
-                }
-                // Nothing the kernel can read — a spline with too few points
-                // to describe a curve. Reversing its stored points is still
-                // the honest answer.
-                None => spline.control_points.reverse(),
-            }
+            *spline = super::reverse::reverse_spline(spline);
         }
         _ => {}
     }

--- a/src/modules/draw/modify/splinedit.rs
+++ b/src/modules/draw/modify/splinedit.rs
@@ -113,7 +113,8 @@ impl SplineditCommand {
                 source.control_points.iter().map(|point| [point.x, point.y, point.z]).collect(),
                 source.knots.clone(), weights)?
                 .with_periodicity(source.flags.closed || source.flags.periodic)
-                .elevated(degree - current)?;
+                .elevated(degree - current)?
+                .compact_knots(source.control_tolerance.max(1e-9))?;
             let mut result = source.clone();
             result.degree = curve.degree() as i32;
             result.control_points = curve.control_points().iter().map(|point| Vector3::new(point[0], point[1], point[2])).collect();

--- a/src/modules/draw/modify/splinedit.rs
+++ b/src/modules/draw/modify/splinedit.rs
@@ -176,6 +176,7 @@ impl CadCommand for SplineditCommand {
                     let mut spline = self.spline.clone()?;
                     let op = match upper.as_str() { "C" | "CLOSE" => "__SPLINEDIT_CLOSE__", "O" | "OPEN" => "__SPLINEDIT_OPEN__", _ => "__SPLINEDIT_REVERSE__" };
                     apply_to_spline(&mut spline, op);
+                    if self.spline.as_ref() == Some(&spline) { return Some(CmdResult::NeedPoint); }
                     return Some(self.replace(spline));
                 }
                 _ => {}
@@ -297,44 +298,72 @@ pub fn apply_spline_op(doc: &mut acadrust::CadDocument, handle: acadrust::Handle
 }
 
 fn apply_to_spline(spline: &mut acadrust::entities::Spline, op: &str) {
-    match op {
-        "__SPLINEDIT_CLOSE__" => {
-            if spline.control_points.len() >= 2 {
-                let first = spline.control_points[0];
-                spline.control_points.push(first);
-                // Regenerate clamped knots.
-                spline.knots = acadrust::entities::Spline::generate_clamped_knots(
-                    spline.degree as usize,
-                    spline.control_points.len(),
-                );
-                spline.fit_points.clear();
-            }
-        }
-        "__SPLINEDIT_OPEN__" => {
-            if spline.control_points.len() >= 2 {
-                let n = spline.control_points.len();
-                let first = spline.control_points[0];
-                let last = spline.control_points[n - 1];
-                if (first.x - last.x).abs() < 1e-9
-                    && (first.y - last.y).abs() < 1e-9
-                    && (first.z - last.z).abs() < 1e-9
-                {
-                    spline.control_points.pop();
-                    spline.knots = acadrust::entities::Spline::generate_clamped_knots(
-                        spline.degree as usize,
-                        spline.control_points.len(),
-                    );
-                    spline.fit_points.clear();
-                }
-            }
-        }
-        "__SPLINEDIT_REVERSE__" => {
-            *spline = super::reverse::reverse_spline(spline);
-        }
-        _ => {}
-    }
+    let result = match op {
+        "__SPLINEDIT_CLOSE__" => change_closure(spline, true),
+        "__SPLINEDIT_OPEN__" => change_closure(spline, false),
+        "__SPLINEDIT_REVERSE__" => Some(super::reverse::reverse_spline(spline)),
+        _ => None,
+    };
+    if let Some(result) = result { *spline = result; }
 }
 
+fn change_closure(source: &acadrust::entities::Spline, closed: bool) -> Option<acadrust::entities::Spline> {
+    use cadkernel::space::{NurbsCurve3, Parameterization};
+    if (source.flags.closed || source.flags.periodic) == closed { return None; }
+    let fit_method = !source.fit_points.is_empty() || source.dwg_flags1 & 1 != 0 || source.dxf_flags & 32 != 0;
+    let parameterization = match source.knot_parameterization {
+        1 => Parameterization::Centripetal, 2 => Parameterization::Uniform, _ => Parameterization::Chord,
+    };
+    let xyz = |point: &Vector3| [point.x, point.y, point.z];
+    let controls: Vec<_> = source.control_points.iter().map(xyz).collect();
+    let degree = usize::try_from(source.degree).ok()?;
+    let weights = if source.weights.is_empty() { vec![1.0; controls.len()] } else { source.weights.clone() };
+    if fit_method && weights.windows(2).any(|pair| pair[0] != pair[1]) { return None; }
+    let stored_curve = || NurbsCurve3::new_strict(degree, controls.clone(), source.knots.clone(), weights.clone());
+    let mut fit_points = Vec::new();
+    let curve = if fit_method {
+        fit_points = source.fit_points.iter().map(xyz).collect();
+        if fit_points.is_empty() {
+            let curve = stored_curve()?;
+            let (start, end) = curve.domain();
+            let mut parameters: Vec<_> = curve.knots().iter().copied()
+                .filter(|parameter| *parameter >= start && if closed { *parameter <= end } else { *parameter < end }).collect();
+            parameters.dedup();
+            fit_points = parameters.into_iter().map(|parameter| curve.point_at_knot(parameter)).collect();
+        }
+        let curve = if closed {
+            NurbsCurve3::interpolate_periodic(&fit_points, parameterization)?
+        } else {
+            NurbsCurve3::interpolate_fit(&fit_points, None, None, parameterization)?
+        };
+        curve.compact_knots(source.control_tolerance.max(1e-9))?
+    } else if closed {
+        NurbsCurve3::from_weighted_control_polygon(degree, &controls, &weights, true)?
+    } else {
+        let curve = stored_curve()?;
+        curve.without_control_vertex(controls.len().checked_sub(1)?)?
+    };
+    let mut result = source.clone();
+    result.degree = curve.degree() as i32;
+    result.control_points = curve.control_points().iter().map(|point| Vector3::new(point[0], point[1], point[2])).collect();
+    result.knots = curve.knots().to_vec();
+    result.weights = curve.weights().to_vec();
+    result.flags.closed = closed;
+    result.flags.periodic = closed;
+    if closed { result.dxf_flags |= 2048; } else { result.dxf_flags &= !2048; }
+    result.flags.rational = if fit_method { false } else { source.flags.rational || curve.is_rational() };
+    result.fit_points = if !closed && fit_method {
+        fit_points.iter().map(|point| Vector3::new(point[0], point[1], point[2])).collect()
+    } else { Vec::new() };
+    if fit_method {
+        result.dwg_flags1 |= 1;
+        result.dxf_flags |= 32 | 1024;
+        result.begin_tangent = Vector3::ZERO;
+        result.end_tangent = Vector3::ZERO;
+    }
+    result.flags.planar = crate::entities::curve::spline_is_planar(&result);
+    Some(result)
+}
 
 // ── Autocomplete registry ─────────────────────────────────
 inventory::submit!(crate::command::CommandRegistration { names: &["SPLINEDIT"] });  // SplineditCommand

--- a/src/modules/draw/modify/splinedit.rs
+++ b/src/modules/draw/modify/splinedit.rs
@@ -225,6 +225,7 @@ impl CadCommand for SplineditCommand {
                 spline.weights = curve.weights().to_vec();
                 spline.knots = curve.knots().to_vec();
                 spline.fit_points.clear();
+                spline.flags.planar = crate::entities::curve::spline_is_planar(&spline);
                 self.replace(spline)
             }
             Step::Add => self.refined(Some(point), None).map_or(CmdResult::NeedPoint, |spline| self.replace(spline)),

--- a/src/modules/draw/modify/splinedit.rs
+++ b/src/modules/draw/modify/splinedit.rs
@@ -74,6 +74,10 @@ impl SplineditCommand {
         }).min_by(|a, b| a.1.total_cmp(&b.1)).map(|(index, _)| index)
     }
 
+    fn closed(&self) -> bool {
+        self.spline.as_ref().is_some_and(|spline| spline.flags.closed || spline.flags.periodic)
+    }
+
     fn replace(&mut self, spline: acadrust::entities::Spline) -> CmdResult {
         self.pending = Some(spline.clone());
         CmdResult::ReplaceManyContinue(vec![(self.handle, vec![EntityType::Spline(spline)])])
@@ -109,7 +113,8 @@ impl CadCommand for SplineditCommand {
     fn prompt(&self) -> String {
         match self.step {
             Step::SelectSpline => crate::t!("SPLINEDIT  Select spline:").into_owned(),
-            Step::Options => crate::t!("SPLINEDIT  [Close/Open/Move vertex/Refine/rEverse/Undo/eXit] <eXit>:").into_owned(),
+            Step::Options if self.closed() => crate::t!("SPLINEDIT  [Open/Move vertex/Refine/rEverse/Undo/eXit] <eXit>:").into_owned(),
+            Step::Options => crate::t!("SPLINEDIT  [Close/Move vertex/Refine/rEverse/Undo/eXit] <eXit>:").into_owned(),
             Step::Refine => crate::t!("SPLINEDIT  [Add/Delete/Elevate order/Move/Weight/eXit] <eXit>:").into_owned(),
             Step::Add => crate::t!("SPLINEDIT  Specify a point on the spline <exit>:").into_owned(),
             Step::Delete => crate::t!("SPLINEDIT  Specify control vertex to delete:").into_owned(),
@@ -122,7 +127,7 @@ impl CadCommand for SplineditCommand {
     fn options(&self) -> Vec<crate::command::CmdOption> {
         use crate::command::CmdOption;
         match self.step {
-            Step::Options => vec![CmdOption::new("Close", "C"), CmdOption::new("Open", "O"), CmdOption::new("Move vertex", "M"), CmdOption::new("Refine", "R"), CmdOption::new("Reverse", "E"), CmdOption::new("Undo", "U"), CmdOption::new("Exit", "X")],
+            Step::Options => vec![if self.closed() { CmdOption::new("Open", "O") } else { CmdOption::new("Close", "C") }, CmdOption::new("Move vertex", "M"), CmdOption::new("Refine", "R"), CmdOption::new("Reverse", "E"), CmdOption::new("Undo", "U"), CmdOption::new("Exit", "X")],
             Step::Refine => vec![CmdOption::new("Add", "A"), CmdOption::new("Delete", "D"), CmdOption::new("Elevate order", "E"), CmdOption::new("Move", "M"), CmdOption::new("Weight", "W"), CmdOption::new("Exit", "X")],
             Step::Move { .. } | Step::Weight { .. } => vec![CmdOption::new("Next", "N"), CmdOption::new("Previous", "P"), CmdOption::new("Select point", "S"), CmdOption::new("Exit", "X")],
             _ => Vec::new(),
@@ -164,6 +169,10 @@ impl CadCommand for SplineditCommand {
                     }
                 }
                 "C" | "CLOSE" | "O" | "OPEN" | "E" | "REVERSE" | "REV" => {
+                    if (matches!(upper.as_str(), "C" | "CLOSE") && self.closed())
+                        || (matches!(upper.as_str(), "O" | "OPEN") && !self.closed()) {
+                        return Some(CmdResult::NeedPoint);
+                    }
                     let mut spline = self.spline.clone()?;
                     let op = match upper.as_str() { "C" | "CLOSE" => "__SPLINEDIT_CLOSE__", "O" | "OPEN" => "__SPLINEDIT_OPEN__", _ => "__SPLINEDIT_REVERSE__" };
                     apply_to_spline(&mut spline, op);

--- a/src/modules/draw/modify/splinedit.rs
+++ b/src/modules/draw/modify/splinedit.rs
@@ -217,7 +217,7 @@ impl CadCommand for SplineditCommand {
                 let weights = if source.weights.is_empty() { vec![1.0; source.control_points.len()] }
                     else { source.weights.clone() };
                 let curve = cadkernel::space::NurbsCurve3::new_strict(source.degree as usize, controls,
-                    source.knots.clone(), weights).map(|curve| curve.with_periodicity(source.flags.periodic));
+                    source.knots.clone(), weights).map(|curve| curve.with_periodicity(source.flags.periodic || source.flags.closed));
                 let Some(curve) = curve.and_then(|curve| curve.without_control_vertex(index)) else { return CmdResult::NeedPoint; };
                 let mut spline = source.clone();
                 spline.degree = curve.degree() as i32;


### PR DESCRIPTION
1) Keep the selected spline available across repeated edits and refresh its handle and cached geometry after replacements.

2) Add command-local Undo with restoration of the previous spline and handle.

3) Add control-vertex navigation, point selection and movement.

4) Add Refine options for knot insertion, degree elevation and control-point weight editing.

5) Preserve the source plane when reconstructing refined control points.

6) Reject unsupported selections, invalid weights and unsupported elevation values without replacing the source.

7) Route `R` to Refine and `E` to Reverse; expose corresponding option buttons and nested prompts.

8) Preserve knot spacing, three-dimensional coordinates and endpoint tangents during spline reversal.

9) Initialize editing directly from one preselected spline; retain the selection prompt for other entity types or multiple selections.

10) Reject a preselected spline on a locked layer before entering its editing options.

11) Add repeated control-vertex deletion in Refine, retaining the selected spline and recording replacements in command-local Undo history.

12) Use the spatial kernel deletion operation to remove control points, weights and associated knots; reduce the degree when the remaining vertices fall below the current order.

13) Keep closed or periodic splines and invalid deletion results unchanged, and return from the deletion prompt to Refine on Enter.

14) Recompute the spline's planar flag from its remaining control points after deletion, including spatial curves that become planar.

15) Supply opt-in commands with the current viewport projection, eye position, pane bounds and configured pick aperture before point dispatch; refresh the context for both direct viewport clicks and shared command input.

16) Select spline control vertices by projected screen distance for deletion and Move/Weight point selection, rejecting picks outside the aperture, outside the viewport or with invalid projection.

17) Refresh point-pick projection after zoom or viewport changes while retaining default input behavior for commands that do not opt in.

18) Interpret Elevate input as spline order, converting it to degree by subtracting one and accepting values from the current order through 26.

19) Treat Enter or the unchanged order as a return to Refine without altering geometry or adding a replacement to the undo history.

20) Show Close only for open splines and Open only for closed or periodic splines; reject redundant closure requests without creating undo entries.

21) Construct closed control-vertex splines through the weighted periodic kernel constructor, preserving rational weights and three-dimensional control coordinates.

22) Open closed control-vertex splines by removing the final control vertex and associated knot through the kernel operation.

23) Close fit splines with periodic interpolation and reopen them with natural open interpolation, compacting redundant knots while preserving the resulting curve.

24) Recover fit stations from the stored knot-domain geometry when a closed fit spline has no explicit fit points, and preserve its construction method through serialized spline flags.

25) Clear endpoint tangents when changing fit-spline closure, restore fit points on opening, and update closure, periodicity, rationality and planarity flags from the resulting geometry.

26) Keep the original spline and undo history unchanged when closure reconstruction fails or a fit spline contains unequal control weights.

27) Add Join for open splines, gather candidate selections through the shared selection system, and return to editing options after Enter or cancellation.

28) Join compatible touching lines and splines through the existing source-curve join operation, retaining source properties and removing only consumed candidates in one document history entry.

29) Restore the source spline and consumed candidates together through command-local Undo, and leave empty or incompatible selections unchanged.

30) Add an opt-in selection-geometry filter for locked layers and use it to skip locked spline-join candidates while preserving the default behavior of other commands.

31) Clear obsolete fit-construction flags after joining so subsequent spline edits operate on the resulting control-vertex geometry.

32) Elevate planar and spatial spline order through the spatial NURBS kernel, preserving three-dimensional coordinates and rational weights while clearing obsolete fit metadata and recomputing planarity.

33) Compact removable polynomial knots after degree elevation using the spline control tolerance; retain unequal-weight rational knot representations unchanged.

34) Resolve fit-only splines through kernel interpolation before order elevation, retaining their knot parameterization and supplied endpoint tangents.

35) Add straight-segment Polyline conversion with integer precision from 0 through 99, default 10, invalid-input retry and cancellation without modifying the source.

36) Use the kernel's independently defined scale-relative, control-hull-bounded approximation; retain the source plane and elevation for lightweight polylines and world coordinates for nonplanar three-dimensional polylines.

37) Preserve closure and source display properties, honor the existing source-deletion preference, and group conversion into a document undo entry.

38) Share spatial spline construction between order elevation and polyline conversion, preserving fit parameterization and supplied tangents.

39) Label this conversion as straight segments; arc-segment conversion and an external application's exact precision-to-vertex policy are not implemented.

40) Include Polyline conversion in the open-spline text prompt as well as its option buttons.