### PR TITLE
Preserve geometric bounds for fit-only splines

### DIFF
--- a/src/entities/spline.rs
+++ b/src/entities/spline.rs
@@ -42,7 +42,6 @@ pub(crate) fn fit_geometry_bounds(spline: &Spline) -> Option<cadkernel::brep::Aa
             Some([spline.end_tangent.x,spline.end_tangent.y,spline.end_tangent.z]),
             parameterization)?
     };
-    let curve = curve.compact_knots(spline.control_tolerance.max(1e-9))?;
     cadkernel::brep::Aabb::around(curve.control_points().iter().copied())
 }
 fn to_render(spl: &Spline) -> RenderEntity {

--- a/src/entities/spline.rs
+++ b/src/entities/spline.rs
@@ -21,6 +21,30 @@ pub(crate) fn shows_fit_points(spline: &Spline) -> bool {
     uses_fit_method(spline) && (!spline.cv_frame_visible || spline.flags.periodic)
 }
 
+/// Conservative world bounds of a fit-only spline. Fit points are interpolation
+/// constraints, not control-hull vertices, so their box can exclude the curve.
+/// The shared kernel reconstructs the same spatial interpolation used by the
+/// curve consumers, then its control hull bounds every point of that curve.
+pub(crate) fn fit_geometry_bounds(spline: &Spline) -> Option<cadkernel::brep::Aabb> {
+    if !spline.control_points.is_empty() || spline.fit_points.len() < 2 { return None; }
+    use cadkernel::space::{NurbsCurve3, Parameterization};
+    let points: Vec<_> = spline.fit_points.iter().map(|p| [p.x,p.y,p.z]).collect();
+    let parameterization = match spline.knot_parameterization {
+        1 => Parameterization::Centripetal, 2 => Parameterization::Uniform,
+        _ => Parameterization::Chord,
+    };
+    let curve = if spline.flags.periodic {
+        NurbsCurve3::interpolate_periodic(&points, parameterization)?
+    } else {
+        if spline.flags.closed { return None; }
+        NurbsCurve3::interpolate_fit(&points,
+            Some([spline.begin_tangent.x,spline.begin_tangent.y,spline.begin_tangent.z]),
+            Some([spline.end_tangent.x,spline.end_tangent.y,spline.end_tangent.z]),
+            parameterization)?
+    };
+    let curve = curve.compact_knots(spline.control_tolerance.max(1e-9))?;
+    cadkernel::brep::Aabb::around(curve.control_points().iter().copied())
+}
 fn to_render(spl: &Spline) -> RenderEntity {
     let n = spl.control_points.len();
     if n < 2 {

--- a/src/scene/convert/tess.rs
+++ b/src/scene/convert/tess.rs
@@ -1731,6 +1731,11 @@ fn entity_bounds(e: &acadrust::EntityType) -> ([f64; 3], [f64; 3]) {
             return (bounds.min, bounds.max);
         }
     }
+    if let acadrust::EntityType::Spline(spline) = e {
+        if let Some(bounds) = crate::entities::spline::fit_geometry_bounds(spline) {
+            return (bounds.min, bounds.max);
+        }
+    }
     let bounds = e.as_entity().bounding_box();
     (
         [bounds.min.x, bounds.min.y, bounds.min.z],


### PR DESCRIPTION
1) Reconstruct fit-only spline control geometry with the shared spatial interpolation kernel, respecting chord, centripetal and uniform parameterization, endpoint tangents and periodic interpolation.
2) Compute conservative world bounds directly from the unmodified reconstructed control hull instead of enclosing only fit points, which can exclude spline overshoot. Preserve the complete interpolation hull independently of editable tolerance values.
3) Route fit-only spline bounds through the shared entity-bound provider used by scene bounds, retaining existing stored-control bounds and entity data unchanged.