### PR TITLE
Complete rectangular and polygonal revision clouds directly

### DIFF
--- a/src/modules/draw/draw/revcloud.rs
+++ b/src/modules/draw/draw/revcloud.rs
@@ -199,6 +199,12 @@ impl RevCloudCommand {
                 entity.common_mut().handle = Handle::NULL;
             }
         }
+        if replacement.is_none()
+            && matches!(self.creation, CreationMode::Rectangular | CreationMode::Polygonal)
+        {
+            self.message = None;
+            return CmdResult::CommitAndExit(entity);
+        }
         self.stage = Stage::Reverse(PendingCloud {
             entity,
             replacement,

--- a/src/modules/draw/draw/revcloud.rs
+++ b/src/modules/draw/draw/revcloud.rs
@@ -725,6 +725,9 @@ impl CadCommand for RevCloudCommand {
                 return self.on_undo_step();
             }
             Stage::Create => match keyword.as_str() {
+                "C" | "CLOSE" if self.creation == CreationMode::Polygonal => {
+                    return Some(if self.points.len() >= 3 { self.on_enter() } else { CmdResult::NeedPoint });
+                }
                 "A" | "ARC" | "ARCLENGTH" => self.stage = Stage::ArcLength,
                 "O" | "OBJECT" => {
                     self.stage = Stage::Object;


### PR DESCRIPTION
1) Complete rectangular revision clouds immediately after the opposite corner is accepted.

2) Complete polygonal revision clouds immediately when their path is closed.

3) Accept C and Close to finish polygonal paths with at least three points, preserving unfinished paths when fewer points exist.