### PR TITLE
Reject invalid ray direction input

### DIFF
--- a/src/modules/draw/draw/ray.rs
+++ b/src/modules/draw/draw/ray.rs
@@ -50,6 +50,9 @@ impl CadCommand for RayCommand {
     }
 
     fn on_point(&mut self, pt: DVec3) -> CmdResult {
+        if !pt.is_finite() {
+            return CmdResult::NeedPoint;
+        }
         if let Some(base) = self.base {
             let dir = pt - base;
             let len = dir.length();


### PR DESCRIPTION
1) Reject nonfinite point input before committing ray geometry, preserving the active command and existing entities.