### PR TITLE
Use oriented bisectors for opposite construction rays

### DIFF
--- a/src/modules/draw/draw/ray.rs
+++ b/src/modules/draw/draw/ray.rs
@@ -165,7 +165,9 @@ impl XLineCommand {
                 let base = self.base?;
                 let first = self.reference?.1;
                 let last = (pt - base).try_normalize()?;
-                (base, first + last)
+                let direction = cadkernel::space::curve::angle_bisector(
+                    first.to_array(), last.to_array(), self.plane.z.to_array())?;
+                (base, DVec3::from_array(direction))
             }
             XLineMode::OffsetSide => {
                 let (base, dir) = self.reference?;


### PR DESCRIPTION
1) Use the spatial kernel bisector for opposite angle rays, selecting the perpendicular direction from the current working-plane normal and retaining rejection of undefined zero-direction geometry.
